### PR TITLE
repo: add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -8,7 +8,11 @@ assignees: ''
 ---
 
 <!--
-Note: Please search to see if an issue already exists for the bug you encountered.
+
+Notes:
+- All these fields are optional, add as much or as little info as you like
+- Please search to see if an issue already exists for the bug you encountered
+
 -->
 
 ## Environment
@@ -35,5 +39,9 @@ Example:
 ## Log
 If possible, add any related logs to help explain the bug.
 
+Note: please remove any sensitive information from the logs (e.g. IP address).
+
 ## Screenshots
 If possible, add screenshots to help explain the bug.
+
+Note: please remove any sensitive information from the screenshot.

--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,39 @@
+---
+name: 🐞 Bug report
+about: Create a bug report
+title: ''
+labels: ["C-bug"]
+assignees: ''
+
+---
+
+<!--
+Note: Please search to see if an issue already exists for the bug you encountered.
+-->
+
+## Environment
+Example:
+- OS: Windows 11
+- CPU: AMD Ryzen 5 5600X
+- Memory: 16GB
+- Storage: SSD 500GB
+- Cuprate: v1.0.0
+
+## Bug
+What is the bug?
+
+### Expected behavior
+What correct beahvior was expected to happen?
+
+## Steps to reproduce
+Example:
+1. In this environment...
+2. With this config...
+3. Run '...'
+4. See error...
+
+## Log
+If possible, add any related logs to help explain the bug.
+
+## Screenshots
+If possible, add screenshots to help explain the bug.

--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -8,11 +8,9 @@ assignees: ''
 ---
 
 <!--
-
 Notes:
 - All these fields are optional, add as much or as little info as you like
 - Please search to see if an issue already exists for the bug you encountered
-
 -->
 
 ## Environment

--- a/.github/ISSUE_TEMPLATE/discussion.md
+++ b/.github/ISSUE_TEMPLATE/discussion.md
@@ -1,0 +1,18 @@
+---
+name: ⏳ Discussion
+about: Start a discussion on a topic
+title: ''
+labels: ["C-discussion"]
+assignees: ''
+
+---
+
+<!--
+Note: Please search to see if an issue already exists for this discussion.
+-->
+
+## What
+What would you would like to discuss?
+
+## Why
+Why would you would like to discuss this?

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -17,8 +17,5 @@ What is the feature you're requesting?
 ## Why
 Why should your feature be added?
 
-## How
-If possible, describe how the proposal could be added.
-
 ## Additional context
 Add any other context or screenshots about the feature request.

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,24 @@
+---
+name: ✨ Feature request
+about: Request a feature
+title: ''
+labels: ["C-request"]
+assignees: ''
+
+---
+
+<!--
+Note: Please search to see if an issue already exists for this request, or if the feature already exists.
+-->
+
+## Feature
+What is the feature you're requesting?
+
+## Why
+Why should your feature be added?
+
+## How
+If possible, describe how the proposal could be added.
+
+## Additional context
+Add any other context or screenshots about the feature request.

--- a/.github/ISSUE_TEMPLATE/proposal.md
+++ b/.github/ISSUE_TEMPLATE/proposal.md
@@ -1,0 +1,24 @@
+---
+name: 📜 Proposal
+about: Propose an idea and request for comments
+title: ''
+labels: ["C-proposal"]
+assignees: ''
+
+---
+
+<!--
+Note: Please search to see if an issue already exists for this proposal.
+-->
+
+## What
+Describe your proposal.
+
+## Where
+Describe where your proposal will cause changes to.
+
+## Why
+Describe why the proposal is needed.
+
+## How
+Describe how the proposal could be implemented.

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,15 @@
+---
+name: ❓ Question
+about: Ask a question
+title: ''
+labels: ["C-question"]
+assignees: ''
+
+---
+
+<!--
+Note: Please search to see if an issue already exists for this question.
+-->
+
+## Question
+What question would you like to ask?


### PR DESCRIPTION
Adds template issue forms that get auto-labeled upon creation.

Reference: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository.

Examples:
- https://github.com/hinto-janai/labeler-test/issues/new/choose
- https://github.com/hinto-janai/labeler-test/issues