### PR TITLE
types: add `hf_vote: u8` to `VerifiedBlockInformation`

### DIFF
--- a/types/src/types.rs
+++ b/types/src/types.rs
@@ -63,6 +63,9 @@ pub struct VerifiedBlockInformation {
     /// TODO
     pub block: Block,
     /// TODO
+    /// This is a `cuprate_consensus::HardFork`.
+    pub hf_vote: u8,
+    /// TODO
     pub txs: Vec<Arc<TransactionVerificationData>>,
     /// TODO
     pub block_hash: [u8; 32],


### PR DESCRIPTION
Missed in https://github.com/Cuprate/cuprate/pull/94.