### PR TITLE
database: make `open_db_rw()` take `&TxRw`

### DIFF
--- a/database/src/backend/heed/database.rs
+++ b/database/src/backend/heed/database.rs
@@ -3,7 +3,7 @@
 //---------------------------------------------------------------------------------------------------- Import
 use std::{
     borrow::{Borrow, Cow},
-    cell::{Ref, RefCell},
+    cell::RefCell,
     fmt::Debug,
     ops::RangeBounds,
     sync::RwLockReadGuard,
@@ -219,7 +219,6 @@ impl<T: Table> DatabaseRw<T> for HeedTableRw<'_, '_, T> {
         // remove the _first_ and only the first `(key, value)`.
         // `delete()` removes all keys including duplicates which
         // is slightly different behavior.
-        // SAFETY: we have `&mut self`.
         let mut iter = self.db.iter_mut(tx_rw)?;
 
         // SAFETY:

--- a/database/src/backend/heed/env.rs
+++ b/database/src/backend/heed/env.rs
@@ -17,7 +17,7 @@ use crate::{
         types::HeedDb,
     },
     config::{Config, SyncMode},
-    database::{DatabaseRo, DatabaseRw},
+    database::{DatabaseIter, DatabaseRo, DatabaseRw},
     env::{Env, EnvInner},
     error::{InitError, RuntimeError},
     resize::ResizeAlgorithm,
@@ -286,7 +286,7 @@ where
     fn open_db_ro<T: Table>(
         &self,
         tx_ro: &heed::RoTxn<'env>,
-    ) -> Result<impl DatabaseRo<T>, RuntimeError> {
+    ) -> Result<impl DatabaseRo<T> + DatabaseIter<T>, RuntimeError> {
         // Open up a read-only database using our table's const metadata.
         Ok(HeedTableRo {
             db: self

--- a/database/src/backend/heed/env.rs
+++ b/database/src/backend/heed/env.rs
@@ -106,7 +106,7 @@ impl Env for ConcreteEnv {
     /// Our mutable accesses are safe and will not panic as:
     /// - Write transactions are `!Sync`
     /// - A table operation does not hold a reference to the inner cell
-    ///   once the call is over, unless the return also holds a lifetime
+    ///   once the call is over
     /// - The function to manipulate the table takes the same type
     ///   of reference that the `RefCell` gets for that function
     ///

--- a/database/src/backend/heed/transaction.rs
+++ b/database/src/backend/heed/transaction.rs
@@ -11,25 +11,25 @@ use crate::{
 //---------------------------------------------------------------------------------------------------- TxRo
 impl TxRo<'_> for heed::RoTxn<'_> {
     fn commit(self) -> Result<(), RuntimeError> {
-        Ok(self.commit()?)
+        Ok(heed::RoTxn::commit(self)?)
     }
 }
 
 //---------------------------------------------------------------------------------------------------- TxRw
 impl TxRo<'_> for UnsafeCell<heed::RwTxn<'_>> {
     fn commit(self) -> Result<(), RuntimeError> {
-        Ok(self.into_inner().commit()?)
+        TxRw::commit(self)
     }
 }
 
 impl TxRw<'_> for UnsafeCell<heed::RwTxn<'_>> {
     fn commit(self) -> Result<(), RuntimeError> {
-        Ok(self.into_inner().commit()?)
+        Ok(heed::RwTxn::commit(self.into_inner())?)
     }
 
     /// This function is infallible.
     fn abort(self) -> Result<(), RuntimeError> {
-        self.into_inner().abort();
+        heed::RwTxn::abort(self.into_inner());
         Ok(())
     }
 }

--- a/database/src/backend/heed/transaction.rs
+++ b/database/src/backend/heed/transaction.rs
@@ -1,6 +1,6 @@
 //! Implementation of `trait TxRo/TxRw` for `heed`.
 
-use std::{cell::UnsafeCell, ops::Deref, sync::RwLockReadGuard};
+use std::{cell::RefCell, ops::Deref, sync::RwLockReadGuard};
 
 //---------------------------------------------------------------------------------------------------- Import
 use crate::{
@@ -16,13 +16,13 @@ impl TxRo<'_> for heed::RoTxn<'_> {
 }
 
 //---------------------------------------------------------------------------------------------------- TxRw
-impl TxRo<'_> for UnsafeCell<heed::RwTxn<'_>> {
+impl TxRo<'_> for RefCell<heed::RwTxn<'_>> {
     fn commit(self) -> Result<(), RuntimeError> {
         TxRw::commit(self)
     }
 }
 
-impl TxRw<'_> for UnsafeCell<heed::RwTxn<'_>> {
+impl TxRw<'_> for RefCell<heed::RwTxn<'_>> {
     fn commit(self) -> Result<(), RuntimeError> {
         Ok(heed::RwTxn::commit(self.into_inner())?)
     }

--- a/database/src/backend/heed/transaction.rs
+++ b/database/src/backend/heed/transaction.rs
@@ -1,6 +1,6 @@
 //! Implementation of `trait TxRo/TxRw` for `heed`.
 
-use std::{ops::Deref, sync::RwLockReadGuard};
+use std::{cell::UnsafeCell, ops::Deref, sync::RwLockReadGuard};
 
 //---------------------------------------------------------------------------------------------------- Import
 use crate::{
@@ -16,20 +16,20 @@ impl TxRo<'_> for heed::RoTxn<'_> {
 }
 
 //---------------------------------------------------------------------------------------------------- TxRw
-impl TxRo<'_> for heed::RwTxn<'_> {
+impl TxRo<'_> for UnsafeCell<heed::RwTxn<'_>> {
     fn commit(self) -> Result<(), RuntimeError> {
-        Ok(self.commit()?)
+        Ok(self.into_inner().commit()?)
     }
 }
 
-impl TxRw<'_> for heed::RwTxn<'_> {
+impl TxRw<'_> for UnsafeCell<heed::RwTxn<'_>> {
     fn commit(self) -> Result<(), RuntimeError> {
-        Ok(self.commit()?)
+        Ok(self.into_inner().commit()?)
     }
 
     /// This function is infallible.
     fn abort(self) -> Result<(), RuntimeError> {
-        self.abort();
+        self.into_inner().abort();
         Ok(())
     }
 }

--- a/database/src/backend/redb/env.rs
+++ b/database/src/backend/redb/env.rs
@@ -9,7 +9,7 @@ use crate::{
         types::{RedbTableRo, RedbTableRw},
     },
     config::{Config, SyncMode},
-    database::{DatabaseRo, DatabaseRw},
+    database::{DatabaseIter, DatabaseRo, DatabaseRw},
     env::{Env, EnvInner},
     error::{InitError, RuntimeError},
     table::Table,
@@ -186,7 +186,7 @@ where
     fn open_db_ro<T: Table>(
         &self,
         tx_ro: &redb::ReadTransaction,
-    ) -> Result<impl DatabaseRo<T>, RuntimeError> {
+    ) -> Result<impl DatabaseRo<T> + DatabaseIter<T>, RuntimeError> {
         // Open up a read-only database using our `T: Table`'s const metadata.
         let table: redb::TableDefinition<'static, StorableRedb<T::Key>, StorableRedb<T::Value>> =
             redb::TableDefinition::new(T::NAME);
@@ -198,7 +198,7 @@ where
     #[inline]
     fn open_db_rw<T: Table>(
         &self,
-        tx_rw: &mut redb::WriteTransaction,
+        tx_rw: &redb::WriteTransaction,
     ) -> Result<impl DatabaseRw<T>, RuntimeError> {
         // Open up a read/write database using our `T: Table`'s const metadata.
         let table: redb::TableDefinition<'static, StorableRedb<T::Key>, StorableRedb<T::Value>> =

--- a/database/src/backend/tests.rs
+++ b/database/src/backend/tests.rs
@@ -24,7 +24,7 @@ use std::borrow::{Borrow, Cow};
 
 use crate::{
     config::{Config, SyncMode},
-    database::{DatabaseRo, DatabaseRw, DatabaseIter},
+    database::{DatabaseIter, DatabaseRo, DatabaseRw},
     env::{Env, EnvInner},
     error::{InitError, RuntimeError},
     resize::ResizeAlgorithm,
@@ -166,6 +166,7 @@ fn non_manual_resize_2() {
 
 /// Test all `DatabaseR{o,w}` operations.
 #[test]
+#[allow(clippy::too_many_lines)]
 fn db_read_write() {
     let (env, _tempdir) = tmp_concrete_env();
     let env_inner = env.env_inner();
@@ -221,12 +222,17 @@ fn db_read_write() {
         assert_same(last);
     }
 
+    // Commit transactions, create new ones.
+    drop(table);
+    TxRw::commit(tx_rw).unwrap();
+    let tx_ro = env_inner.tx_ro().unwrap();
+    let table_ro = env_inner.open_db_ro::<Outputs>(&tx_ro).unwrap();
+    let tx_rw = env_inner.tx_rw().unwrap();
+    let mut table = env_inner.open_db_rw::<Outputs>(&tx_rw).unwrap();
+
     // Assert the whole range is there.
     {
-        let table = env_inner
-            .open_db_ro::<Outputs>(&env_inner.tx_ro().unwrap())
-            .unwrap();
-        let range = table.get_range(..).unwrap();
+        let range = table_ro.get_range(..).unwrap();
         let mut i = 0;
         for result in range {
             let value: Output = result.unwrap();
@@ -243,11 +249,14 @@ fn db_read_write() {
     let range = KEY..key;
 
     // Assert count is correct.
-    assert_eq!(N as usize, table.get_range(range.clone()).unwrap().count());
+    assert_eq!(
+        N as usize,
+        table_ro.get_range(range.clone()).unwrap().count()
+    );
 
     // Assert each returned value from the iterator is owned.
     {
-        let mut iter = table.get_range(range.clone()).unwrap();
+        let mut iter = table_ro.get_range(range.clone()).unwrap();
         let value: Output = iter.next().unwrap().unwrap(); // 1. take value out
         drop(iter); // 2. drop the `impl Iterator + 'a`
         assert_same(value); // 3. assert even without the iterator, the value is alive
@@ -255,7 +264,7 @@ fn db_read_write() {
 
     // Assert each value is the same.
     {
-        let mut iter = table.get_range(range).unwrap();
+        let mut iter = table_ro.get_range(range).unwrap();
         for _ in 0..N {
             let value: Output = iter.next().unwrap().unwrap();
             assert_same(value);
@@ -277,14 +286,10 @@ fn db_read_write() {
 
     drop(table);
     TxRw::commit(tx_rw).unwrap();
-    let mut tx_rw = env_inner.tx_rw().unwrap();
 
     // Assert `clear_db()` works.
     {
-        // Make sure this works even if readers have the table open.
-        let tx_ro = env_inner.tx_ro().unwrap();
-        let reader_table = env_inner.open_db_ro::<Outputs>(&tx_ro).unwrap();
-
+        let mut tx_rw = env_inner.tx_rw().unwrap();
         env_inner.clear_db::<Outputs>(&mut tx_rw).unwrap();
         let table = env_inner.open_db_rw::<Outputs>(&tx_rw).unwrap();
         assert!(table.is_empty().unwrap());
@@ -297,7 +302,7 @@ fn db_read_write() {
         }
 
         // Reader still sees old value.
-        assert!(!reader_table.is_empty().unwrap());
+        assert!(!table_ro.is_empty().unwrap());
 
         // Writer sees updated value (nothing).
         assert!(table.is_empty().unwrap());
@@ -348,11 +353,19 @@ macro_rules! test_tables {
             assert!(table.contains(&KEY).unwrap());
             assert_eq!(table.len().unwrap(), 1);
 
+            // Commit transactions, create new ones.
+            drop(table);
+            TxRw::commit(tx_rw).unwrap();
+            let mut tx_rw = env_inner.tx_rw().unwrap();
+            let tx_ro = env_inner.tx_ro().unwrap();
+            let mut table = env_inner.open_db_rw::<$table>(&tx_rw).unwrap();
+            let table_ro = env_inner.open_db_ro::<$table>(&tx_ro).unwrap();
+
             // Assert `get_range()` works.
             {
                 let range = KEY..;
-                assert_eq!(1, table.get_range(range.clone()).unwrap().count());
-                let mut iter = table.get_range(range).unwrap();
+                assert_eq!(1, table_ro.get_range(range.clone()).unwrap().count());
+                let mut iter = table_ro.get_range(range).unwrap();
                 let value = iter.next().unwrap().unwrap();
                 assert_eq(&value);
             }

--- a/database/src/backend/tests.rs
+++ b/database/src/backend/tests.rs
@@ -81,7 +81,7 @@ fn open_db() {
     let (env, _tempdir) = tmp_concrete_env();
     let env_inner = env.env_inner();
     let tx_ro = env_inner.tx_ro().unwrap();
-    let mut tx_rw = env_inner.tx_rw().unwrap();
+    let tx_rw = env_inner.tx_rw().unwrap();
 
     // Open all tables in read-only mode.
     // This should be updated when tables are modified.
@@ -103,21 +103,21 @@ fn open_db() {
     TxRo::commit(tx_ro).unwrap();
 
     // Open all tables in read/write mode.
-    env_inner.open_db_rw::<BlockBlobs>(&mut tx_rw).unwrap();
-    env_inner.open_db_rw::<BlockHeights>(&mut tx_rw).unwrap();
-    env_inner.open_db_rw::<BlockInfoV1s>(&mut tx_rw).unwrap();
-    env_inner.open_db_rw::<BlockInfoV2s>(&mut tx_rw).unwrap();
-    env_inner.open_db_rw::<BlockInfoV3s>(&mut tx_rw).unwrap();
-    env_inner.open_db_rw::<KeyImages>(&mut tx_rw).unwrap();
-    env_inner.open_db_rw::<NumOutputs>(&mut tx_rw).unwrap();
-    env_inner.open_db_rw::<Outputs>(&mut tx_rw).unwrap();
-    env_inner.open_db_rw::<PrunableHashes>(&mut tx_rw).unwrap();
-    env_inner.open_db_rw::<PrunableTxBlobs>(&mut tx_rw).unwrap();
-    env_inner.open_db_rw::<PrunedTxBlobs>(&mut tx_rw).unwrap();
-    env_inner.open_db_rw::<RctOutputs>(&mut tx_rw).unwrap();
-    env_inner.open_db_rw::<TxHeights>(&mut tx_rw).unwrap();
-    env_inner.open_db_rw::<TxIds>(&mut tx_rw).unwrap();
-    env_inner.open_db_rw::<TxUnlockTime>(&mut tx_rw).unwrap();
+    env_inner.open_db_rw::<BlockBlobs>(&tx_rw).unwrap();
+    env_inner.open_db_rw::<BlockHeights>(&tx_rw).unwrap();
+    env_inner.open_db_rw::<BlockInfoV1s>(&tx_rw).unwrap();
+    env_inner.open_db_rw::<BlockInfoV2s>(&tx_rw).unwrap();
+    env_inner.open_db_rw::<BlockInfoV3s>(&tx_rw).unwrap();
+    env_inner.open_db_rw::<KeyImages>(&tx_rw).unwrap();
+    env_inner.open_db_rw::<NumOutputs>(&tx_rw).unwrap();
+    env_inner.open_db_rw::<Outputs>(&tx_rw).unwrap();
+    env_inner.open_db_rw::<PrunableHashes>(&tx_rw).unwrap();
+    env_inner.open_db_rw::<PrunableTxBlobs>(&tx_rw).unwrap();
+    env_inner.open_db_rw::<PrunedTxBlobs>(&tx_rw).unwrap();
+    env_inner.open_db_rw::<RctOutputs>(&tx_rw).unwrap();
+    env_inner.open_db_rw::<TxHeights>(&tx_rw).unwrap();
+    env_inner.open_db_rw::<TxIds>(&tx_rw).unwrap();
+    env_inner.open_db_rw::<TxUnlockTime>(&tx_rw).unwrap();
     TxRw::commit(tx_rw).unwrap();
 }
 
@@ -169,8 +169,8 @@ fn non_manual_resize_2() {
 fn db_read_write() {
     let (env, _tempdir) = tmp_concrete_env();
     let env_inner = env.env_inner();
-    let mut tx_rw = env_inner.tx_rw().unwrap();
-    let mut table = env_inner.open_db_rw::<Outputs>(&mut tx_rw).unwrap();
+    let tx_rw = env_inner.tx_rw().unwrap();
+    let mut table = env_inner.open_db_rw::<Outputs>(&tx_rw).unwrap();
 
     /// The (1st) key.
     const KEY: PreRctOutputId = PreRctOutputId {
@@ -273,7 +273,7 @@ fn db_read_write() {
     }
 
     drop(table);
-    tx_rw.commit().unwrap();
+    TxRw::commit(tx_rw).unwrap();
     let mut tx_rw = env_inner.tx_rw().unwrap();
 
     // Assert `clear_db()` works.
@@ -283,7 +283,7 @@ fn db_read_write() {
         let reader_table = env_inner.open_db_ro::<Outputs>(&tx_ro).unwrap();
 
         env_inner.clear_db::<Outputs>(&mut tx_rw).unwrap();
-        let table = env_inner.open_db_rw::<Outputs>(&mut tx_rw).unwrap();
+        let table = env_inner.open_db_rw::<Outputs>(&tx_rw).unwrap();
         assert!(table.is_empty().unwrap());
         for n in 0..N {
             let mut key = KEY;

--- a/database/src/backend/tests.rs
+++ b/database/src/backend/tests.rs
@@ -24,7 +24,7 @@ use std::borrow::{Borrow, Cow};
 
 use crate::{
     config::{Config, SyncMode},
-    database::{DatabaseRo, DatabaseRw},
+    database::{DatabaseRo, DatabaseRw, DatabaseIter},
     env::{Env, EnvInner},
     error::{InitError, RuntimeError},
     resize::ResizeAlgorithm,
@@ -223,6 +223,9 @@ fn db_read_write() {
 
     // Assert the whole range is there.
     {
+        let table = env_inner
+            .open_db_ro::<Outputs>(&env_inner.tx_ro().unwrap())
+            .unwrap();
         let range = table.get_range(..).unwrap();
         let mut i = 0;
         for result in range {

--- a/database/src/database.rs
+++ b/database/src/database.rs
@@ -20,8 +20,8 @@ use crate::{
 /// can only be called from [`DatabaseRo`] objects.
 ///
 /// # Hack
-/// This is a hack to get around the fact our read/write tables
-/// cannot _safely_ return values returning lifetimes, as such,
+/// This is a HACK to get around the fact our read/write tables
+/// cannot safely return values returning lifetimes, as such,
 /// only read-only tables implement this trait.
 ///
 /// - <https://github.com/Cuprate/cuprate/pull/102#discussion_r1548695610>

--- a/database/src/database.rs
+++ b/database/src/database.rs
@@ -13,22 +13,20 @@ use crate::{
     transaction::{TxRo, TxRw},
 };
 
-//---------------------------------------------------------------------------------------------------- DatabaseRo
-/// Database (key-value store) read abstraction.
+//---------------------------------------------------------------------------------------------------- DatabaseRoIter
+/// Database (key-value store) read-only iteration abstraction.
 ///
-/// This is a read-only database table,
-/// write operations are defined in [`DatabaseRw`].
-pub trait DatabaseRo<T: Table> {
-    /// Get the value corresponding to a key.
-    ///
-    /// The returned value is _owned_.
-    ///
-    /// # Errors
-    /// This will return [`RuntimeError::KeyNotFound`] wrapped in [`Err`] if `key` does not exist.
-    ///
-    /// It will return other [`RuntimeError`]'s on things like IO errors as well.
-    fn get(&self, key: &T::Key) -> Result<T::Value, RuntimeError>;
-
+/// These are read-only iteration-related operations that
+/// can only be called from [`DatabaseRo`] objects.
+///
+/// # Hack
+/// This is a hack to get around the fact our read/write tables
+/// cannot _safely_ return values returning lifetimes, as such,
+/// only read-only tables implement this trait.
+///
+/// - <https://github.com/Cuprate/cuprate/pull/102#discussion_r1548695610>
+/// - <https://github.com/Cuprate/cuprate/pull/104>
+pub trait DatabaseIter<T: Table> {
     /// Get an iterator of value's corresponding to a range of keys.
     ///
     /// For example:
@@ -77,6 +75,23 @@ pub trait DatabaseRo<T: Table> {
     fn values(
         &self,
     ) -> Result<impl Iterator<Item = Result<T::Value, RuntimeError>> + '_, RuntimeError>;
+}
+
+//---------------------------------------------------------------------------------------------------- DatabaseRo
+/// Database (key-value store) read abstraction.
+///
+/// This is a read-only database table,
+/// write operations are defined in [`DatabaseRw`].
+pub trait DatabaseRo<T: Table> {
+    /// Get the value corresponding to a key.
+    ///
+    /// The returned value is _owned_.
+    ///
+    /// # Errors
+    /// This will return [`RuntimeError::KeyNotFound`] wrapped in [`Err`] if `key` does not exist.
+    ///
+    /// It will return other [`RuntimeError`]'s on things like IO errors as well.
+    fn get(&self, key: &T::Key) -> Result<T::Value, RuntimeError>;
 
     /// TODO
     ///

--- a/database/src/env.rs
+++ b/database/src/env.rs
@@ -217,7 +217,7 @@ where
     /// As [`Table`] is `Sealed`, and all tables are created
     /// upon [`Env::open`], this function will never error because
     /// a table doesn't exist.
-    fn open_db_rw<T: Table>(&self, tx_rw: &mut Rw) -> Result<impl DatabaseRw<T>, RuntimeError>;
+    fn open_db_rw<T: Table>(&self, tx_rw: &Rw) -> Result<impl DatabaseRw<T>, RuntimeError>;
 
     /// Clear all `(key, value)`'s from a database table.
     ///

--- a/database/src/env.rs
+++ b/database/src/env.rs
@@ -5,7 +5,7 @@ use std::{fmt::Debug, ops::Deref};
 
 use crate::{
     config::Config,
-    database::{DatabaseRo, DatabaseRw},
+    database::{DatabaseIter, DatabaseRo, DatabaseRw},
     error::{InitError, RuntimeError},
     resize::ResizeAlgorithm,
     table::Table,
@@ -201,7 +201,10 @@ where
     /// As [`Table`] is `Sealed`, and all tables are created
     /// upon [`Env::open`], this function will never error because
     /// a table doesn't exist.
-    fn open_db_ro<T: Table>(&self, tx_ro: &Ro) -> Result<impl DatabaseRo<T>, RuntimeError>;
+    fn open_db_ro<T: Table>(
+        &self,
+        tx_ro: &Ro,
+    ) -> Result<impl DatabaseRo<T> + DatabaseIter<T>, RuntimeError>;
 
     /// Open a database in read/write mode.
     ///

--- a/database/src/lib.rs
+++ b/database/src/lib.rs
@@ -222,7 +222,7 @@ pub use constants::{
 };
 
 mod database;
-pub use database::{DatabaseRo, DatabaseRw};
+pub use database::{DatabaseIter, DatabaseRo, DatabaseRw};
 
 mod env;
 pub use env::{Env, EnvInner};


### PR DESCRIPTION
## Part 21
https://github.com/Cuprate/cuprate/pull/102 <- Previous

Fixes https://github.com/Cuprate/cuprate/pull/102#discussion_r1548695610.

- Makes `EnvInner::open_db_rw()` take a `&` instead of `&mut` write transaction
- Makes `heed` compatible by using `RefCell`
- Moves iteration functions from `trait DatabaseRo` -> `trait DatabaseIter` that are no longer accessible from `trait DatabaseRw` objects