### PR TITLE
database: use `Infallible` for non-dup secondary keys

### DIFF
--- a/database/src/key.rs
+++ b/database/src/key.rs
@@ -69,7 +69,12 @@ macro_rules! impl_key {
             impl Key for $t {
                 const DUPLICATE: bool = false;
                 type Primary = $t;
-                type Secondary = $t;
+                // This 0 variant enum is unconstructable,
+                // and "has the same role as the ! “never” type":
+                // <https://doc.rust-lang.org/std/convert/enum.Infallible.html#future-compatibility>.
+                //
+                // FIXME: Use the `!` type when stable.
+                type Secondary = std::convert::Infallible;
 
                 #[inline(always)]
                 fn primary(self) -> Self::Primary {


### PR DESCRIPTION
## Part 2
https://github.com/Cuprate/cuprate/pull/35 <- Previous Next -> https://github.com/Cuprate/cuprate/pull/61

Fixes https://github.com/Cuprate/cuprate/pull/35#discussion_r1488313416.