### PR TITLE
cryptonight: silence `ftime` deprecated warning

### DIFF
--- a/cryptonight/build.rs
+++ b/cryptonight/build.rs
@@ -22,7 +22,16 @@ fn main() {
         .file("c/slow-hash.c")
         .file("c/CryptonightR_JIT.c")
         .flag("-O3")
-        .flag("-fexceptions");
+        .flag("-fexceptions")
+        // c/oaes_lib.c: In function ‘oaes_get_seed’:
+        // c/oaes_lib.c:515:9: warning: ‘ftime’ is deprecated: Use gettimeofday or clock_gettime instead [-Wdeprecated-declarations]
+        //   515 |         ftime (&timer);
+        //       |         ^~~~~
+        // In file included from c/oaes_lib.c:45:
+        // /usr/include/sys/timeb.h:29:12: note: declared here
+        //    29 | extern int ftime (struct timeb *__timebuf)
+        //       |            ^~~~~
+        .flag("-Wno-deprecated-declarations");
 
     let target = env::var("TARGET").unwrap();
     if target.contains("x86_64") {


### PR DESCRIPTION
Silences this warning when running `cargo doc/clippy/build`.

```
warning: cryptonight-cuprate@0.1.0: c/oaes_lib.c: In function ‘oaes_get_seed’:
warning: cryptonight-cuprate@0.1.0: c/oaes_lib.c:515:9: warning: ‘ftime’ is deprecated: Use gettimeofday or clock_gettime instead [-Wdeprecated-declarations]
warning: cryptonight-cuprate@0.1.0:   515 |         ftime (&timer);
warning: cryptonight-cuprate@0.1.0:       |         ^~~~~
warning: cryptonight-cuprate@0.1.0: In file included from c/oaes_lib.c:45:
warning: cryptonight-cuprate@0.1.0: /usr/include/sys/timeb.h:29:12: note: declared here
warning: cryptonight-cuprate@0.1.0:    29 | extern int ftime (struct timeb *__timebuf)
warning: cryptonight-cuprate@0.1.0:       |            ^~~~~
```

Either `gettimeofday` or `clock_gettime` is recommended but I think they have slightly different precision semantics.

https://man7.org/linux/man-pages/man3/ftime.3.html