### PR TITLE
storage: create Cargo.toml for `{database, cuprate-txpool}`

### DIFF
--- a/storage/cuprate-txpool/Cargo.toml
+++ b/storage/cuprate-txpool/Cargo.toml
@@ -1,6 +1,15 @@
 [package]
-name = "cuprate-txpool"
-version = "0.0.0"
-edition = "2021"
+name        = "cuprate-txpool"
+version     = "0.0.0"
+edition     = "2021"
+description = "Cuprate's transaction pool database"
+license     = "MIT"
+authors     = ["hinto-janai"]
+repository  = "https://github.com/Cuprate/cuprate/tree/main/storage/cuprate-txpool"
+keywords    = ["cuprate", "txpool", "transaction", "pool", "database"]
+
+[features]
 
 [dependencies]
+
+[dev-dependencies]

--- a/storage/database/Cargo.toml
+++ b/storage/database/Cargo.toml
@@ -1,6 +1,15 @@
 [package]
-name = "database"
-version = "0.0.0"
-edition = "2021"
+name        = "database"
+version     = "0.0.0"
+edition     = "2021"
+description = "Cuprate's database abstraction"
+license     = "MIT"
+authors     = ["hinto-janai"]
+repository  = "https://github.com/Cuprate/cuprate/tree/main/storage/database"
+keywords    = ["cuprate", "database"]
+
+[features]
 
 [dependencies]
+
+[dev-dependencies]


### PR DESCRIPTION
Fixes https://github.com/Cuprate/cuprate/actions/runs/9278688444/job/25530080931 (`storage/` crates are missing a `license` field).