### PR TITLE
ci: use `dtolnay/rust-toolchain`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,10 +71,7 @@ jobs:
     - name: Cache
       uses: actions/cache@v3
       with:
-        path: |
-          target
-          ~/.cargo
-          ~/.rustup
+        path: target
         key: ${{ matrix.os }}
 
     - name: Download monerod
@@ -116,7 +113,7 @@ jobs:
       run: |
         cargo test --all-features --workspace
         cargo test --package cuprate-database --no-default-features --features redb --features service
-        
+
     # TODO: upload binaries with `actions/upload-artifact@v3`
     - name: Build
       run: cargo build --all-features --all-targets --workspace

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,10 +53,13 @@ jobs:
         include:
           - os: windows-latest
             shell: msys2 {0}
+            rust: stable-x86_64-pc-windows-gnu
           - os: macos-latest
             shell: bash
+            rust: stable
           - os: ubuntu-latest
             shell: bash
+            rust: stable
 
     defaults:
       run:
@@ -67,6 +70,12 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: recursive
+
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: ${{ matrix.rust }}
+        components: clippy
 
     - name: Cache
       uses: actions/cache@v3
@@ -95,12 +104,6 @@ jobs:
         path-type: inherit
         update: true
         install: mingw-w64-x86_64-toolchain mingw-w64-x86_64-boost msys2-runtime-devel git mingw-w64-x86_64-cmake mingw-w64-x86_64-ninja
-
-    - name: Switch target (Windows)
-      if: matrix.os == 'windows-latest'
-      run: |
-        rustup toolchain install stable-x86_64-pc-windows-gnu -c clippy --no-self-update
-        rustup default stable-x86_64-pc-windows-gnu
 
     - name: Documentation
       run: cargo doc --workspace --all-features --no-deps


### PR DESCRIPTION
May help https://github.com/Cuprate/cuprate/actions/runs/8945390632/job/24574288677 in https://github.com/Cuprate/cuprate/pull/111.

The function causing errors in that CI fail was stabilized in 1.76, current should be 1.77.x.

I think caching `.cargo` and `.rustup` is saving old versions of Rust then causing them to be used, so this PR replaces it with https://github.com/dtolnay/rust-toolchain.