### PR TITLE
database: add more `fn` to `trait DatabaseR{o,w}`

### DIFF
--- a/database/Cargo.toml
+++ b/database/Cargo.toml
@@ -9,8 +9,8 @@ repository  = "https://github.com/Cuprate/cuprate/tree/main/database"
 keywords    = ["cuprate", "database"]
 
 [features]
-default   = ["heed", "redb", "service"]
-# default   = ["redb", "service"]
+# default   = ["heed", "redb", "service"]
+default   = ["redb", "service"]
 heed    = ["dep:heed"]
 redb    = ["dep:redb"]
 service = ["dep:crossbeam", "dep:futures", "dep:tokio", "dep:tokio-util", "dep:tower", "dep:rayon"]

--- a/database/Cargo.toml
+++ b/database/Cargo.toml
@@ -9,8 +9,8 @@ repository  = "https://github.com/Cuprate/cuprate/tree/main/database"
 keywords    = ["cuprate", "database"]
 
 [features]
-# default   = ["heed", "redb", "service"]
-default   = ["redb", "service"]
+default   = ["heed", "redb", "service"]
+# default   = ["redb", "service"]
 heed    = ["dep:heed"]
 redb    = ["dep:redb"]
 service = ["dep:crossbeam", "dep:futures", "dep:tokio", "dep:tokio-util", "dep:tower", "dep:rayon"]

--- a/database/src/backend/heed/database.rs
+++ b/database/src/backend/heed/database.rs
@@ -69,11 +69,11 @@ fn get_range<'a, T: Table, Range>(
     db: &'a HeedDb<T::Key, T::Value>,
     tx_ro: &'a heed::RoTxn<'_>,
     range: Range,
-) -> Result<impl Iterator<Item = Result<(T::Key, T::Value), RuntimeError>> + 'a, RuntimeError>
+) -> Result<impl Iterator<Item = Result<T::Value, RuntimeError>> + 'a, RuntimeError>
 where
     Range: RangeBounds<T::Key> + 'a,
 {
-    Ok(db.range(tx_ro, &range)?.map(|res| Ok(res?)))
+    Ok(db.range(tx_ro, &range)?.map(|res| Ok(res?.1)))
 }
 
 /// Shared [`DatabaseRo::iter()`].
@@ -150,7 +150,7 @@ impl<T: Table> DatabaseRo<T> for HeedTableRo<'_, T> {
     fn get_range<'a, Range>(
         &'a self,
         range: Range,
-    ) -> Result<impl Iterator<Item = Result<(T::Key, T::Value), RuntimeError>> + 'a, RuntimeError>
+    ) -> Result<impl Iterator<Item = Result<T::Value, RuntimeError>> + 'a, RuntimeError>
     where
         Range: RangeBounds<T::Key> + 'a,
     {
@@ -211,7 +211,7 @@ impl<T: Table> DatabaseRo<T> for HeedTableRw<'_, '_, T> {
     fn get_range<'a, Range>(
         &'a self,
         range: Range,
-    ) -> Result<impl Iterator<Item = Result<(T::Key, T::Value), RuntimeError>> + 'a, RuntimeError>
+    ) -> Result<impl Iterator<Item = Result<T::Value, RuntimeError>> + 'a, RuntimeError>
     where
         Range: RangeBounds<T::Key> + 'a,
     {

--- a/database/src/backend/heed/database.rs
+++ b/database/src/backend/heed/database.rs
@@ -240,6 +240,7 @@ impl<T: Table> DatabaseRw<T> for HeedTableRw<'_, '_, T> {
     {
         let mut iter = self.db.iter_mut(self.tx_rw)?;
 
+        // FIXME: is this optimal?
         loop {
             let Some(result) = iter.next() else {
                 return Ok(());
@@ -254,6 +255,7 @@ impl<T: Table> DatabaseRw<T> for HeedTableRw<'_, '_, T> {
                 // We are deleting the value and never accessing
                 // it again so this should be safe.
                 unsafe {
+                    // TODO: is this actually safe?
                     iter.del_current()?;
                 }
             }

--- a/database/src/backend/heed/database.rs
+++ b/database/src/backend/heed/database.rs
@@ -274,11 +274,6 @@ impl<T: Table> DatabaseRw<T> for HeedTableRw<'_, '_, T> {
     }
 
     #[inline]
-    fn clear(&mut self) -> Result<(), RuntimeError> {
-        Ok(self.db.clear(self.tx_rw)?)
-    }
-
-    #[inline]
     fn pop_first(&mut self) -> Result<(T::Key, T::Value), RuntimeError> {
         // Get the first value first...
         let Some(first) = self.db.first(self.tx_rw)? else {

--- a/database/src/backend/heed/database.rs
+++ b/database/src/backend/heed/database.rs
@@ -53,7 +53,7 @@ pub(super) struct HeedTableRw<'env, 'tx, T: Table> {
 // call the functions since the database is held by value, so
 // just use these generic functions that both can call instead.
 
-/// Shared generic `get()` between `HeedTableR{o,w}`.
+/// Shared [`DatabaseRo::get()`].
 #[inline]
 fn get<T: Table>(
     db: &HeedDb<T::Key, T::Value>,
@@ -63,7 +63,7 @@ fn get<T: Table>(
     db.get(tx_ro, key)?.ok_or(RuntimeError::KeyNotFound)
 }
 
-/// Shared generic `get_range()` between `HeedTableR{o,w}`.
+/// Shared [`DatabaseRo::get_range()`].
 #[inline]
 fn get_range<'a, T: Table, Range>(
     db: &'a HeedDb<T::Key, T::Value>,
@@ -74,6 +74,53 @@ where
     Range: RangeBounds<T::Key> + 'a,
 {
     Ok(db.range(tx_ro, &range)?.map(|res| Ok(res?.1)))
+}
+
+/// Shared [`DatabaseRo::iter()`].
+#[inline]
+#[allow(clippy::unnecessary_wraps)]
+fn iter<'a, T: Table>(
+    db: &'a HeedDb<T::Key, T::Value>,
+    tx_ro: &'a heed::RoTxn<'_>,
+) -> Result<impl Iterator<Item = Result<T::Value, RuntimeError>> + 'a, RuntimeError> {
+    let iter: std::vec::Drain<'_, Result<T::Value, RuntimeError>> = todo!();
+    Ok(iter)
+}
+
+/// Shared [`DatabaseRo::len()`].
+#[inline]
+fn len<T: Table>(
+    db: &HeedDb<T::Key, T::Value>,
+    tx_ro: &heed::RoTxn<'_>,
+) -> Result<u64, RuntimeError> {
+    todo!()
+}
+
+/// Shared [`DatabaseRo::first()`].
+#[inline]
+fn first<T: Table>(
+    db: &HeedDb<T::Key, T::Value>,
+    tx_ro: &heed::RoTxn<'_>,
+) -> Result<T::Value, RuntimeError> {
+    todo!()
+}
+
+/// Shared [`DatabaseRo::last()`].
+#[inline]
+fn last<T: Table>(
+    db: &HeedDb<T::Key, T::Value>,
+    tx_ro: &heed::RoTxn<'_>,
+) -> Result<T::Value, RuntimeError> {
+    todo!()
+}
+
+/// Shared [`DatabaseRo::is_empty()`].
+#[inline]
+fn is_empty<T: Table>(
+    db: &HeedDb<T::Key, T::Value>,
+    tx_ro: &heed::RoTxn<'_>,
+) -> Result<bool, RuntimeError> {
+    todo!()
 }
 
 //---------------------------------------------------------------------------------------------------- DatabaseRo Impl

--- a/database/src/backend/heed/database.rs
+++ b/database/src/backend/heed/database.rs
@@ -86,6 +86,26 @@ fn iter<'a, T: Table>(
     Ok(db.iter(tx_ro)?.map(|res| Ok(res?)))
 }
 
+/// Shared [`DatabaseRo::keys()`].
+#[inline]
+#[allow(clippy::unnecessary_wraps)]
+fn keys<'a, T: Table>(
+    db: &'a HeedDb<T::Key, T::Value>,
+    tx_ro: &'a heed::RoTxn<'_>,
+) -> Result<impl Iterator<Item = Result<T::Key, RuntimeError>> + 'a, RuntimeError> {
+    Ok(db.iter(tx_ro)?.map(|res| Ok(res?.0)))
+}
+
+/// Shared [`DatabaseRo::values()`].
+#[inline]
+#[allow(clippy::unnecessary_wraps)]
+fn values<'a, T: Table>(
+    db: &'a HeedDb<T::Key, T::Value>,
+    tx_ro: &'a heed::RoTxn<'_>,
+) -> Result<impl Iterator<Item = Result<T::Value, RuntimeError>> + 'a, RuntimeError> {
+    Ok(db.iter(tx_ro)?.map(|res| Ok(res?.1)))
+}
+
 /// Shared [`DatabaseRo::len()`].
 #[inline]
 fn len<T: Table>(
@@ -149,6 +169,20 @@ impl<T: Table> DatabaseRo<T> for HeedTableRo<'_, T> {
     }
 
     #[inline]
+    fn keys(
+        &self,
+    ) -> Result<impl Iterator<Item = Result<T::Key, RuntimeError>> + '_, RuntimeError> {
+        keys::<T>(&self.db, self.tx_ro)
+    }
+
+    #[inline]
+    fn values(
+        &self,
+    ) -> Result<impl Iterator<Item = Result<T::Value, RuntimeError>> + '_, RuntimeError> {
+        values::<T>(&self.db, self.tx_ro)
+    }
+
+    #[inline]
     fn len(&self) -> Result<u64, RuntimeError> {
         len::<T>(&self.db, self.tx_ro)
     }
@@ -193,6 +227,20 @@ impl<T: Table> DatabaseRo<T> for HeedTableRw<'_, '_, T> {
     ) -> Result<impl Iterator<Item = Result<(T::Key, T::Value), RuntimeError>> + '_, RuntimeError>
     {
         iter::<T>(&self.db, self.tx_rw)
+    }
+
+    #[inline]
+    fn keys(
+        &self,
+    ) -> Result<impl Iterator<Item = Result<T::Key, RuntimeError>> + '_, RuntimeError> {
+        keys::<T>(&self.db, self.tx_rw)
+    }
+
+    #[inline]
+    fn values(
+        &self,
+    ) -> Result<impl Iterator<Item = Result<T::Value, RuntimeError>> + '_, RuntimeError> {
+        values::<T>(&self.db, self.tx_rw)
     }
 
     #[inline]
@@ -255,13 +303,59 @@ impl<T: Table> DatabaseRw<T> for HeedTableRw<'_, '_, T> {
                 // We are deleting the value and never accessing
                 // it again so this should be safe.
                 unsafe {
-                    // TODO: is this actually safe?
                     iter.del_current()?;
                 }
             }
         }
 
         Ok(())
+    }
+
+    #[inline]
+    fn pop_first(&mut self) -> Result<(T::Key, T::Value), RuntimeError> {
+        // Get the first value first...
+        let Some(first) = self.db.first(self.tx_rw)? else {
+            return Err(RuntimeError::KeyNotFound);
+        };
+
+        // ...then remove it.
+        //
+        // We use an iterator because we want to semantically
+        // remove the _first_ and only the first `(key, value)`.
+        // `delete()` removes all keys including duplicates which
+        // is slightly different behavior.
+        let mut iter = self.db.iter_mut(self.tx_rw)?;
+
+        // SAFETY:
+        // It is undefined behavior to keep a reference of
+        // a value from this database while modifying it.
+        // We are deleting the value and never accessing
+        // the iterator again so this should be safe.
+        unsafe {
+            iter.del_current()?;
+        }
+
+        Ok(first)
+    }
+
+    #[inline]
+    fn pop_last(&mut self) -> Result<(T::Key, T::Value), RuntimeError> {
+        let Some(first) = self.db.last(self.tx_rw)? else {
+            return Err(RuntimeError::KeyNotFound);
+        };
+
+        let mut iter = self.db.rev_iter_mut(self.tx_rw)?;
+
+        // SAFETY:
+        // It is undefined behavior to keep a reference of
+        // a value from this database while modifying it.
+        // We are deleting the value and never accessing
+        // the iterator again so this should be safe.
+        unsafe {
+            iter.del_current()?;
+        }
+
+        Ok(first)
     }
 }
 

--- a/database/src/backend/heed/database.rs
+++ b/database/src/backend/heed/database.rs
@@ -69,11 +69,11 @@ fn get_range<'a, T: Table, Range>(
     db: &'a HeedDb<T::Key, T::Value>,
     tx_ro: &'a heed::RoTxn<'_>,
     range: Range,
-) -> Result<impl Iterator<Item = Result<T::Value, RuntimeError>> + 'a, RuntimeError>
+) -> Result<impl Iterator<Item = Result<(T::Key, T::Value), RuntimeError>> + 'a, RuntimeError>
 where
     Range: RangeBounds<T::Key> + 'a,
 {
-    Ok(db.range(tx_ro, &range)?.map(|res| Ok(res?.1)))
+    Ok(db.range(tx_ro, &range)?.map(|res| Ok(res?)))
 }
 
 /// Shared [`DatabaseRo::iter()`].
@@ -133,7 +133,7 @@ impl<T: Table> DatabaseRo<T> for HeedTableRo<'_, T> {
     fn get_range<'a, Range>(
         &'a self,
         range: Range,
-    ) -> Result<impl Iterator<Item = Result<T::Value, RuntimeError>> + 'a, RuntimeError>
+    ) -> Result<impl Iterator<Item = Result<(T::Key, T::Value), RuntimeError>> + 'a, RuntimeError>
     where
         Range: RangeBounds<T::Key> + 'a,
     {
@@ -182,7 +182,7 @@ impl<T: Table> DatabaseRo<T> for HeedTableRw<'_, '_, T> {
     fn get_range<'a, Range>(
         &'a self,
         range: Range,
-    ) -> Result<impl Iterator<Item = Result<T::Value, RuntimeError>> + 'a, RuntimeError>
+    ) -> Result<impl Iterator<Item = Result<(T::Key, T::Value), RuntimeError>> + 'a, RuntimeError>
     where
         Range: RangeBounds<T::Key> + 'a,
     {

--- a/database/src/backend/heed/database.rs
+++ b/database/src/backend/heed/database.rs
@@ -78,7 +78,6 @@ where
 
 /// Shared [`DatabaseRo::iter()`].
 #[inline]
-#[allow(clippy::unnecessary_wraps)]
 fn iter<'a, T: Table>(
     db: &'a HeedDb<T::Key, T::Value>,
     tx_ro: &'a heed::RoTxn<'_>,
@@ -88,7 +87,6 @@ fn iter<'a, T: Table>(
 
 /// Shared [`DatabaseRo::keys()`].
 #[inline]
-#[allow(clippy::unnecessary_wraps)]
 fn keys<'a, T: Table>(
     db: &'a HeedDb<T::Key, T::Value>,
     tx_ro: &'a heed::RoTxn<'_>,
@@ -98,7 +96,6 @@ fn keys<'a, T: Table>(
 
 /// Shared [`DatabaseRo::values()`].
 #[inline]
-#[allow(clippy::unnecessary_wraps)]
 fn values<'a, T: Table>(
     db: &'a HeedDb<T::Key, T::Value>,
     tx_ro: &'a heed::RoTxn<'_>,

--- a/database/src/backend/heed/database.rs
+++ b/database/src/backend/heed/database.rs
@@ -82,9 +82,8 @@ where
 fn iter<'a, T: Table>(
     db: &'a HeedDb<T::Key, T::Value>,
     tx_ro: &'a heed::RoTxn<'_>,
-) -> Result<impl Iterator<Item = Result<T::Value, RuntimeError>> + 'a, RuntimeError> {
-    let iter: std::vec::Drain<'_, Result<T::Value, RuntimeError>> = todo!();
-    Ok(iter)
+) -> Result<impl Iterator<Item = Result<(T::Key, T::Value), RuntimeError>> + 'a, RuntimeError> {
+    Ok(db.iter(tx_ro)?.map(|res| Ok(res?)))
 }
 
 /// Shared [`DatabaseRo::len()`].
@@ -144,8 +143,10 @@ impl<T: Table> DatabaseRo<T> for HeedTableRo<'_, T> {
     #[inline]
     fn iter(
         &self,
-    ) -> Result<impl Iterator<Item = Result<T::Value, RuntimeError>> + '_, RuntimeError> {
-        let iter: std::vec::Drain<'_, Result<T::Value, RuntimeError>> = todo!();
+    ) -> Result<impl Iterator<Item = Result<(T::Key, T::Value), RuntimeError>> + '_, RuntimeError>
+    {
+        #[allow(clippy::type_complexity)]
+        let iter: std::vec::Drain<'_, Result<(T::Key, T::Value), RuntimeError>> = todo!();
         Ok(iter)
     }
 
@@ -191,8 +192,10 @@ impl<T: Table> DatabaseRo<T> for HeedTableRw<'_, '_, T> {
     #[inline]
     fn iter(
         &self,
-    ) -> Result<impl Iterator<Item = Result<T::Value, RuntimeError>> + '_, RuntimeError> {
-        let iter: std::vec::Drain<'_, Result<T::Value, RuntimeError>> = todo!();
+    ) -> Result<impl Iterator<Item = Result<(T::Key, T::Value), RuntimeError>> + '_, RuntimeError>
+    {
+        #[allow(clippy::type_complexity)]
+        let iter: std::vec::Drain<'_, Result<(T::Key, T::Value), RuntimeError>> = todo!();
         Ok(iter)
     }
 

--- a/database/src/backend/heed/database.rs
+++ b/database/src/backend/heed/database.rs
@@ -248,7 +248,7 @@ impl<T: Table> DatabaseRw<T> for HeedTableRw<'_, '_, T> {
 
             let (key, value) = result?;
 
-            if predicate(key, value) {
+            if !predicate(key, value) {
                 // SAFETY:
                 // It is undefined behavior to keep a reference of
                 // a value from this database while modifying it.

--- a/database/src/backend/heed/database.rs
+++ b/database/src/backend/heed/database.rs
@@ -42,7 +42,7 @@ pub(super) struct HeedTableRo<'tx, T: Table> {
 ///
 /// Matches `redb::Table` (read & write).
 pub(super) struct HeedTableRw<'env, 'tx, T: Table> {
-    /// TODO
+    /// An already opened database table.
     pub(super) db: HeedDb<T::Key, T::Value>,
     /// The associated read/write transaction that opened this table.
     pub(super) tx_rw: &'tx mut heed::RwTxn<'env>,
@@ -92,7 +92,7 @@ fn len<T: Table>(
     db: &HeedDb<T::Key, T::Value>,
     tx_ro: &heed::RoTxn<'_>,
 ) -> Result<u64, RuntimeError> {
-    todo!()
+    Ok(db.len(tx_ro)?)
 }
 
 /// Shared [`DatabaseRo::first()`].
@@ -100,7 +100,7 @@ fn len<T: Table>(
 fn first<T: Table>(
     db: &HeedDb<T::Key, T::Value>,
     tx_ro: &heed::RoTxn<'_>,
-) -> Result<T::Value, RuntimeError> {
+) -> Result<(T::Key, T::Value), RuntimeError> {
     todo!()
 }
 
@@ -109,7 +109,7 @@ fn first<T: Table>(
 fn last<T: Table>(
     db: &HeedDb<T::Key, T::Value>,
     tx_ro: &heed::RoTxn<'_>,
-) -> Result<T::Value, RuntimeError> {
+) -> Result<(T::Key, T::Value), RuntimeError> {
     todo!()
 }
 
@@ -156,12 +156,12 @@ impl<T: Table> DatabaseRo<T> for HeedTableRo<'_, T> {
     }
 
     #[inline]
-    fn first(&self) -> Result<T::Value, RuntimeError> {
+    fn first(&self) -> Result<(T::Key, T::Value), RuntimeError> {
         todo!()
     }
 
     #[inline]
-    fn last(&self) -> Result<T::Value, RuntimeError> {
+    fn last(&self) -> Result<(T::Key, T::Value), RuntimeError> {
         todo!()
     }
 
@@ -205,12 +205,12 @@ impl<T: Table> DatabaseRo<T> for HeedTableRw<'_, '_, T> {
     }
 
     #[inline]
-    fn first(&self) -> Result<T::Value, RuntimeError> {
+    fn first(&self) -> Result<(T::Key, T::Value), RuntimeError> {
         todo!()
     }
 
     #[inline]
-    fn last(&self) -> Result<T::Value, RuntimeError> {
+    fn last(&self) -> Result<(T::Key, T::Value), RuntimeError> {
         todo!()
     }
 

--- a/database/src/backend/heed/database.rs
+++ b/database/src/backend/heed/database.rs
@@ -93,6 +93,34 @@ impl<T: Table> DatabaseRo<T> for HeedTableRo<'_, T> {
     {
         get_range::<T, Range>(&self.db, self.tx_ro, range)
     }
+
+    #[inline]
+    fn iter(
+        &self,
+    ) -> Result<impl Iterator<Item = Result<T::Value, RuntimeError>> + '_, RuntimeError> {
+        let iter: std::vec::Drain<'_, Result<T::Value, RuntimeError>> = todo!();
+        Ok(iter)
+    }
+
+    #[inline]
+    fn len(&self) -> Result<u64, RuntimeError> {
+        todo!()
+    }
+
+    #[inline]
+    fn first(&self) -> Result<T::Value, RuntimeError> {
+        todo!()
+    }
+
+    #[inline]
+    fn last(&self) -> Result<T::Value, RuntimeError> {
+        todo!()
+    }
+
+    #[inline]
+    fn is_empty(&self) -> Result<bool, RuntimeError> {
+        todo!()
+    }
 }
 
 //---------------------------------------------------------------------------------------------------- DatabaseRw Impl
@@ -112,6 +140,34 @@ impl<T: Table> DatabaseRo<T> for HeedTableRw<'_, '_, T> {
     {
         get_range::<T, Range>(&self.db, self.tx_rw, range)
     }
+
+    #[inline]
+    fn iter(
+        &self,
+    ) -> Result<impl Iterator<Item = Result<T::Value, RuntimeError>> + '_, RuntimeError> {
+        let iter: std::vec::Drain<'_, Result<T::Value, RuntimeError>> = todo!();
+        Ok(iter)
+    }
+
+    #[inline]
+    fn len(&self) -> Result<u64, RuntimeError> {
+        todo!()
+    }
+
+    #[inline]
+    fn first(&self) -> Result<T::Value, RuntimeError> {
+        todo!()
+    }
+
+    #[inline]
+    fn last(&self) -> Result<T::Value, RuntimeError> {
+        todo!()
+    }
+
+    #[inline]
+    fn is_empty(&self) -> Result<bool, RuntimeError> {
+        todo!()
+    }
 }
 
 impl<T: Table> DatabaseRw<T> for HeedTableRw<'_, '_, T> {
@@ -124,6 +180,19 @@ impl<T: Table> DatabaseRw<T> for HeedTableRw<'_, '_, T> {
     fn delete(&mut self, key: &T::Key) -> Result<(), RuntimeError> {
         self.db.delete(self.tx_rw, key)?;
         Ok(())
+    }
+
+    #[inline]
+    fn clear(&mut self) -> Result<(), RuntimeError> {
+        todo!()
+    }
+
+    #[inline]
+    fn retain<P>(&mut self) -> Result<(), RuntimeError>
+    where
+        P: FnMut(T::Key, T::Value) -> bool,
+    {
+        todo!()
     }
 }
 

--- a/database/src/backend/heed/env.rs
+++ b/database/src/backend/heed/env.rs
@@ -304,6 +304,17 @@ where
             tx_rw,
         })
     }
+
+    #[inline]
+    fn clear_db<T: Table>(&self, tx_rw: &mut heed::RwTxn<'env>) -> Result<(), RuntimeError> {
+        // Open the table first...
+        let db: HeedDb<T::Key, T::Value> = self
+            .open_database(tx_rw, Some(T::NAME))?
+            .expect(PANIC_MSG_MISSING_TABLE);
+
+        // ...then clear it.
+        Ok(db.clear(tx_rw)?)
+    }
 }
 
 //---------------------------------------------------------------------------------------------------- Tests

--- a/database/src/backend/redb/database.rs
+++ b/database/src/backend/redb/database.rs
@@ -38,13 +38,13 @@ fn get<T: Table + 'static>(
 fn get_range<'a, T: Table, Range>(
     db: &'a impl redb::ReadableTable<StorableRedb<T::Key>, StorableRedb<T::Value>>,
     range: Range,
-) -> Result<impl Iterator<Item = Result<(T::Key, T::Value), RuntimeError>> + 'a, RuntimeError>
+) -> Result<impl Iterator<Item = Result<T::Value, RuntimeError>> + 'a, RuntimeError>
 where
     Range: RangeBounds<T::Key> + 'a,
 {
     Ok(db.range(range)?.map(|result| {
-        let (key, value) = result?;
-        Ok((key.value(), value.value()))
+        let (_key, value) = result?;
+        Ok(value.value())
     }))
 }
 
@@ -126,7 +126,7 @@ impl<T: Table + 'static> DatabaseRo<T> for RedbTableRo<T::Key, T::Value> {
     fn get_range<'a, Range>(
         &'a self,
         range: Range,
-    ) -> Result<impl Iterator<Item = Result<(T::Key, T::Value), RuntimeError>> + 'a, RuntimeError>
+    ) -> Result<impl Iterator<Item = Result<T::Value, RuntimeError>> + 'a, RuntimeError>
     where
         Range: RangeBounds<T::Key> + 'a,
     {
@@ -187,7 +187,7 @@ impl<T: Table + 'static> DatabaseRo<T> for RedbTableRw<'_, T::Key, T::Value> {
     fn get_range<'a, Range>(
         &'a self,
         range: Range,
-    ) -> Result<impl Iterator<Item = Result<(T::Key, T::Value), RuntimeError>> + 'a, RuntimeError>
+    ) -> Result<impl Iterator<Item = Result<T::Value, RuntimeError>> + 'a, RuntimeError>
     where
         Range: RangeBounds<T::Key> + 'a,
     {

--- a/database/src/backend/redb/database.rs
+++ b/database/src/backend/redb/database.rs
@@ -253,20 +253,6 @@ impl<T: Table + 'static> DatabaseRw<T> for RedbTableRw<'_, T::Key, T::Value> {
     }
 
     #[inline]
-    fn clear(&mut self) -> Result<(), RuntimeError> {
-        // FIXME:
-        // Deleting and re-creating the table outright
-        // would be faster, although we don't have direct
-        // access to the write transaction, which implements
-        // this functionality in `redb::WriteTransaction::delete_table`.
-
-        // Pop the last `(key, value)` until there are none.
-        while redb::Table::pop_last(self)?.is_some() {}
-
-        Ok(())
-    }
-
-    #[inline]
     fn pop_first(&mut self) -> Result<(T::Key, T::Value), RuntimeError> {
         let (key, value) = redb::Table::pop_first(self)?.ok_or(RuntimeError::KeyNotFound)?;
         Ok((key.value(), value.value()))

--- a/database/src/backend/redb/database.rs
+++ b/database/src/backend/redb/database.rs
@@ -24,7 +24,7 @@ use crate::{
 // call the functions since the database is held by value, so
 // just use these generic functions that both can call instead.
 
-/// Shared generic `get()` between `RedbTableR{o,w}`.
+/// Shared [`DatabaseRo::get()`].
 #[inline]
 fn get<T: Table + 'static>(
     db: &impl redb::ReadableTable<StorableRedb<T::Key>, StorableRedb<T::Value>>,
@@ -33,19 +33,65 @@ fn get<T: Table + 'static>(
     Ok(db.get(key)?.ok_or(RuntimeError::KeyNotFound)?.value())
 }
 
-/// Shared generic `get_range()` between `RedbTableR{o,w}`.
+/// Shared [`DatabaseRo::get_range()`].
 #[inline]
 fn get_range<'a, T: Table, Range>(
     db: &'a impl redb::ReadableTable<StorableRedb<T::Key>, StorableRedb<T::Value>>,
     range: Range,
-) -> Result<impl Iterator<Item = Result<T::Value, RuntimeError>> + 'a, RuntimeError>
+) -> Result<impl Iterator<Item = Result<(T::Key, T::Value), RuntimeError>> + 'a, RuntimeError>
 where
     Range: RangeBounds<T::Key> + 'a,
 {
     Ok(db.range(range)?.map(|result| {
-        let (_key, value_guard) = result?;
-        Ok(value_guard.value())
+        let (key, value) = result?;
+        Ok((key.value(), value.value()))
     }))
+}
+
+/// Shared [`DatabaseRo::iter()`].
+#[inline]
+#[allow(clippy::unnecessary_wraps)]
+fn iter<T: Table>(
+    db: &impl redb::ReadableTable<StorableRedb<T::Key>, StorableRedb<T::Value>>,
+) -> Result<impl Iterator<Item = Result<(T::Key, T::Value), RuntimeError>> + '_, RuntimeError> {
+    Ok(db.iter()?.map(|result| {
+        let (key, value) = result?;
+        Ok((key.value(), value.value()))
+    }))
+}
+
+/// Shared [`DatabaseRo::len()`].
+#[inline]
+fn len<T: Table>(
+    db: &impl redb::ReadableTable<StorableRedb<T::Key>, StorableRedb<T::Value>>,
+) -> Result<u64, RuntimeError> {
+    Ok(db.len()?)
+}
+
+/// Shared [`DatabaseRo::first()`].
+#[inline]
+fn first<T: Table>(
+    db: &impl redb::ReadableTable<StorableRedb<T::Key>, StorableRedb<T::Value>>,
+) -> Result<(T::Key, T::Value), RuntimeError> {
+    let (key, value) = db.first()?.ok_or(RuntimeError::KeyNotFound)?;
+    Ok((key.value(), value.value()))
+}
+
+/// Shared [`DatabaseRo::last()`].
+#[inline]
+fn last<T: Table>(
+    db: &impl redb::ReadableTable<StorableRedb<T::Key>, StorableRedb<T::Value>>,
+) -> Result<(T::Key, T::Value), RuntimeError> {
+    let (key, value) = db.last()?.ok_or(RuntimeError::KeyNotFound)?;
+    Ok((key.value(), value.value()))
+}
+
+/// Shared [`DatabaseRo::is_empty()`].
+#[inline]
+fn is_empty<T: Table>(
+    db: &impl redb::ReadableTable<StorableRedb<T::Key>, StorableRedb<T::Value>>,
+) -> Result<bool, RuntimeError> {
+    Ok(db.is_empty()?)
 }
 
 //---------------------------------------------------------------------------------------------------- DatabaseRo
@@ -59,11 +105,39 @@ impl<T: Table + 'static> DatabaseRo<T> for RedbTableRo<T::Key, T::Value> {
     fn get_range<'a, Range>(
         &'a self,
         range: Range,
-    ) -> Result<impl Iterator<Item = Result<T::Value, RuntimeError>> + 'a, RuntimeError>
+    ) -> Result<impl Iterator<Item = Result<(T::Key, T::Value), RuntimeError>> + 'a, RuntimeError>
     where
         Range: RangeBounds<T::Key> + 'a,
     {
         get_range::<T, Range>(self, range)
+    }
+
+    #[inline]
+    fn iter(
+        &self,
+    ) -> Result<impl Iterator<Item = Result<(T::Key, T::Value), RuntimeError>> + '_, RuntimeError>
+    {
+        iter::<T>(self)
+    }
+
+    #[inline]
+    fn len(&self) -> Result<u64, RuntimeError> {
+        len::<T>(self)
+    }
+
+    #[inline]
+    fn first(&self) -> Result<(T::Key, T::Value), RuntimeError> {
+        first::<T>(self)
+    }
+
+    #[inline]
+    fn last(&self) -> Result<(T::Key, T::Value), RuntimeError> {
+        last::<T>(self)
+    }
+
+    #[inline]
+    fn is_empty(&self) -> Result<bool, RuntimeError> {
+        is_empty::<T>(self)
     }
 }
 
@@ -78,27 +152,77 @@ impl<T: Table + 'static> DatabaseRo<T> for RedbTableRw<'_, T::Key, T::Value> {
     fn get_range<'a, Range>(
         &'a self,
         range: Range,
-    ) -> Result<impl Iterator<Item = Result<T::Value, RuntimeError>> + 'a, RuntimeError>
+    ) -> Result<impl Iterator<Item = Result<(T::Key, T::Value), RuntimeError>> + 'a, RuntimeError>
     where
         Range: RangeBounds<T::Key> + 'a,
     {
         get_range::<T, Range>(self, range)
     }
+
+    #[inline]
+    fn iter(
+        &self,
+    ) -> Result<impl Iterator<Item = Result<(T::Key, T::Value), RuntimeError>> + '_, RuntimeError>
+    {
+        iter::<T>(self)
+    }
+
+    #[inline]
+    fn len(&self) -> Result<u64, RuntimeError> {
+        len::<T>(self)
+    }
+
+    #[inline]
+    fn first(&self) -> Result<(T::Key, T::Value), RuntimeError> {
+        first::<T>(self)
+    }
+
+    #[inline]
+    fn last(&self) -> Result<(T::Key, T::Value), RuntimeError> {
+        last::<T>(self)
+    }
+
+    #[inline]
+    fn is_empty(&self) -> Result<bool, RuntimeError> {
+        is_empty::<T>(self)
+    }
 }
 
 impl<T: Table + 'static> DatabaseRw<T> for RedbTableRw<'_, T::Key, T::Value> {
-    // `redb` returns the value after `insert()/remove()`
-    // we end with Ok(()) instead.
+    // `redb` returns the value after function calls so we end with Ok(()) instead.
 
     #[inline]
     fn put(&mut self, key: &T::Key, value: &T::Value) -> Result<(), RuntimeError> {
-        self.insert(key, value)?;
+        redb::Table::insert(self, key, value)?;
         Ok(())
     }
 
     #[inline]
     fn delete(&mut self, key: &T::Key) -> Result<(), RuntimeError> {
-        self.remove(key)?;
+        redb::Table::remove(self, key)?;
+        Ok(())
+    }
+
+    #[inline]
+    fn clear(&mut self) -> Result<(), RuntimeError> {
+        // FIXME:
+        // Deleting and re-creating the table outright
+        // would be faster, although we don't have direct
+        // access to the write transaction, which implements
+        // this functionality in `redb::WriteTransaction::delete_table`.
+
+        // Pop the last `(key, value)` until there are none.
+        while self.pop_last()?.is_some() {}
+
+        Ok(())
+    }
+
+    #[inline]
+    fn retain<P>(&mut self, predicate: P) -> Result<(), RuntimeError>
+    where
+        P: FnMut(T::Key, T::Value) -> bool,
+    {
+        redb::Table::retain(self, predicate)?;
         Ok(())
     }
 }

--- a/database/src/backend/redb/database.rs
+++ b/database/src/backend/redb/database.rs
@@ -50,7 +50,6 @@ where
 
 /// Shared [`DatabaseRo::iter()`].
 #[inline]
-#[allow(clippy::unnecessary_wraps)]
 fn iter<T: Table>(
     db: &impl redb::ReadableTable<StorableRedb<T::Key>, StorableRedb<T::Value>>,
 ) -> Result<impl Iterator<Item = Result<(T::Key, T::Value), RuntimeError>> + '_, RuntimeError> {
@@ -62,7 +61,6 @@ fn iter<T: Table>(
 
 /// Shared [`DatabaseRo::iter()`].
 #[inline]
-#[allow(clippy::unnecessary_wraps)]
 fn keys<T: Table>(
     db: &impl redb::ReadableTable<StorableRedb<T::Key>, StorableRedb<T::Value>>,
 ) -> Result<impl Iterator<Item = Result<T::Key, RuntimeError>> + '_, RuntimeError> {
@@ -74,7 +72,6 @@ fn keys<T: Table>(
 
 /// Shared [`DatabaseRo::values()`].
 #[inline]
-#[allow(clippy::unnecessary_wraps)]
 fn values<T: Table>(
     db: &impl redb::ReadableTable<StorableRedb<T::Key>, StorableRedb<T::Value>>,
 ) -> Result<impl Iterator<Item = Result<T::Value, RuntimeError>> + '_, RuntimeError> {

--- a/database/src/backend/redb/database.rs
+++ b/database/src/backend/redb/database.rs
@@ -267,15 +267,6 @@ impl<T: Table + 'static> DatabaseRw<T> for RedbTableRw<'_, T::Key, T::Value> {
     }
 
     #[inline]
-    fn retain<P>(&mut self, predicate: P) -> Result<(), RuntimeError>
-    where
-        P: FnMut(T::Key, T::Value) -> bool,
-    {
-        redb::Table::retain(self, predicate)?;
-        Ok(())
-    }
-
-    #[inline]
     fn pop_first(&mut self) -> Result<(T::Key, T::Value), RuntimeError> {
         let (key, value) = redb::Table::pop_first(self)?.ok_or(RuntimeError::KeyNotFound)?;
         Ok((key.value(), value.value()))

--- a/database/src/backend/redb/env.rs
+++ b/database/src/backend/redb/env.rs
@@ -202,6 +202,20 @@ where
         // <https://docs.rs/redb/latest/redb/struct.WriteTransaction.html#method.open_table>
         Ok(tx_rw.open_table(table)?)
     }
+
+    #[inline]
+    fn clear_db(&self, tx_rw: &mut redb::WriteTransaction) -> Result<(), RuntimeError> {
+        let table: redb::TableDefinition<
+            'static,
+            StorableRedb<<T as Table>::Key>,
+            StorableRedb<<T as Table>::Value>,
+        > = redb::TableDefinition::new(<T as Table>::NAME);
+
+        // TODO: this may panic if readers have this table open?
+        redb::WriteTransaction::delete_table(table)?;
+
+        Ok(())
+    }
 }
 
 //---------------------------------------------------------------------------------------------------- Tests

--- a/database/src/backend/redb/env.rs
+++ b/database/src/backend/redb/env.rs
@@ -222,6 +222,9 @@ where
         //
         // Reader-open tables do not affect this, if they're open the below is still OK.
         redb::WriteTransaction::delete_table(tx_rw, table)?;
+        // Re-create the table.
+        // `redb` creates tables if they don't exist, so this should never panic.
+        redb::WriteTransaction::open_table(tx_rw, table)?;
 
         Ok(())
     }

--- a/database/src/backend/redb/env.rs
+++ b/database/src/backend/redb/env.rs
@@ -204,7 +204,7 @@ where
     }
 
     #[inline]
-    fn clear_db(&self, tx_rw: &mut redb::WriteTransaction) -> Result<(), RuntimeError> {
+    fn clear_db<T: Table>(&self, tx_rw: &mut redb::WriteTransaction) -> Result<(), RuntimeError> {
         let table: redb::TableDefinition<
             'static,
             StorableRedb<<T as Table>::Key>,
@@ -221,7 +221,7 @@ where
         // 3. So it's not being used to open a table since that needs `&tx_rw`
         //
         // Reader-open tables do not affect this, if they're open the below is still OK.
-        redb::WriteTransaction::delete_table(table)?;
+        redb::WriteTransaction::delete_table(tx_rw, table)?;
 
         Ok(())
     }

--- a/database/src/backend/tests.rs
+++ b/database/src/backend/tests.rs
@@ -210,6 +210,7 @@ fn db_read_write() {
 
     // Assert the first/last `(key, value)`s are there.
     {
+        assert!(table.contains(&KEY).unwrap());
         let get: Output = table.get(&KEY).unwrap();
         assert_same(get);
 
@@ -262,6 +263,7 @@ fn db_read_write() {
     {
         table.delete(&KEY).unwrap();
         let value = table.get(&KEY);
+        assert!(!table.contains(&KEY).unwrap());
         assert!(matches!(value, Err(RuntimeError::KeyNotFound)));
         // Assert the other `(key, value)` pairs are still there.
         let mut key = KEY;
@@ -290,6 +292,7 @@ fn db_read_write() {
             key.amount += n;
             let value = table.get(&key);
             assert!(matches!(value, Err(RuntimeError::KeyNotFound)));
+            assert!(!table.contains(&key).unwrap());
         }
     }
 }
@@ -335,6 +338,7 @@ macro_rules! test_tables {
                 assert_eq(&value);
             }
 
+            assert!(table.contains(&KEY).unwrap());
             assert_eq!(table.len().unwrap(), 1);
 
             // Assert `get_range()` works.
@@ -351,6 +355,7 @@ macro_rules! test_tables {
                 table.delete(&KEY).unwrap();
                 let value = table.get(&KEY);
                 assert!(matches!(value, Err(RuntimeError::KeyNotFound)));
+                assert!(!table.contains(&KEY).unwrap());
                 assert_eq!(table.len().unwrap(), 0);
             }
 
@@ -371,6 +376,7 @@ macro_rules! test_tables {
                 table.clear().unwrap();
                 let value = table.get(&KEY);
                 assert!(matches!(value, Err(RuntimeError::KeyNotFound)));
+                assert!(!table.contains(&KEY).unwrap());
                 assert_eq!(table.len().unwrap(), 0);
             }
         }

--- a/database/src/backend/tests.rs
+++ b/database/src/backend/tests.rs
@@ -209,7 +209,7 @@ fn db_read_write() {
         let range = table.get_range(..).unwrap();
         let mut i = 0;
         for result in range {
-            let value: Output = result.unwrap();
+            let (key, value): (PreRctOutputId, Output) = result.unwrap();
             assert_same(value);
 
             i += 1;
@@ -228,7 +228,7 @@ fn db_read_write() {
     // Assert each returned value from the iterator is owned.
     {
         let mut iter = table.get_range(range.clone()).unwrap();
-        let value: Output = iter.next().unwrap().unwrap(); // 1. take value out
+        let (key, value): (PreRctOutputId, Output) = iter.next().unwrap().unwrap(); // 1. take value out
         drop(iter); // 2. drop the `impl Iterator + 'a`
         assert_same(value); // 3. assert even without the iterator, the value is alive
     }
@@ -237,7 +237,7 @@ fn db_read_write() {
     {
         let mut iter = table.get_range(range).unwrap();
         for _ in 0..100 {
-            let value: Output = iter.next().unwrap().unwrap();
+            let (key, value): (PreRctOutputId, Output) = iter.next().unwrap().unwrap();
             assert_same(value);
         }
     }
@@ -298,7 +298,7 @@ macro_rules! test_tables {
                 let range = KEY..;
                 assert_eq!(1, table.get_range(range.clone()).unwrap().count());
                 let mut iter = table.get_range(range).unwrap();
-                let value = iter.next().unwrap().unwrap();
+                let (_key, value) = iter.next().unwrap().unwrap();
                 assert_eq(&value);
             }
 

--- a/database/src/backend/tests.rs
+++ b/database/src/backend/tests.rs
@@ -272,17 +272,6 @@ fn db_read_write() {
         assert_same(value);
     }
 
-    // Assert `retain()` works.
-    // This should leave only the last `(key, value)` pair.
-    {
-        let mut key = KEY;
-        key.amount += N - 1; // we used inclusive `0..N`
-        table.retain(|k, v| k == key).unwrap();
-        assert_eq!(table.len().unwrap(), 1);
-        let value = table.get(&key).unwrap();
-        assert_same(value);
-    }
-
     // Assert `clear()` works.
     {
         table.clear().unwrap();
@@ -360,16 +349,6 @@ macro_rules! test_tables {
             }
 
             table.put(&KEY, &value).unwrap();
-
-            // Assert `retain()` works.
-            // This retains the key we put in
-            // (it does nothing).
-            {
-                table.retain(|k, v| k == KEY).unwrap();
-                assert_eq!(table.len().unwrap(), 1);
-                let value = table.get(&KEY).unwrap();
-                assert_eq(&value);
-            }
 
             // Assert `clear()` works.
             {

--- a/database/src/database.rs
+++ b/database/src/database.rs
@@ -47,19 +47,35 @@ pub trait DatabaseRo<T: Table> {
         Range: RangeBounds<T::Key> + 'a;
 
     /// TODO
-    fn iter<'a>(
-        &'a self,
-    ) -> Result<impl Iterator<Item = Result<T::Value, RuntimeError>> + 'a, RuntimeError>;
+    ///
+    /// # Errors
+    /// TODO
+    #[allow(clippy::iter_not_returning_iterator)] // this returns `impl Iterator` in a `Result`
+    fn iter(
+        &self,
+    ) -> Result<impl Iterator<Item = Result<T::Value, RuntimeError>> + '_, RuntimeError>;
 
+    /// TODO
+    ///
+    /// # Errors
     /// TODO
     fn len(&self) -> Result<u64, RuntimeError>;
 
     /// TODO
+    ///
+    /// # Errors
+    /// TODO
     fn first(&self) -> Result<T::Value, RuntimeError>;
 
     /// TODO
+    ///
+    /// # Errors
+    /// TODO
     fn last(&self) -> Result<T::Value, RuntimeError>;
 
+    /// TODO
+    ///
+    /// # Errors
     /// TODO
     fn is_empty(&self) -> Result<bool, RuntimeError>;
 }
@@ -84,8 +100,14 @@ pub trait DatabaseRw<T: Table>: DatabaseRo<T> {
     fn delete(&mut self, key: &T::Key) -> Result<(), RuntimeError>;
 
     /// TODO
+    ///
+    /// # Errors
+    /// TODO
     fn clear(&mut self) -> Result<(), RuntimeError>;
 
+    /// TODO
+    ///
+    /// # Errors
     /// TODO
     fn retain<P>(&mut self) -> Result<(), RuntimeError>
     where

--- a/database/src/database.rs
+++ b/database/src/database.rs
@@ -29,7 +29,14 @@ pub trait DatabaseRo<T: Table> {
     /// It will return other [`RuntimeError`]'s on things like IO errors as well.
     fn get(&self, key: &T::Key) -> Result<T::Value, RuntimeError>;
 
-    /// Get an iterator of values corresponding to a range of keys.
+    /// Get an iterator of `(key, value)`s corresponding to a range of keys.
+    ///
+    /// For example:
+    /// ```rust,ignore
+    /// // This will return all 100 tuples of `(key, value)` where
+    /// // `key` is `0..100` and `value` is the corresponding value.
+    /// self.get_range(0..100);
+    /// ```
     ///
     /// Although the returned iterator itself is tied to the lifetime
     /// of `&'a self`, the returned values from the iterator are _owned_.
@@ -39,10 +46,11 @@ pub trait DatabaseRo<T: Table> {
     /// if a particular key in the `range` does not exist,
     /// [`RuntimeError::KeyNotFound`] wrapped in [`Err`] will be returned
     /// from the iterator.
+    #[allow(clippy::iter_not_returning_iterator)]
     fn get_range<'a, Range>(
         &'a self,
         range: Range,
-    ) -> Result<impl Iterator<Item = Result<T::Value, RuntimeError>> + 'a, RuntimeError>
+    ) -> Result<impl Iterator<Item = Result<(T::Key, T::Value), RuntimeError>> + 'a, RuntimeError>
     where
         Range: RangeBounds<T::Key> + 'a;
 
@@ -50,7 +58,7 @@ pub trait DatabaseRo<T: Table> {
     ///
     /// # Errors
     /// TODO
-    #[allow(clippy::iter_not_returning_iterator)] // this returns `impl Iterator` in a `Result`
+    #[allow(clippy::iter_not_returning_iterator)]
     fn iter(
         &self,
     ) -> Result<impl Iterator<Item = Result<(T::Key, T::Value), RuntimeError>> + '_, RuntimeError>;

--- a/database/src/database.rs
+++ b/database/src/database.rs
@@ -67,7 +67,6 @@ pub trait DatabaseRo<T: Table> {
     ///
     /// # Errors
     /// TODO
-    #[allow(clippy::iter_not_returning_iterator)]
     fn keys(&self)
         -> Result<impl Iterator<Item = Result<T::Key, RuntimeError>> + '_, RuntimeError>;
 
@@ -75,10 +74,21 @@ pub trait DatabaseRo<T: Table> {
     ///
     /// # Errors
     /// TODO
-    #[allow(clippy::iter_not_returning_iterator)]
     fn values(
         &self,
     ) -> Result<impl Iterator<Item = Result<T::Value, RuntimeError>> + '_, RuntimeError>;
+
+    /// TODO
+    ///
+    /// # Errors
+    /// TODO
+    fn contains(&self, key: &T::Key) -> Result<bool, RuntimeError> {
+        match self.get(key) {
+            Ok(_) => Ok(true),
+            Err(RuntimeError::KeyNotFound) => Ok(false),
+            Err(e) => Err(e),
+        }
+    }
 
     /// TODO
     ///

--- a/database/src/database.rs
+++ b/database/src/database.rs
@@ -33,8 +33,8 @@ pub trait DatabaseRo<T: Table> {
     ///
     /// For example:
     /// ```rust,ignore
-    /// // This will return all 100 tuples of `(key, value)` where
-    /// // `key` is `0..100` and `value` is the corresponding value.
+    /// // This will return all 100 values corresponding
+    /// // to the keys `{0, 1, 2, ..., 100}`.
     /// self.get_range(0..100);
     /// ```
     ///

--- a/database/src/database.rs
+++ b/database/src/database.rs
@@ -138,12 +138,6 @@ pub trait DatabaseRw<T: Table>: DatabaseRo<T> {
     ///
     /// # Errors
     /// TODO
-    fn clear(&mut self) -> Result<(), RuntimeError>;
-
-    /// TODO
-    ///
-    /// # Errors
-    /// TODO
     fn pop_first(&mut self) -> Result<(T::Key, T::Value), RuntimeError>;
 
     /// TODO

--- a/database/src/database.rs
+++ b/database/src/database.rs
@@ -115,6 +115,9 @@ pub trait DatabaseRw<T: Table>: DatabaseRo<T> {
 
     /// TODO
     ///
+    /// - `true == keep`
+    /// - `false == remove`
+    ///
     /// # Errors
     /// TODO
     fn retain<P>(&mut self, predicate: P) -> Result<(), RuntimeError>

--- a/database/src/database.rs
+++ b/database/src/database.rs
@@ -117,7 +117,7 @@ pub trait DatabaseRw<T: Table>: DatabaseRo<T> {
     ///
     /// # Errors
     /// TODO
-    fn retain<P>(&mut self) -> Result<(), RuntimeError>
+    fn retain<P>(&mut self, predicate: P) -> Result<(), RuntimeError>
     where
         P: FnMut(T::Key, T::Value) -> bool;
 }

--- a/database/src/database.rs
+++ b/database/src/database.rs
@@ -67,6 +67,23 @@ pub trait DatabaseRo<T: Table> {
     ///
     /// # Errors
     /// TODO
+    #[allow(clippy::iter_not_returning_iterator)]
+    fn keys(&self)
+        -> Result<impl Iterator<Item = Result<T::Key, RuntimeError>> + '_, RuntimeError>;
+
+    /// TODO
+    ///
+    /// # Errors
+    /// TODO
+    #[allow(clippy::iter_not_returning_iterator)]
+    fn values(
+        &self,
+    ) -> Result<impl Iterator<Item = Result<T::Value, RuntimeError>> + '_, RuntimeError>;
+
+    /// TODO
+    ///
+    /// # Errors
+    /// TODO
     fn len(&self) -> Result<u64, RuntimeError>;
 
     /// TODO
@@ -120,7 +137,21 @@ pub trait DatabaseRw<T: Table>: DatabaseRo<T> {
     ///
     /// # Errors
     /// TODO
+    ///
+    /// TODO: Document early return on error.
     fn retain<P>(&mut self, predicate: P) -> Result<(), RuntimeError>
     where
         P: FnMut(T::Key, T::Value) -> bool;
+
+    /// TODO
+    ///
+    /// # Errors
+    /// TODO
+    fn pop_first(&mut self) -> Result<(T::Key, T::Value), RuntimeError>;
+
+    /// TODO
+    ///
+    /// # Errors
+    /// TODO
+    fn pop_last(&mut self) -> Result<(T::Key, T::Value), RuntimeError>;
 }

--- a/database/src/database.rs
+++ b/database/src/database.rs
@@ -73,13 +73,13 @@ pub trait DatabaseRo<T: Table> {
     ///
     /// # Errors
     /// TODO
-    fn first(&self) -> Result<T::Value, RuntimeError>;
+    fn first(&self) -> Result<(T::Key, T::Value), RuntimeError>;
 
     /// TODO
     ///
     /// # Errors
     /// TODO
-    fn last(&self) -> Result<T::Value, RuntimeError>;
+    fn last(&self) -> Result<(T::Key, T::Value), RuntimeError>;
 
     /// TODO
     ///

--- a/database/src/database.rs
+++ b/database/src/database.rs
@@ -29,7 +29,7 @@ pub trait DatabaseRo<T: Table> {
     /// It will return other [`RuntimeError`]'s on things like IO errors as well.
     fn get(&self, key: &T::Key) -> Result<T::Value, RuntimeError>;
 
-    /// Get an iterator of `(key, value)`s corresponding to a range of keys.
+    /// Get an iterator of value's corresponding to a range of keys.
     ///
     /// For example:
     /// ```rust,ignore
@@ -50,7 +50,7 @@ pub trait DatabaseRo<T: Table> {
     fn get_range<'a, Range>(
         &'a self,
         range: Range,
-    ) -> Result<impl Iterator<Item = Result<(T::Key, T::Value), RuntimeError>> + 'a, RuntimeError>
+    ) -> Result<impl Iterator<Item = Result<T::Value, RuntimeError>> + 'a, RuntimeError>
     where
         Range: RangeBounds<T::Key> + 'a;
 

--- a/database/src/database.rs
+++ b/database/src/database.rs
@@ -45,6 +45,23 @@ pub trait DatabaseRo<T: Table> {
     ) -> Result<impl Iterator<Item = Result<T::Value, RuntimeError>> + 'a, RuntimeError>
     where
         Range: RangeBounds<T::Key> + 'a;
+
+    /// TODO
+    fn iter<'a>(
+        &'a self,
+    ) -> Result<impl Iterator<Item = Result<T::Value, RuntimeError>> + 'a, RuntimeError>;
+
+    /// TODO
+    fn len(&self) -> Result<u64, RuntimeError>;
+
+    /// TODO
+    fn first(&self) -> Result<T::Value, RuntimeError>;
+
+    /// TODO
+    fn last(&self) -> Result<T::Value, RuntimeError>;
+
+    /// TODO
+    fn is_empty(&self) -> Result<bool, RuntimeError>;
 }
 
 //---------------------------------------------------------------------------------------------------- DatabaseRw
@@ -65,4 +82,12 @@ pub trait DatabaseRw<T: Table>: DatabaseRo<T> {
     /// # Errors
     /// This will return [`RuntimeError::KeyNotFound`] wrapped in [`Err`] if `key` does not exist.
     fn delete(&mut self, key: &T::Key) -> Result<(), RuntimeError>;
+
+    /// TODO
+    fn clear(&mut self) -> Result<(), RuntimeError>;
+
+    /// TODO
+    fn retain<P>(&mut self) -> Result<(), RuntimeError>
+    where
+        P: FnMut(T::Key, T::Value) -> bool;
 }

--- a/database/src/database.rs
+++ b/database/src/database.rs
@@ -53,7 +53,7 @@ pub trait DatabaseRo<T: Table> {
     #[allow(clippy::iter_not_returning_iterator)] // this returns `impl Iterator` in a `Result`
     fn iter(
         &self,
-    ) -> Result<impl Iterator<Item = Result<T::Value, RuntimeError>> + '_, RuntimeError>;
+    ) -> Result<impl Iterator<Item = Result<(T::Key, T::Value), RuntimeError>> + '_, RuntimeError>;
 
     /// TODO
     ///

--- a/database/src/database.rs
+++ b/database/src/database.rs
@@ -142,19 +142,6 @@ pub trait DatabaseRw<T: Table>: DatabaseRo<T> {
 
     /// TODO
     ///
-    /// - `true == keep`
-    /// - `false == remove`
-    ///
-    /// # Errors
-    /// TODO
-    ///
-    /// TODO: Document early return on error.
-    fn retain<P>(&mut self, predicate: P) -> Result<(), RuntimeError>
-    where
-        P: FnMut(T::Key, T::Value) -> bool;
-
-    /// TODO
-    ///
     /// # Errors
     /// TODO
     fn pop_first(&mut self) -> Result<(T::Key, T::Value), RuntimeError>;

--- a/database/src/env.rs
+++ b/database/src/env.rs
@@ -196,6 +196,8 @@ where
     /// ```
     ///
     /// # Errors
+    /// This function errors upon internal database/IO errors.
+    ///
     /// As [`Table`] is `Sealed`, and all tables are created
     /// upon [`Env::open`], this function will never error because
     /// a table doesn't exist.
@@ -210,8 +212,26 @@ where
     /// passed as a generic to this function.
     ///
     /// # Errors
+    /// This function errors upon internal database/IO errors.
+    ///
     /// As [`Table`] is `Sealed`, and all tables are created
     /// upon [`Env::open`], this function will never error because
     /// a table doesn't exist.
     fn open_db_rw<T: Table>(&self, tx_rw: &mut Rw) -> Result<impl DatabaseRw<T>, RuntimeError>;
+
+    /// Clear all `(key, value)`'s from a database table.
+    ///
+    /// This will delete all key and values in the passed
+    /// `T: Table`, but the table itself will continue to exist.
+    ///
+    /// Note that this operation is tied to `tx_rw`, as such this
+    /// function's effects can be aborted using [`TxRw::abort`].
+    ///
+    /// # Errors
+    /// This function errors upon internal database/IO errors.
+    ///
+    /// As [`Table`] is `Sealed`, and all tables are created
+    /// upon [`Env::open`], this function will never error because
+    /// a table doesn't exist.
+    fn clear_db<T: Table>(&self, tx_rw: &mut Rw) -> Result<(), RuntimeError>;
 }


### PR DESCRIPTION
## Part 16
https://github.com/Cuprate/cuprate/pull/95 <- Previous Next -> https://github.com/Cuprate/cuprate/pull/97

This add various functions to `trait DatabaseR{o,w}` that are supported by both backends `heed` & `redb` - more specifically, APIs that are `BTreeMap`-like are added since both are based on B-trees.

All methods were added to the current tests in `src/backend/tests.rs`.

```rust
// Read methods.

fn iter(
    &self,
) -> Result<impl Iterator<Item = Result<(T::Key, T::Value), RuntimeError>> + '_, RuntimeError>;

fn keys(
    &self,
) -> Result<impl Iterator<Item = Result<T::Key, RuntimeError>> + '_, RuntimeError>;  

fn values(
    &self,
) -> Result<impl Iterator<Item = Result<T::Value, RuntimeError>> + '_, RuntimeError>; 

fn contains(&self, key: &T::Key) -> Result<bool, RuntimeError>;

fn len(&self) -> Result<u64, RuntimeError>; 

fn first(&self) -> Result<(T::Key, T::Value), RuntimeError>; 

fn last(&self) -> Result<(T::Key, T::Value), RuntimeError>; 

fn is_empty(&self) -> Result<bool, RuntimeError>; 
```
```rust
// Write methods.

fn pop_first(&mut self) -> Result<(T::Key, T::Value), RuntimeError>;

fn pop_last(&mut self) -> Result<(T::Key, T::Value), RuntimeError>;
```
```rust
// trait EnvInner

fn clear_db<T: Table>(&self, tx_rw: &mut impl TxRw<'_>) -> Result<(), RuntimeError>;
```