### PR TITLE
database: add `redb-memory` backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,7 @@ jobs:
       run: |
         cargo test --all-features --workspace
         cargo test --package cuprate-database --no-default-features --features redb --features service
+        cargo test --package cuprate-database --no-default-features --features redb-memory --features service
 
     # TODO: upload binaries with `actions/upload-artifact@v3`
     - name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,6 @@ jobs:
       run: |
         cargo test --all-features --workspace
         cargo test --package cuprate-database --no-default-features --features redb --features service
-        cargo test --package cuprate-database --no-default-features --features redb-memory --features service
 
     # TODO: upload binaries with `actions/upload-artifact@v3`
     - name: Build

--- a/database/Cargo.toml
+++ b/database/Cargo.toml
@@ -9,11 +9,13 @@ repository  = "https://github.com/Cuprate/cuprate/tree/main/database"
 keywords    = ["cuprate", "database"]
 
 [features]
-default   = ["heed", "redb", "service"]
+# default   = ["heed", "redb", "service"]
 # default   = ["redb", "service"]
-heed    = ["dep:heed"]
-redb    = ["dep:redb"]
-service = ["dep:crossbeam", "dep:futures", "dep:tokio", "dep:tokio-util", "dep:tower", "dep:rayon"]
+default   = ["redb-memory", "service"]
+heed       = ["dep:heed"]
+redb       = ["dep:redb"]
+redb-memory = ["redb"]
+service     = ["dep:crossbeam", "dep:futures", "dep:tokio", "dep:tokio-util", "dep:tower", "dep:rayon"]
 
 [dependencies]
 bytemuck = { version = "1.14.3", features = ["must_cast", "derive", "min_const_generics", "extern_crate_alloc"] }

--- a/database/README.md
+++ b/database/README.md
@@ -11,6 +11,7 @@ Cuprate's database implementation.
 1. [Backends](#backends)
     - [`heed`](#heed)
     - [`redb`](#redb)
+    - [`redb-memory`](#redb-memory)
     - [`sanakirja`](#sanakirja)
     - [`MDBX`](#mdbx)
 1. [Layers](#layers)
@@ -164,6 +165,11 @@ The upstream versions from [`crates.io`](https://crates.io/crates/redb) are used
 | `data.redb` | Main data file
 
 TODO: document DB on remote filesystem (does redb allow this?)
+
+## `redb-memory`
+This backend is 100% the same as `redb`, although, it uses `redb::backend::InMemoryBackend` which is a key-value store that completely resides in memory instead of a file.
+
+All other details about this should be the same as the normal `redb` backend.
 
 ## `sanakirja`
 [`sanakirja`](https://docs.rs/sanakirja) was a candidate as a backend, however there were problems with maximum value sizes.


### PR DESCRIPTION
## Part 17
https://github.com/Cuprate/cuprate/pull/96 <- Previous

- Adds a new `redb-memory` feature flag that uses the same code from `src/backend/redb`, except that it uses `redb::backend::InMemoryBackend` instead which resides completely in memory instead of on disk