### PR TITLE
Add `PollSender`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -594,6 +594,7 @@ dependencies = [
  "libc",
  "rayon",
  "tokio",
+ "tokio-util",
  "windows",
 ]
 

--- a/helper/Cargo.toml
+++ b/helper/Cargo.toml
@@ -13,17 +13,19 @@ repository = "https://github.com/Cuprate/cuprate/tree/main/consensus"
 default   = ["std", "atomic", "asynch", "num", "time", "thread", "constants"]
 std       = []
 atomic    = ["dep:crossbeam"]
-asynch    = ["dep:futures", "dep:rayon"]
+asynch    = ["dep:futures", "dep:rayon", "dep:tokio", "dep:tokio-util"]
 constants = []
 num       = []
 time      = ["dep:chrono", "std"]
 thread    = ["std", "dep:target_os_lib"]
 
 [dependencies]
-crossbeam = { workspace = true, optional = true }
-chrono    = { workspace = true, optional = true, features = ["std", "clock"] }
-futures   = { workspace = true, optional = true, features = ["std"] }
-rayon     = { workspace = true, optional = true }
+crossbeam  = { workspace = true, optional = true }
+chrono     = { workspace = true, optional = true, features = ["std", "clock"] }
+futures    = { workspace = true, optional = true, features = ["std"] }
+tokio      = { workspace = true, optional = true, features = ["sync"] }
+tokio-util = { workspace = true, optional = true }
+rayon      = { workspace = true, optional = true }
 
 # This is kinda a stupid work around.
 # [thread] needs to activate one of these libs (windows|libc)
@@ -34,4 +36,4 @@ target_os_lib = { package = "windows", version = ">=0.51", features = ["Win32_Sy
 target_os_lib = { package = "libc", version = "0.2.151", optional = true }
 
 [dev-dependencies]
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["full"] }

--- a/helper/src/asynch.rs
+++ b/helper/src/asynch.rs
@@ -3,13 +3,17 @@
 //! `#[no_std]` compatible.
 
 //---------------------------------------------------------------------------------------------------- Use
+use alloc::sync::Arc;
 use core::{
     future::Future,
+    marker::PhantomData,
     pin::Pin,
     task::{Context, Poll},
 };
 
-use futures::{channel::oneshot, FutureExt};
+use futures::{channel::oneshot, ready, FutureExt};
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+use tokio_util::sync::PollSemaphore;
 
 //---------------------------------------------------------------------------------------------------- InfallibleOneshotReceiver
 /// A oneshot receiver channel that doesn't return an Error.
@@ -46,6 +50,105 @@ where
         let _ = tx.send(f());
     });
     rx.await.expect("The sender must not be dropped")
+}
+
+//---------------------------------------------------------------------------------------------------- Poll Sender
+mod hidden {
+
+    pub trait UnboundedChannel<T>: Clone {
+        fn send(&mut self, message: T);
+    }
+
+    impl<T> UnboundedChannel<T> for tokio::sync::mpsc::UnboundedSender<T> {
+        fn send(&mut self, message: T) {
+            tokio::sync::mpsc::UnboundedSender::send(self, message)
+                .expect("Unable to send message receivers dropped!")
+        }
+    }
+}
+
+/// Create a new channel with the sender wrapped in [`PollSender`].
+///
+/// ```rust
+/// use tokio::sync::mpsc;
+///
+/// use cuprate_helper::asynch::poll_sender_channel;
+///
+/// // although the inner channel is unbounded the `PollSender` will apply a limit.
+/// let (tx, rx) = poll_sender_channel::<_, _, u8>(mpsc::unbounded_channel, 3);
+///
+/// ```
+pub fn poll_sender_channel<C: hidden::UnboundedChannel<T>, R, T>(
+    new_inner: impl FnOnce() -> (C, R),
+    buffer: usize,
+) -> (PollSender<C, T>, R) {
+    let (inner_tx, inner_rx) = new_inner();
+
+    let semaphore = Arc::new(Semaphore::new(buffer));
+    let poll_semaphore = PollSemaphore::new(semaphore);
+
+    (
+        PollSender {
+            channel: inner_tx,
+            semaphore: poll_semaphore,
+            permit: None,
+            ty: PhantomData,
+        },
+        inner_rx,
+    )
+}
+
+/// The channel was closed.
+pub struct ChannelClosedError;
+
+/// This is a wrapper around a channel's send half, that adds a method [`PollSender::poll_ready`] to asses is the channel
+/// has enough capacity to receive a message.
+#[derive(Debug)]
+pub struct PollSender<C: hidden::UnboundedChannel<T>, T> {
+    channel: C,
+    semaphore: PollSemaphore,
+    permit: Option<OwnedSemaphorePermit>,
+
+    ty: PhantomData<T>,
+}
+
+impl<C: hidden::UnboundedChannel<T>, T> Clone for PollSender<C, T> {
+    fn clone(&self) -> Self {
+        Self {
+            channel: self.channel.clone(),
+            semaphore: self.semaphore.clone(),
+            permit: None,
+            ty: PhantomData,
+        }
+    }
+}
+
+impl<C: hidden::UnboundedChannel<T>, T> PollSender<C, T> {
+    /// Polls the channel to check if it has enough capacity to receive a message. When this function returns [`Poll::Ready`]
+    /// a spot in the channel has been reserved for a message, this means the channel will lose a spot until [`PollSender::send`]
+    /// is called or the [`PollSender`] is dropped.
+    pub fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), ChannelClosedError>> {
+        if self.permit.is_some() {
+            return Poll::Ready(Ok(()));
+        }
+
+        let Some(permit) = ready!(self.semaphore.poll_acquire(cx)) else {
+            return Poll::Ready(Err(ChannelClosedError));
+        };
+        self.permit = Some(permit);
+
+        Poll::Ready(Ok(()))
+    }
+
+    /// Sends a message on the channel, will panic if [`PollSender::poll_ready`] has not returned [`Poll::Ready`].
+    pub fn send(&mut self, mes: T) {
+        let _permit = self
+            .permit
+            .take()
+            .expect("`poll_ready must be called first!`");
+
+        self.channel.send(mes)
+    }
 }
 
 //---------------------------------------------------------------------------------------------------- Tests

--- a/helper/src/lib.rs
+++ b/helper/src/lib.rs
@@ -33,6 +33,8 @@
 )]
 #![cfg_attr(not(feature = "std"), no_std)]
 
+extern crate alloc;
+
 //---------------------------------------------------------------------------------------------------- Public API
 #[cfg(feature = "asynch")]
 pub mod asynch; // async collides


### PR DESCRIPTION
`PollSender` is a wrapper type to add poll functionality to _any_ channel. Although in MPSC contexts we can use tokio's [PollSender](https://docs.rs/tokio-util/latest/tokio_util/sync/struct.PollSender.html) when we need another channel like a MPMC we can't use this.

@hinto-janai  The DB will probably need to use this for the `poll_ready` impl on the reader/ writer handles.