### PR TITLE
Fix link errors in `cargo doc`

### DIFF
--- a/consensus/rules/src/blocks.rs
+++ b/consensus/rules/src/blocks.rs
@@ -56,7 +56,7 @@ pub fn is_randomx_seed_height(height: u64) -> bool {
 
 /// Returns the RandomX seed height for this block.
 ///
-/// ref: https://monero-book.cuprate.org/consensus_rules/blocks.html#randomx-seed
+/// ref: <https://monero-book.cuprate.org/consensus_rules/blocks.html#randomx-seed>
 pub fn randomx_seed_height(height: u64) -> u64 {
     if height <= RX_SEEDHASH_EPOCH_BLOCKS + RX_SEEDHASH_EPOCH_LAG {
         0
@@ -69,7 +69,7 @@ pub fn randomx_seed_height(height: u64) -> u64 {
 ///
 /// `randomx_vm` must be [`Some`] after hf 12.
 ///
-/// ref: https://monero-book.cuprate.org/consensus_rules/blocks.html#pow-function
+/// ref: <https://monero-book.cuprate.org/consensus_rules/blocks.html#pow-function>
 pub fn calculate_pow_hash<R: RandomX>(
     randomx_vm: Option<&R>,
     buf: &[u8],
@@ -98,7 +98,7 @@ pub fn calculate_pow_hash<R: RandomX>(
 
 /// Returns if the blocks POW hash is valid for the current difficulty.
 ///
-/// ref: https://monero-book.cuprate.org/consensus_rules/blocks.html#checking-pow-hash
+/// ref: <https://monero-book.cuprate.org/consensus_rules/blocks.html#checking-pow-hash>
 pub fn check_block_pow(hash: &[u8; 32], difficulty: u128) -> Result<(), BlockError> {
     let int_hash = U256::from_le_slice(hash);
 
@@ -118,7 +118,7 @@ pub fn check_block_pow(hash: &[u8; 32], difficulty: u128) -> Result<(), BlockErr
 
 /// Returns the penalty free zone
 ///
-/// https://cuprate.github.io/monero-book/consensus_rules/blocks/weight_limit.html#penalty-free-zone
+/// <https://cuprate.github.io/monero-book/consensus_rules/blocks/weight_limit.html#penalty-free-zone>
 pub fn penalty_free_zone(hf: &HardFork) -> usize {
     if hf == &HardFork::V1 {
         PENALTY_FREE_ZONE_1
@@ -131,7 +131,7 @@ pub fn penalty_free_zone(hf: &HardFork) -> usize {
 
 /// Sanity check on the block blob size.
 ///
-/// ref: https://monero-book.cuprate.org/consensus_rules/blocks.html#block-weight-and-size
+/// ref: <https://monero-book.cuprate.org/consensus_rules/blocks.html#block-weight-and-size>
 fn block_size_sanity_check(
     block_blob_len: usize,
     effective_median: usize,
@@ -145,7 +145,7 @@ fn block_size_sanity_check(
 
 /// Sanity check on the block weight.
 ///
-/// ref: https://monero-book.cuprate.org/consensus_rules/blocks.html#block-weight-and-size
+/// ref: <https://monero-book.cuprate.org/consensus_rules/blocks.html#block-weight-and-size>
 fn check_block_weight(
     block_weight: usize,
     median_for_block_reward: usize,
@@ -159,7 +159,7 @@ fn check_block_weight(
 
 /// Sanity check on number of txs in the block.
 ///
-/// ref: https://monero-book.cuprate.org/consensus_rules/blocks.html#amount-of-transactions
+/// ref: <https://monero-book.cuprate.org/consensus_rules/blocks.html#amount-of-transactions>
 fn check_amount_txs(number_none_miner_txs: usize) -> Result<(), BlockError> {
     if number_none_miner_txs + 1 > 0x10000000 {
         Err(BlockError::TooManyTxs)
@@ -170,7 +170,7 @@ fn check_amount_txs(number_none_miner_txs: usize) -> Result<(), BlockError> {
 
 /// Verifies the previous id is the last blocks hash
 ///
-/// ref: https://monero-book.cuprate.org/consensus_rules/blocks.html#previous-id
+/// ref: <https://monero-book.cuprate.org/consensus_rules/blocks.html#previous-id>
 fn check_prev_id(block: &Block, top_hash: &[u8; 32]) -> Result<(), BlockError> {
     if &block.header.previous != top_hash {
         Err(BlockError::PreviousIDIncorrect)
@@ -181,7 +181,7 @@ fn check_prev_id(block: &Block, top_hash: &[u8; 32]) -> Result<(), BlockError> {
 
 /// Checks the blocks timestamp is in the valid range.
 ///
-/// ref: https://monero-book.cuprate.org/consensus_rules/blocks.html#timestamp
+/// ref: <https://monero-book.cuprate.org/consensus_rules/blocks.html#timestamp>
 fn check_timestamp(block: &Block, median_timestamp: u64) -> Result<(), BlockError> {
     if block.header.timestamp < median_timestamp
         || block.header.timestamp > current_unix_timestamp() + BLOCK_FUTURE_TIME_LIMIT
@@ -194,7 +194,7 @@ fn check_timestamp(block: &Block, median_timestamp: u64) -> Result<(), BlockErro
 
 /// Checks that all txs in the block have a unique hash.
 ///
-/// ref: https://monero-book.cuprate.org/consensus_rules/blocks.html#no-duplicate-transactions
+/// ref: <https://monero-book.cuprate.org/consensus_rules/blocks.html#no-duplicate-transactions>
 fn check_txs_unique(txs: &[[u8; 32]]) -> Result<(), BlockError> {
     txs.windows(2).try_for_each(|window| {
         if window[0] == window[1] {
@@ -208,9 +208,9 @@ fn check_txs_unique(txs: &[[u8; 32]]) -> Result<(), BlockError> {
 /// the data in this struct is calculated correctly.
 #[derive(Debug, Clone)]
 pub struct ContextToVerifyBlock {
-    /// ref: https://monero-book.cuprate.org/consensus_rules/blocks/weights.html#median-weight-for-coinbase-checks
+    /// ref: <https://monero-book.cuprate.org/consensus_rules/blocks/weights.html#median-weight-for-coinbase-checks>
     pub median_weight_for_block_reward: usize,
-    /// ref: https://monero-book.cuprate.org/consensus_rules/blocks/weights.html#effective-median-weight
+    /// ref: <https://monero-book.cuprate.org/consensus_rules/blocks/weights.html#effective-median-weight>
     pub effective_median_weight: usize,
     /// The top hash of the blockchain, aka the block hash of the previous block to the one we are verifying.
     pub top_hash: [u8; 32],
@@ -220,7 +220,7 @@ pub struct ContextToVerifyBlock {
     pub chain_height: u64,
     /// The current hard-fork.
     pub current_hf: HardFork,
-    /// ref: https://monero-book.cuprate.org/consensus_rules/blocks/difficulty.html#calculating-difficulty
+    /// ref: <https://monero-book.cuprate.org/consensus_rules/blocks/difficulty.html#calculating-difficulty>
     pub next_difficulty: u128,
     /// The amount of coins already minted.
     pub already_generated_coins: u64,
@@ -234,8 +234,8 @@ pub struct ContextToVerifyBlock {
 ///
 /// Missed block checks in this function:
 ///
-/// https://monero-book.cuprate.org/consensus_rules/blocks.html#key-images
-/// https://monero-book.cuprate.org/consensus_rules/blocks.html#checking-pow-hash
+/// <https://monero-book.cuprate.org/consensus_rules/blocks.html#key-images>
+/// <https://monero-book.cuprate.org/consensus_rules/blocks.html#checking-pow-hash>
 ///
 ///
 pub fn check_block(

--- a/consensus/rules/src/decomposed_amount.rs
+++ b/consensus/rules/src/decomposed_amount.rs
@@ -36,8 +36,8 @@ pub fn decomposed_amounts() -> &'static [u64; 172] {
 ///
 /// This is also used during miner tx verification.
 ///
-/// ref: https://monero-book.cuprate.org/consensus_rules/transactions/ring_signatures.html#output-amount
-/// ref: https://monero-book.cuprate.org/consensus_rules/blocks/miner_tx.html#output-amounts
+/// ref: <https://monero-book.cuprate.org/consensus_rules/transactions/ring_signatures.html#output-amount>
+/// ref: <https://monero-book.cuprate.org/consensus_rules/blocks/miner_tx.html#output-amounts>
 #[inline]
 pub fn is_decomposed_amount(amount: &u64) -> bool {
     decomposed_amounts().binary_search(amount).is_ok()

--- a/consensus/rules/src/genesis.rs
+++ b/consensus/rules/src/genesis.rs
@@ -25,7 +25,7 @@ fn genesis_miner_tx(network: &Network) -> Transaction {
 
 /// Generates the Monero genesis block.
 ///
-/// ref: https://monero-book.cuprate.org/consensus_rules/genesis_block.html
+/// ref: <https://monero-book.cuprate.org/consensus_rules/genesis_block.html>
 pub fn generate_genesis_block(network: &Network) -> Block {
     Block {
         header: BlockHeader {

--- a/consensus/rules/src/hard_forks.rs
+++ b/consensus/rules/src/hard_forks.rs
@@ -18,11 +18,11 @@ mod tests;
 
 /// Target block time for hf 1.
 ///
-/// ref: https://monero-book.cuprate.org/consensus_rules/blocks/difficulty.html#target-seconds
+/// ref: <https://monero-book.cuprate.org/consensus_rules/blocks/difficulty.html#target-seconds>
 const BLOCK_TIME_V1: Duration = Duration::from_secs(60);
 /// Target block time from v2.
 ///
-/// ref: https://monero-book.cuprate.org/consensus_rules/blocks/difficulty.html#target-seconds
+/// ref: <https://monero-book.cuprate.org/consensus_rules/blocks/difficulty.html#target-seconds>
 const BLOCK_TIME_V2: Duration = Duration::from_secs(120);
 
 pub const NUMB_OF_HARD_FORKS: usize = 16;
@@ -64,7 +64,7 @@ impl HFsInfo {
 
     /// Returns the main-net hard-fork information.
     ///
-    /// ref: https://monero-book.cuprate.org/consensus_rules/hardforks.html#Mainnet-Hard-Forks
+    /// ref: <https://monero-book.cuprate.org/consensus_rules/hardforks.html#Mainnet-Hard-Forks>
     pub const fn main_net() -> HFsInfo {
         Self([
             HFInfo::new(0, 0),
@@ -88,7 +88,7 @@ impl HFsInfo {
 
     /// Returns the test-net hard-fork information.
     ///
-    /// ref: https://monero-book.cuprate.org/consensus_rules/hardforks.html#Testnet-Hard-Forks
+    /// ref: <https://monero-book.cuprate.org/consensus_rules/hardforks.html#Testnet-Hard-Forks>
     pub const fn test_net() -> HFsInfo {
         Self([
             HFInfo::new(0, 0),
@@ -112,7 +112,7 @@ impl HFsInfo {
 
     /// Returns the test-net hard-fork information.
     ///
-    /// ref: https://monero-book.cuprate.org/consensus_rules/hardforks.html#Stagenet-Hard-Forks
+    /// ref: <https://monero-book.cuprate.org/consensus_rules/hardforks.html#Stagenet-Hard-Forks>
     pub const fn stage_net() -> HFsInfo {
         Self([
             HFInfo::new(0, 0),
@@ -162,7 +162,7 @@ pub enum HardFork {
 impl HardFork {
     /// Returns the hard-fork for a blocks `major_version` field.
     ///
-    /// https://monero-book.cuprate.org/consensus_rules/hardforks.html#blocks-version-and-vote
+    /// <https://monero-book.cuprate.org/consensus_rules/hardforks.html#blocks-version-and-vote>
     pub fn from_version(version: u8) -> Result<HardFork, HardForkError> {
         Ok(match version {
             1 => HardFork::V1,
@@ -187,7 +187,7 @@ impl HardFork {
 
     /// Returns the hard-fork for a blocks `minor_version` (vote) field.
     ///
-    /// https://monero-book.cuprate.org/consensus_rules/hardforks.html#blocks-version-and-vote
+    /// <https://monero-book.cuprate.org/consensus_rules/hardforks.html#blocks-version-and-vote>
     pub fn from_vote(vote: u8) -> HardFork {
         if vote == 0 {
             // A vote of 0 is interpreted as 1 as that's what Monero used to default to.
@@ -211,7 +211,7 @@ impl HardFork {
 
     /// Returns the target block time for this hardfork.
     ///
-    /// ref: https://monero-book.cuprate.org/consensus_rules/blocks/difficulty.html#target-seconds
+    /// ref: <https://monero-book.cuprate.org/consensus_rules/blocks/difficulty.html#target-seconds>
     pub fn block_time(&self) -> Duration {
         match self {
             HardFork::V1 => BLOCK_TIME_V1,
@@ -221,7 +221,7 @@ impl HardFork {
 
     /// Checks a blocks version and vote, assuming that `self` is the current hard-fork.
     ///
-    /// ref: https://monero-book.cuprate.org/consensus_rules/hardforks.html#blocks-version-and-vote
+    /// ref: <https://monero-book.cuprate.org/consensus_rules/hardforks.html#blocks-version-and-vote>
     pub fn check_block_version_vote(
         &self,
         version: &HardFork,
@@ -292,7 +292,7 @@ impl HFVotes {
 
     /// Returns the total votes for a hard-fork.
     ///
-    /// ref: https://monero-book.cuprate.org/consensus_rules/hardforks.html#accepting-a-fork
+    /// ref: <https://monero-book.cuprate.org/consensus_rules/hardforks.html#accepting-a-fork>
     pub fn votes_for_hf(&self, hf: &HardFork) -> u64 {
         self.votes[*hf as usize - 1..].iter().sum()
     }
@@ -305,7 +305,7 @@ impl HFVotes {
     /// Checks if a future hard fork should be activated, returning the next hard-fork that should be
     /// activated.
     ///
-    /// ref: https://monero-book.cuprate.org/consensus_rules/hardforks.html#accepting-a-fork
+    /// ref: <https://monero-book.cuprate.org/consensus_rules/hardforks.html#accepting-a-fork>
     pub fn current_fork(
         &self,
         current_hf: &HardFork,
@@ -335,7 +335,7 @@ impl HFVotes {
 
 /// Returns the votes needed for a hard-fork.
 ///
-/// ref: https://monero-book.cuprate.org/consensus_rules/hardforks.html#accepting-a-fork
+/// ref: <https://monero-book.cuprate.org/consensus_rules/hardforks.html#accepting-a-fork>
 pub fn votes_needed(threshold: u64, window: u64) -> u64 {
     (threshold * window).div_ceil(100)
 }

--- a/consensus/rules/src/lib.rs
+++ b/consensus/rules/src/lib.rs
@@ -21,7 +21,7 @@ pub enum ConsensusError {
 
 /// Checks that a point is canonically encoded.
 ///
-/// https://github.com/dalek-cryptography/curve25519-dalek/issues/380
+/// <https://github.com/dalek-cryptography/curve25519-dalek/issues/380>
 fn check_point_canonically_encoded(point: &curve25519_dalek::edwards::CompressedEdwardsY) -> bool {
     let bytes = point.as_bytes();
 

--- a/consensus/rules/src/miner_tx.rs
+++ b/consensus/rules/src/miner_tx.rs
@@ -40,7 +40,7 @@ const MINER_TX_TIME_LOCKED_BLOCKS: u64 = 60;
 /// Calculates the base block reward without taking away the penalty for expanding
 /// the block.
 ///
-/// ref: https://monero-book.cuprate.org/consensus_rules/blocks/reward.html#calculating-base-block-reward
+/// ref: <https://monero-book.cuprate.org/consensus_rules/blocks/reward.html#calculating-base-block-reward>
 fn calculate_base_reward(already_generated_coins: u64, hf: &HardFork) -> u64 {
     let target_mins = hf.block_time().as_secs() / 60;
     let emission_speed_factor = 20 - (target_mins - 1);
@@ -50,7 +50,7 @@ fn calculate_base_reward(already_generated_coins: u64, hf: &HardFork) -> u64 {
 
 /// Calculates the miner reward for this block.
 ///
-/// ref: https://monero-book.cuprate.org/consensus_rules/blocks/reward.html#calculating-block-reward
+/// ref: <https://monero-book.cuprate.org/consensus_rules/blocks/reward.html#calculating-block-reward>
 pub fn calculate_block_reward(
     block_weight: usize,
     median_bw: usize,
@@ -75,7 +75,7 @@ pub fn calculate_block_reward(
 
 /// Checks the miner transactions version.
 ///
-/// ref: https://monero-book.cuprate.org/consensus_rules/blocks/miner_tx.html#version
+/// ref: <https://monero-book.cuprate.org/consensus_rules/blocks/miner_tx.html#version>
 fn check_miner_tx_version(tx_version: &TxVersion, hf: &HardFork) -> Result<(), MinerTxError> {
     // The TxVersion enum checks if the version is not 1 or 2
     if hf >= &HardFork::V12 && tx_version != &TxVersion::RingCT {
@@ -87,7 +87,7 @@ fn check_miner_tx_version(tx_version: &TxVersion, hf: &HardFork) -> Result<(), M
 
 /// Checks the miner transactions inputs.
 ///
-/// ref: https://monero-book.cuprate.org/consensus_rules/blocks/miner_tx.html#input
+/// ref: <https://monero-book.cuprate.org/consensus_rules/blocks/miner_tx.html#input>
 fn check_inputs(inputs: &[Input], chain_height: u64) -> Result<(), MinerTxError> {
     if inputs.len() != 1 {
         return Err(MinerTxError::IncorrectNumbOfInputs);
@@ -107,7 +107,7 @@ fn check_inputs(inputs: &[Input], chain_height: u64) -> Result<(), MinerTxError>
 
 /// Checks the miner transaction has a correct time lock.
 ///
-/// ref: https://monero-book.cuprate.org/consensus_rules/blocks/miner_tx.html#unlock-time
+/// ref: <https://monero-book.cuprate.org/consensus_rules/blocks/miner_tx.html#unlock-time>
 fn check_time_lock(time_lock: &Timelock, chain_height: u64) -> Result<(), MinerTxError> {
     match time_lock {
         Timelock::Block(till_height) => {
@@ -128,8 +128,8 @@ fn check_time_lock(time_lock: &Timelock, chain_height: u64) -> Result<(), MinerT
 
 /// Sums the outputs checking for overflow.
 ///
-/// ref: https://monero-book.cuprate.org/consensus_rules/blocks/miner_tx.html#output-amounts
-/// &&   https://monero-book.cuprate.org/consensus_rules/blocks/miner_tx.html#zero-amount-v1-output
+/// ref: <https://monero-book.cuprate.org/consensus_rules/blocks/miner_tx.html#output-amounts>
+/// &&   <https://monero-book.cuprate.org/consensus_rules/blocks/miner_tx.html#zero-amount-v1-output>
 fn sum_outputs(
     outputs: &[Output],
     hf: &HardFork,
@@ -153,7 +153,7 @@ fn sum_outputs(
 
 /// Checks the total outputs amount is correct returning the amount of coins collected by the miner.
 ///
-/// ref: https://monero-book.cuprate.org/consensus_rules/blocks/miner_tx.html#total-outputs
+/// ref: <https://monero-book.cuprate.org/consensus_rules/blocks/miner_tx.html#total-outputs>
 fn check_total_output_amt(
     total_output: u64,
     reward: u64,
@@ -176,7 +176,7 @@ fn check_total_output_amt(
 /// Checks all miner transactions rules.
 ///
 /// Excluding:
-/// https://monero-book.cuprate.org/consensus_rules/blocks/miner_tx.html#v2-output-pool
+/// <https://monero-book.cuprate.org/consensus_rules/blocks/miner_tx.html#v2-output-pool>
 ///
 /// as this needs to be done in a database.
 pub fn check_miner_tx(
@@ -191,7 +191,7 @@ pub fn check_miner_tx(
     let tx_version = TxVersion::from_raw(tx.prefix.version).ok_or(MinerTxError::VersionInvalid)?;
     check_miner_tx_version(&tx_version, hf)?;
 
-    // ref: https://monero-book.cuprate.org/consensus_rules/blocks/miner_tx.html#ringct-type
+    // ref: <https://monero-book.cuprate.org/consensus_rules/blocks/miner_tx.html#ringct-type>
     if hf >= &HardFork::V12 && tx.rct_signatures.rct_type() != RctType::Null {
         return Err(MinerTxError::RCTTypeNotNULL);
     }

--- a/consensus/rules/src/transactions.rs
+++ b/consensus/rules/src/transactions.rs
@@ -86,8 +86,8 @@ impl TxVersion {
     ///
     /// This will return `None` on invalid values.
     ///
-    /// ref: https://monero-book.cuprate.org/consensus_rules/transactions.html#version
-    ///  &&  https://monero-book.cuprate.org/consensus_rules/blocks/miner_tx.html#version  
+    /// ref: <https://monero-book.cuprate.org/consensus_rules/transactions.html#version>
+    ///  &&  <https://monero-book.cuprate.org/consensus_rules/blocks/miner_tx.html#version>
     pub fn from_raw(version: u64) -> Option<TxVersion> {
         Some(match version {
             1 => TxVersion::RingSignatures,
@@ -101,7 +101,7 @@ impl TxVersion {
 
 /// Checks the output keys are canonically encoded points.
 ///
-/// https://monero-book.cuprate.org/consensus_rules/transactions/outputs.html#output-keys-canonical
+/// <https://monero-book.cuprate.org/consensus_rules/transactions/outputs.html#output-keys-canonical>
 fn check_output_keys(outputs: &[Output]) -> Result<(), TransactionError> {
     for out in outputs {
         if !check_point_canonically_encoded(&out.key) {
@@ -116,8 +116,8 @@ fn check_output_keys(outputs: &[Output]) -> Result<(), TransactionError> {
 ///
 /// This is also used during miner-tx verification.
 ///
-/// https://monero-book.cuprate.org/consensus_rules/transactions/outputs.html#output-type
-/// https://monero-book.cuprate.org/consensus_rules/blocks/miner_tx.html#output-type
+/// <https://monero-book.cuprate.org/consensus_rules/transactions/outputs.html#output-type>
+/// <https://monero-book.cuprate.org/consensus_rules/blocks/miner_tx.html#output-type>
 pub(crate) fn check_output_types(
     outputs: &[Output],
     hf: &HardFork,
@@ -143,7 +143,7 @@ pub(crate) fn check_output_types(
 
 /// Checks the individual outputs amount for version 1 txs.
 ///
-/// ref: https://monero-book.cuprate.org/consensus_rules/transactions/outputs.html#output-amount
+/// ref: <https://monero-book.cuprate.org/consensus_rules/transactions/outputs.html#output-amount>
 fn check_output_amount_v1(amount: u64, hf: &HardFork) -> Result<(), TransactionError> {
     if amount == 0 {
         return Err(TransactionError::ZeroOutputForV1);
@@ -158,7 +158,7 @@ fn check_output_amount_v1(amount: u64, hf: &HardFork) -> Result<(), TransactionE
 
 /// Checks the individual outputs amount for version 2 txs.
 ///
-/// ref: https://monero-book.cuprate.org/consensus_rules/transactions/outputs.html#output-amount
+/// ref: <https://monero-book.cuprate.org/consensus_rules/transactions/outputs.html#output-amount>
 fn check_output_amount_v2(amount: u64) -> Result<(), TransactionError> {
     if amount == 0 {
         Ok(())
@@ -169,8 +169,8 @@ fn check_output_amount_v2(amount: u64) -> Result<(), TransactionError> {
 
 /// Sums the outputs, checking for overflow and other consensus rules.
 ///
-/// ref: https://monero-book.cuprate.org/consensus_rules/transactions/outputs.html#output-amount
-/// &&   https://monero-book.cuprate.org/consensus_rules/transactions/outputs.html#outputs-must-not-overflow
+/// ref: <https://monero-book.cuprate.org/consensus_rules/transactions/outputs.html#output-amount>
+/// &&   <https://monero-book.cuprate.org/consensus_rules/transactions/outputs.html#outputs-must-not-overflow>
 fn sum_outputs(
     outputs: &[Output],
     hf: &HardFork,
@@ -195,9 +195,9 @@ fn sum_outputs(
 
 /// Checks the number of outputs is allowed.
 ///
-/// ref: https://monero-book.cuprate.org/consensus_rules/transactions/outputs.html#2-outputs
-/// &&   https://monero-book.cuprate.org/consensus_rules/transactions/ring_ct/bulletproofs.html#max-outputs
-/// &&   https://monero-book.cuprate.org/consensus_rules/transactions/ring_ct/bulletproofs+.html#max-outputs
+/// ref: <https://monero-book.cuprate.org/consensus_rules/transactions/outputs.html#2-outputs>
+/// &&   <https://monero-book.cuprate.org/consensus_rules/transactions/ring_ct/bulletproofs.html#max-outputs>
+/// &&   <https://monero-book.cuprate.org/consensus_rules/transactions/ring_ct/bulletproofs+.html#max-outputs>
 fn check_number_of_outputs(
     outputs: usize,
     hf: &HardFork,
@@ -226,9 +226,9 @@ fn check_number_of_outputs(
 
 /// Checks the outputs against all output consensus rules, returning the sum of the output amounts.
 ///
-/// ref: https://monero-book.cuprate.org/consensus_rules/transactions/outputs.html
-/// &&   https://monero-book.cuprate.org/consensus_rules/transactions/ring_ct/bulletproofs.html#max-outputs
-/// &&   https://monero-book.cuprate.org/consensus_rules/transactions/ring_ct/bulletproofs+.html#max-outputs
+/// ref: <https://monero-book.cuprate.org/consensus_rules/transactions/outputs.html>
+/// &&   <https://monero-book.cuprate.org/consensus_rules/transactions/ring_ct/bulletproofs.html#max-outputs>
+/// &&   <https://monero-book.cuprate.org/consensus_rules/transactions/ring_ct/bulletproofs+.html#max-outputs>
 fn check_outputs_semantics(
     outputs: &[Output],
     hf: &HardFork,
@@ -246,7 +246,7 @@ fn check_outputs_semantics(
 
 /// Checks if an outputs unlock time has passed.
 ///
-/// https://monero-book.cuprate.org/consensus_rules/transactions/unlock_time.html
+/// <https://monero-book.cuprate.org/consensus_rules/transactions/unlock_time.html>
 fn output_unlocked(
     time_lock: &Timelock,
     current_chain_height: u64,
@@ -266,7 +266,7 @@ fn output_unlocked(
 
 /// Returns if a locked output, which uses a block height, can be spent.
 ///
-/// ref: https://monero-book.cuprate.org/consensus_rules/transactions/unlock_time.html#block-height
+/// ref: <https://monero-book.cuprate.org/consensus_rules/transactions/unlock_time.html#block-height>
 fn check_block_time_lock(unlock_height: u64, current_chain_height: u64) -> bool {
     // current_chain_height = 1 + top height
     unlock_height <= current_chain_height
@@ -274,7 +274,7 @@ fn check_block_time_lock(unlock_height: u64, current_chain_height: u64) -> bool 
 
 /// Returns if a locked output, which uses a block height, can be spend.
 ///
-/// ref: https://monero-book.cuprate.org/consensus_rules/transactions/unlock_time.html#timestamp
+/// ref: <https://monero-book.cuprate.org/consensus_rules/transactions/unlock_time.html#timestamp>
 fn check_timestamp_time_lock(
     unlock_timestamp: u64,
     current_time_lock_timestamp: u64,
@@ -285,10 +285,10 @@ fn check_timestamp_time_lock(
 
 /// Checks all the time locks are unlocked.
 ///
-/// `current_time_lock_timestamp` must be: https://monero-book.cuprate.org/consensus_rules/transactions/unlock_time.html#getting-the-current-time
+/// `current_time_lock_timestamp` must be: <https://monero-book.cuprate.org/consensus_rules/transactions/unlock_time.html#getting-the-current-time>
 ///
-/// https://monero-book.cuprate.org/consensus_rules/transactions/unlock_time.html
-/// https://monero-book.cuprate.org/consensus_rules/transactions/inputs.html#the-output-must-not-be-locked
+/// <https://monero-book.cuprate.org/consensus_rules/transactions/unlock_time.html>
+/// <https://monero-book.cuprate.org/consensus_rules/transactions/inputs.html#the-output-must-not-be-locked>
 fn check_all_time_locks(
     time_locks: &[Timelock],
     current_chain_height: u64,
@@ -313,8 +313,8 @@ fn check_all_time_locks(
 
 /// Checks the decoys are allowed.
 ///
-/// ref: https://monero-book.cuprate.org/consensus_rules/transactions/inputs.html#minimum-decoys
-/// &&   https://monero-book.cuprate.org/consensus_rules/transactions/inputs.html#equal-number-of-decoys
+/// ref: <https://monero-book.cuprate.org/consensus_rules/transactions/inputs.html#minimum-decoys>
+/// &&   <https://monero-book.cuprate.org/consensus_rules/transactions/inputs.html#equal-number-of-decoys>
 fn check_decoy_info(decoy_info: &DecoyInfo, hf: &HardFork) -> Result<(), TransactionError> {
     if hf == &HardFork::V15 {
         // Hard-fork 15 allows both v14 and v16 rules
@@ -351,8 +351,8 @@ fn check_decoy_info(decoy_info: &DecoyInfo, hf: &HardFork) -> Result<(), Transac
 /// The `spent_kis` parameter is not meant to be a complete list of key images, just a list of related transactions
 /// key images, for example transactions in a block. The chain will be checked for duplicates later.
 ///
-/// ref: https://monero-book.cuprate.org/consensus_rules/transactions/inputs.html#unique-key-image
-/// &&   https://monero-book.cuprate.org/consensus_rules/transactions/inputs.html#torsion-free-key-image
+/// ref: <https://monero-book.cuprate.org/consensus_rules/transactions/inputs.html#unique-key-image>
+/// &&   <https://monero-book.cuprate.org/consensus_rules/transactions/inputs.html#torsion-free-key-image>
 fn check_key_images(
     input: &Input,
     spent_kis: &mut HashSet<[u8; 32]>,
@@ -375,7 +375,7 @@ fn check_key_images(
 
 /// Checks that the input is of type [`Input::ToKey`] aka txin_to_key.
 ///
-/// ref: https://monero-book.cuprate.org/consensus_rules/transactions/inputs.html#input-type
+/// ref: <https://monero-book.cuprate.org/consensus_rules/transactions/inputs.html#input-type>
 fn check_input_type(input: &Input) -> Result<(), TransactionError> {
     match input {
         Input::ToKey { .. } => Ok(()),
@@ -385,7 +385,7 @@ fn check_input_type(input: &Input) -> Result<(), TransactionError> {
 
 /// Checks that the input has decoys.
 ///
-/// ref: https://monero-book.cuprate.org/consensus_rules/transactions/inputs.html#no-empty-decoys
+/// ref: <https://monero-book.cuprate.org/consensus_rules/transactions/inputs.html#no-empty-decoys>
 fn check_input_has_decoys(input: &Input) -> Result<(), TransactionError> {
     match input {
         Input::ToKey { key_offsets, .. } => {
@@ -401,7 +401,7 @@ fn check_input_has_decoys(input: &Input) -> Result<(), TransactionError> {
 
 /// Checks that the ring members for the input are unique after hard-fork 6.
 ///
-/// ref: https://monero-book.cuprate.org/consensus_rules/transactions/inputs.html#unique-ring-members
+/// ref: <https://monero-book.cuprate.org/consensus_rules/transactions/inputs.html#unique-ring-members>
 fn check_ring_members_unique(input: &Input, hf: &HardFork) -> Result<(), TransactionError> {
     if hf >= &HardFork::V6 {
         match input {
@@ -421,7 +421,7 @@ fn check_ring_members_unique(input: &Input, hf: &HardFork) -> Result<(), Transac
 
 /// Checks that from hf 7 the inputs are sorted by key image.
 ///
-/// ref: https://monero-book.cuprate.org/consensus_rules/transactions/inputs.html#sorted-inputs
+/// ref: <https://monero-book.cuprate.org/consensus_rules/transactions/inputs.html#sorted-inputs>
 fn check_inputs_sorted(inputs: &[Input], hf: &HardFork) -> Result<(), TransactionError> {
     let get_ki = |inp: &Input| match inp {
         Input::ToKey { key_image, .. } => Ok(key_image.compress().to_bytes()),
@@ -443,7 +443,7 @@ fn check_inputs_sorted(inputs: &[Input], hf: &HardFork) -> Result<(), Transactio
 
 /// Checks the youngest output is at least 10 blocks old.
 ///
-/// ref: https://monero-book.cuprate.org/consensus_rules/transactions/inputs.html#10-block-lock
+/// ref: <https://monero-book.cuprate.org/consensus_rules/transactions/inputs.html#10-block-lock>
 fn check_10_block_lock(
     youngest_used_out_height: u64,
     current_chain_height: u64,
@@ -462,7 +462,7 @@ fn check_10_block_lock(
 
 /// Sums the inputs checking for overflow.
 ///
-/// ref: https://monero-book.cuprate.org/consensus_rules/transactions/inputs.html#inputs-must-not-overflow
+/// ref: <https://monero-book.cuprate.org/consensus_rules/transactions/inputs.html#inputs-must-not-overflow>
 fn sum_inputs_check_overflow(inputs: &[Input]) -> Result<u64, TransactionError> {
     let mut sum: u64 = 0;
     for inp in inputs {
@@ -485,7 +485,7 @@ fn sum_inputs_check_overflow(inputs: &[Input]) -> Result<u64, TransactionError> 
 /// - The tx-pool will use the current hard-fork
 /// - When syncing the hard-fork is in the block header.
 fn check_inputs_semantics(inputs: &[Input], hf: &HardFork) -> Result<u64, TransactionError> {
-    // https://monero-book.cuprate.org/consensus_rules/transactions/inputs.html#no-empty-inputs
+    // <https://monero-book.cuprate.org/consensus_rules/transactions/inputs.html#no-empty-inputs>
     if inputs.is_empty() {
         return Err(TransactionError::NoInputs);
     }
@@ -542,7 +542,7 @@ fn check_inputs_contextual(
 
 /// Checks the version is in the allowed range.
 ///
-/// https://monero-book.cuprate.org/consensus_rules/transactions.html#version
+/// <https://monero-book.cuprate.org/consensus_rules/transactions.html#version>
 fn check_tx_version(
     decoy_info: &Option<DecoyInfo>,
     version: &TxVersion,
@@ -606,7 +606,7 @@ pub fn check_transaction_semantic(
     hf: &HardFork,
     verifier: &mut BatchVerifier<(), dalek_ff_group::EdwardsPoint>,
 ) -> Result<u64, TransactionError> {
-    // https://monero-book.cuprate.org/consensus_rules/transactions.html#transaction-size
+    // <https://monero-book.cuprate.org/consensus_rules/transactions.html#transaction-size>
     if tx_blob_size > MAX_TX_BLOB_SIZE
         || (hf >= &HardFork::V8 && tx_weight > transaction_weight_limit(hf))
     {
@@ -645,7 +645,7 @@ pub fn check_transaction_semantic(
 ///
 /// To fully verify a transaction this must be accompanied with [`check_transaction_semantic`]
 ///
-/// `current_time_lock_timestamp` must be: https://monero-book.cuprate.org/consensus_rules/transactions/unlock_time.html#getting-the-current-time
+/// `current_time_lock_timestamp` must be: <https://monero-book.cuprate.org/consensus_rules/transactions/unlock_time.html#getting-the-current-time>
 
 pub fn check_transaction_contextual(
     tx: &Transaction,

--- a/consensus/rules/src/transactions/contextual_data.rs
+++ b/consensus/rules/src/transactions/contextual_data.rs
@@ -20,7 +20,7 @@ pub struct OutputOnChain {
 /// Gets the absolute offsets from the relative offsets.
 ///
 /// This function will return an error if the relative offsets are empty.
-/// https://cuprate.github.io/monero-book/consensus_rules/transactions.html#inputs-must-have-decoys
+/// <https://cuprate.github.io/monero-book/consensus_rules/transactions.html#inputs-must-have-decoys>
 fn get_absolute_offsets(relative_offsets: &[u64]) -> Result<Vec<u64>, TransactionError> {
     if relative_offsets.is_empty() {
         return Err(TransactionError::InputDoesNotHaveExpectedNumbDecoys);
@@ -38,7 +38,7 @@ fn get_absolute_offsets(relative_offsets: &[u64]) -> Result<Vec<u64>, Transactio
 /// Inserts the output IDs that are needed to verify the transaction inputs into the provided HashMap.
 ///
 /// This will error if the inputs are empty
-/// https://cuprate.github.io/monero-book/consensus_rules/transactions.html#no-empty-inputs
+/// <https://cuprate.github.io/monero-book/consensus_rules/transactions.html#no-empty-inputs>
 ///
 pub fn insert_ring_member_ids(
     inputs: &[Input],
@@ -191,7 +191,7 @@ impl TxRingMembersInfo {
 /// - The input amounts are *ALL* 0 (RCT)
 /// - The top block hash is the same as when this data was retrieved (the blockchain state is unchanged).
 ///
-/// https://cuprate.github.io/monero-book/consensus_rules/transactions/decoys.html
+/// <https://cuprate.github.io/monero-book/consensus_rules/transactions/decoys.html>
 #[derive(Debug)]
 pub struct DecoyInfo {
     /// The number of inputs that have enough outputs on the chain to mix with.
@@ -241,7 +241,7 @@ impl DecoyInfo {
                             .get(amount)
                             .expect("outputs_with_amount does not include needed amount.");
 
-                        // https://cuprate.github.io/monero-book/consensus_rules/transactions/decoys.html#mixable-and-unmixable-inputs
+                        // <https://cuprate.github.io/monero-book/consensus_rules/transactions/decoys.html#mixable-and-unmixable-inputs>
                         if outs_with_amt <= minimum_decoys {
                             not_mixable += 1;
                         } else {
@@ -257,7 +257,7 @@ impl DecoyInfo {
                         .checked_sub(1)
                         .ok_or(TransactionError::InputDoesNotHaveExpectedNumbDecoys)?;
 
-                    // https://cuprate.github.io/monero-book/consensus_rules/transactions/decoys.html#minimum-and-maximum-decoys-used
+                    // <https://cuprate.github.io/monero-book/consensus_rules/transactions/decoys.html#minimum-and-maximum-decoys-used>
                     min_decoys = min(min_decoys, numb_decoys);
                     max_decoys = max(max_decoys, numb_decoys);
                 }
@@ -277,7 +277,7 @@ impl DecoyInfo {
 /// Returns the default minimum amount of decoys for a hard-fork.
 /// **There are exceptions to this always being the minimum decoys**
 ///
-/// ref: https://monero-book.cuprate.org/consensus_rules/transactions/inputs.html#default-minimum-decoys
+/// ref: <https://monero-book.cuprate.org/consensus_rules/transactions/inputs.html#default-minimum-decoys>
 pub(crate) fn minimum_decoys(hf: &HardFork) -> usize {
     use HardFork as HF;
     match hf {

--- a/consensus/rules/src/transactions/ring_ct.rs
+++ b/consensus/rules/src/transactions/ring_ct.rs
@@ -43,7 +43,7 @@ pub enum RingCTError {
 
 /// Checks the RingCT type is allowed for the current hard fork.
 ///
-/// https://monero-book.cuprate.org/consensus_rules/ring_ct.html#type
+/// <https://monero-book.cuprate.org/consensus_rules/ring_ct.html#type>
 fn check_rct_type(ty: &RctType, hf: HardFork, tx_hash: &[u8; 32]) -> Result<(), RingCTError> {
     use HardFork as F;
     use RctType as T;
@@ -61,7 +61,7 @@ fn check_rct_type(ty: &RctType, hf: HardFork, tx_hash: &[u8; 32]) -> Result<(), 
 
 /// Checks that the pseudo-outs sum to the same point as the output commitments.
 ///
-/// https://monero-book.cuprate.org/consensus_rules/ring_ct.html#pseudo-outs-outpks-balance
+/// <https://monero-book.cuprate.org/consensus_rules/ring_ct.html#pseudo-outs-outpks-balance>
 fn simple_type_balances(rct_sig: &RctSignatures) -> Result<(), RingCTError> {
     let pseudo_outs = if rct_sig.rct_type() == RctType::MlsagIndividual {
         &rct_sig.base.pseudo_outs
@@ -86,9 +86,9 @@ fn simple_type_balances(rct_sig: &RctSignatures) -> Result<(), RingCTError> {
 
 /// Checks the outputs range proof(s)
 ///
-/// https://monero-book.cuprate.org/consensus_rules/ring_ct/borromean.html
-/// https://monero-book.cuprate.org/consensus_rules/ring_ct/bulletproofs.html
-/// https://monero-book.cuprate.org/consensus_rules/ring_ct/bulletproofs+.html
+/// <https://monero-book.cuprate.org/consensus_rules/ring_ct/borromean.html>
+/// <https://monero-book.cuprate.org/consensus_rules/ring_ct/bulletproofs.html>
+/// <https://monero-book.cuprate.org/consensus_rules/ring_ct/bulletproofs+.html>
 fn check_output_range_proofs(
     rct_sig: &RctSignatures,
     verifier: &mut BatchVerifier<(), dalek_ff_group::EdwardsPoint>,
@@ -138,8 +138,8 @@ pub(crate) fn ring_ct_semantic_checks(
 
 /// Check the input signatures: MLSAG, CLSAG.
 ///
-/// https://monero-book.cuprate.org/consensus_rules/ring_ct/mlsag.html
-/// https://monero-book.cuprate.org/consensus_rules/ring_ct/clsag.html
+/// <https://monero-book.cuprate.org/consensus_rules/ring_ct/mlsag.html>
+/// <https://monero-book.cuprate.org/consensus_rules/ring_ct/clsag.html>
 pub(crate) fn check_input_signatures(
     msg: &[u8; 32],
     inputs: &[Input],

--- a/consensus/rules/src/transactions/ring_signatures.rs
+++ b/consensus/rules/src/transactions/ring_signatures.rs
@@ -1,9 +1,9 @@
 //! Version 1 ring signature verification.
 //!
 //! Some checks have to be done at deserialization or with data we don't have so we can't do them here, those checks are:
-//! https://monero-book.cuprate.org/consensus_rules/transactions/ring_signatures.html#signatures-must-be-canonical
+//! <https://monero-book.cuprate.org/consensus_rules/transactions/ring_signatures.html#signatures-must-be-canonical>
 //! this happens at deserialization in monero-serai.
-//! https://monero-book.cuprate.org/consensus_rules/transactions/ring_signatures.html#amount-of-signatures-in-a-ring
+//! <https://monero-book.cuprate.org/consensus_rules/transactions/ring_signatures.html#amount-of-signatures-in-a-ring>
 //! and this happens during ring signature verification in monero-serai.
 //!
 use monero_serai::{ring_signatures::RingSignature, transaction::Input};
@@ -16,7 +16,7 @@ use crate::try_par_iter;
 
 /// Verifies the ring signature.
 ///
-/// ref: https://monero-book.cuprate.org/consensus_rules/transactions/ring_signatures.html
+/// ref: <https://monero-book.cuprate.org/consensus_rules/transactions/ring_signatures.html>
 pub fn check_input_signatures(
     inputs: &[Input],
     signatures: &[RingSignature],
@@ -25,7 +25,7 @@ pub fn check_input_signatures(
 ) -> Result<(), TransactionError> {
     match rings {
         Rings::Legacy(rings) => {
-            // https://monero-book.cuprate.org/consensus_rules/transactions/ring_signatures.html#amount-of-ring-signatures
+            // <https://monero-book.cuprate.org/consensus_rules/transactions/ring_signatures.html#amount-of-ring-signatures>
             // rings.len() != inputs.len() can't happen but check any way.
             if signatures.len() != inputs.len() || rings.len() != inputs.len() {
                 return Err(TransactionError::RingSignatureIncorrect);

--- a/consensus/src/context.rs
+++ b/consensus/src/context.rs
@@ -183,7 +183,7 @@ impl std::ops::Deref for RawBlockChainContext {
 impl RawBlockChainContext {
     /// Returns the timestamp the should be used when checking locked outputs.
     ///
-    /// https://cuprate.github.io/monero-book/consensus_rules/transactions/unlock_time.html#getting-the-current-time
+    /// <https://cuprate.github.io/monero-book/consensus_rules/transactions/unlock_time.html#getting-the-current-time>
     pub fn current_adjusted_timestamp_for_time_lock(&self) -> u64 {
         if self.current_hf < HardFork::V13 || self.median_block_timestamp.is_none() {
             current_unix_timestamp()

--- a/helper/src/atomic.rs
+++ b/helper/src/atomic.rs
@@ -18,8 +18,8 @@ use core::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 // Using `UnsafeCell<float>` is also viable,
 // and would allow for a `const fn new(f: float) -> Self`
 // except that becomes problematic with NaN's and infinites:
-// - https://github.com/rust-lang/rust/issues/73328
-// - https://github.com/rust-lang/rfcs/pull/3514
+// - <https://github.com/rust-lang/rust/issues/73328>
+// - <https://github.com/rust-lang/rfcs/pull/3514>
 //
 // This is most likely safe(?) but... instead of risking UB,
 // this just uses the Atomic unsigned integer as the inner
@@ -30,7 +30,7 @@ use core::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 // - `AtomicF64`
 //
 // Originally taken from:
-// https://github.com/hinto-janai/sansan/blob/1f6680b2d08ff5fbf4f090178ea5233d4cf9056f/src/atomic.rs
+// <https://github.com/hinto-janai/sansan/blob/1f6680b2d08ff5fbf4f090178ea5233d4cf9056f/src/atomic.rs>
 macro_rules! impl_atomic_f {
     (
 		$atomic_float:ident,       // Name of the new float type
@@ -47,7 +47,7 @@ macro_rules! impl_atomic_f {
         /// An atomic float.
         ///
         /// ## Portability
-        /// [Quoting the std library: ](https://doc.rust-lang.org/1.70.0/std/primitive.f32.html#method.to_bits)
+        /// [Quoting the std library: ](<https://doc.rust-lang.org/1.70.0/std/primitive.f32.html#method.to_bits)>
         /// "See from_bits for some discussion of the portability of this operation (there are almost no issues)."
         ///
         /// ## Compile-time failure
@@ -75,7 +75,7 @@ macro_rules! impl_atomic_f {
             // FIXME:
             // Seems like `std` internals has some unstable cfg options that
             // allow interior mutable consts to be defined without clippy complaining:
-            // https://doc.rust-lang.org/1.70.0/src/core/sync/atomic.rs.html#3013.
+            // <https://doc.rust-lang.org/1.70.0/src/core/sync/atomic.rs.html#3013>.
             //
             /// `0.0`, returned by [`Self::default`].
             pub const DEFAULT: Self = Self($atomic_unsigned::new($bits_0));
@@ -83,10 +83,10 @@ macro_rules! impl_atomic_f {
             #[inline]
             /// Create a new atomic float.
             ///
-            /// Equivalent to https://doc.rust-lang.org/1.70.0/std/sync/atomic/struct.AtomicUsize.html#method.new
+            /// Equivalent to <https://doc.rust-lang.org/1.70.0/std/sync/atomic/struct.AtomicUsize.html#method.new>
             pub fn new(f: $float) -> Self {
                 // FIXME: Update to const when available.
-                // https://doc.rust-lang.org/1.70.0/src/core/num/f32.rs.html#998
+                // <https://doc.rust-lang.org/1.70.0/src/core/num/f32.rs.html#998>
                 //
                 // `transmute()` here would be safe (`to_bits()` is doing this)
                 // although checking for NaN's and infinites are non-`const`...
@@ -96,7 +96,7 @@ macro_rules! impl_atomic_f {
             }
 
             #[inline]
-            /// Equivalent to https://doc.rust-lang.org/1.70.0/std/sync/atomic/struct.AtomicUsize.html#method.into_inner
+            /// Equivalent to <https://doc.rust-lang.org/1.70.0/std/sync/atomic/struct.AtomicUsize.html#method.into_inner>
             pub fn into_inner(self) -> $float {
                 $float::from_bits(self.0.into_inner())
             }
@@ -110,7 +110,7 @@ macro_rules! impl_atomic_f {
             #[inline]
             /// Store a float inside the atomic.
             ///
-            /// Equivalent to https://doc.rust-lang.org/1.70.0/std/sync/atomic/struct.AtomicUsize.html#method.store
+            /// Equivalent to <https://doc.rust-lang.org/1.70.0/std/sync/atomic/struct.AtomicUsize.html#method.store>
             pub fn store(&self, f: $float, ordering: Ordering) {
                 self.0.store(f.to_bits(), ordering);
             }
@@ -124,10 +124,10 @@ macro_rules! impl_atomic_f {
             #[inline]
             /// Load the internal float from the atomic.
             ///
-            /// Equivalent to https://doc.rust-lang.org/1.70.0/std/sync/atomic/struct.AtomicUsize.html#method.load
+            /// Equivalent to <https://doc.rust-lang.org/1.70.0/std/sync/atomic/struct.AtomicUsize.html#method.load>
             pub fn load(&self, ordering: Ordering) -> $float {
                 // FIXME: Update to const when available.
-                // https://doc.rust-lang.org/1.70.0/src/core/num/f32.rs.html#1088
+                // <https://doc.rust-lang.org/1.70.0/src/core/num/f32.rs.html#1088>
                 $float::from_bits(self.0.load(ordering))
             }
 
@@ -138,13 +138,13 @@ macro_rules! impl_atomic_f {
             }
 
             #[inline]
-            /// Equivalent to https://doc.rust-lang.org/1.70.0/std/sync/atomic/struct.AtomicUsize.html#method.swap
+            /// Equivalent to <https://doc.rust-lang.org/1.70.0/std/sync/atomic/struct.AtomicUsize.html#method.swap>
             pub fn swap(&self, val: $float, ordering: Ordering) -> $float {
                 $float::from_bits(self.0.swap($float::to_bits(val), ordering))
             }
 
             #[inline]
-            /// Equivalent to https://doc.rust-lang.org/1.70.0/std/sync/atomic/struct.AtomicUsize.html#method.compare_exchange
+            /// Equivalent to <https://doc.rust-lang.org/1.70.0/std/sync/atomic/struct.AtomicUsize.html#method.compare_exchange>
             pub fn compare_exchange(
                 &self,
                 current: $float,
@@ -162,7 +162,7 @@ macro_rules! impl_atomic_f {
             }
 
             #[inline]
-            /// Equivalent to https://doc.rust-lang.org/1.70.0/std/sync/atomic/struct.AtomicUsize.html#method.compare_exchange_weak
+            /// Equivalent to <https://doc.rust-lang.org/1.70.0/std/sync/atomic/struct.AtomicUsize.html#method.compare_exchange_weak>
             pub fn compare_exchange_weak(
                 &self,
                 current: $float,
@@ -211,14 +211,14 @@ macro_rules! impl_atomic_f {
                 // if the closure we pass it returns `None`.
                 // As seen below, we're passing a `Some`.
                 //
-                // https://doc.rust-lang.org/1.70.0/std/sync/atomic/struct.AtomicUsize.html#method.fetch_update
+                // <https://doc.rust-lang.org/1.70.0/std/sync/atomic/struct.AtomicUsize.html#method.fetch_update>
                 self.fetch_update(ordering, second_order, |f| Some(update(f)))
                     .unwrap()
             }
 
             #[inline]
             /// This function is implemented with [`Self::fetch_update`], and is not 100% equivalent to
-            /// https://doc.rust-lang.org/1.70.0/std/sync/atomic/struct.AtomicUsize.html#method.fetch_add.
+            /// <https://doc.rust-lang.org/1.70.0/std/sync/atomic/struct.AtomicUsize.html#method.fetch_add>.
             ///
             /// In particular, this method will not circumvent the [ABA Problem](https://en.wikipedia.org/wiki/ABA_problem).
             ///
@@ -229,7 +229,7 @@ macro_rules! impl_atomic_f {
 
             #[inline]
             /// This function is implemented with [`Self::fetch_update`], and is not 100% equivalent to
-            /// https://doc.rust-lang.org/1.70.0/std/sync/atomic/struct.AtomicUsize.html#method.fetch_sub.
+            /// <https://doc.rust-lang.org/1.70.0/std/sync/atomic/struct.AtomicUsize.html#method.fetch_sub>.
             ///
             /// In particular, this method will not circumvent the [ABA Problem](https://en.wikipedia.org/wiki/ABA_problem).
             ///
@@ -240,7 +240,7 @@ macro_rules! impl_atomic_f {
 
             #[inline]
             /// This function is implemented with [`Self::fetch_update`], and is not 100% equivalent to
-            /// https://doc.rust-lang.org/1.70.0/std/sync/atomic/struct.AtomicUsize.html#method.fetch_max.
+            /// <https://doc.rust-lang.org/1.70.0/std/sync/atomic/struct.AtomicUsize.html#method.fetch_max>.
             ///
             /// In particular, this method will not circumvent the [ABA Problem](https://en.wikipedia.org/wiki/ABA_problem).
             ///
@@ -251,7 +251,7 @@ macro_rules! impl_atomic_f {
 
             #[inline]
             /// This function is implemented with [`Self::fetch_update`], and is not 100% equivalent to
-            /// https://doc.rust-lang.org/1.70.0/std/sync/atomic/struct.AtomicUsize.html#method.fetch_min.
+            /// <https://doc.rust-lang.org/1.70.0/std/sync/atomic/struct.AtomicUsize.html#method.fetch_min>.
             ///
             /// In particular, this method will not circumvent the [ABA Problem](https://en.wikipedia.org/wiki/ABA_problem).
             ///
@@ -261,7 +261,7 @@ macro_rules! impl_atomic_f {
             }
 
             #[inline]
-            /// Equivalent to https://doc.rust-lang.org/1.70.0/std/sync/atomic/struct.AtomicUsize.html#method.fetch_update
+            /// Equivalent to <https://doc.rust-lang.org/1.70.0/std/sync/atomic/struct.AtomicUsize.html#method.fetch_update>
             pub fn fetch_update<F>(
                 &self,
                 set_order: Ordering,

--- a/helper/src/thread.rs
+++ b/helper/src/thread.rs
@@ -62,7 +62,7 @@ impl_thread_percent! {
 ///
 /// Sets the calling thread’s priority to the lowest platform-specific value possible.
 ///
-/// https://docs.rs/lpt
+/// Originally from <https://docs.rs/lpt>.
 ///
 /// # Windows
 /// Uses SetThreadPriority() with THREAD_PRIORITY_IDLE (-15).


### PR DESCRIPTION
Fixes a whole bunch of `cargo doc` errors caused from links not being within `<>`.

```
warning: this URL is not a hyperlink
   --> consensus/src/context.rs:186:9
    |
186 | ...// https://cuprate.github.io/monero-book/consensus_rules/transactions/unlock_time.html#getting-the-current-time
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use an automatic link instead: `<https://cuprate.github.io/monero-book/consensus_rules/transactions/unlock_time.html#getting-the-current-time>`
    |
    = note: bare URLs are not automatically turned into clickable links
    = note: `#[warn(rustdoc::bare_urls)]` on by default

```