### PR TITLE
contributing: add crate naming rules

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,14 +31,15 @@ After that, ensure all lints, tests, and builds are successful by running:
 - `cargo build --all-features --all-targets --workspace`
 
 ## Crate names
-Cuprate's crates (libraries) follows these naming patterns/rules:
+All of Cuprate's crates (libraries) are prefixed with `cuprate-`.
 
-| Pattern                                               | Name             | Example |
-|-------------------------------------------------------|------------------|---------|
-| Crates defining Monero related behavior               | `monero` prefix  | `monero-consensus`
-| Crates specific to Cuprate's implementation      | `cuprate` prefix | `cuprate-blockchain`
-| Monero related code re-written for Cuprate purposes   | `cuprate` suffix | `levin-cuprate`, `cryptonight-cuprate`
-| General crate, not necessarily Monero/Cuprate related | No prefix/suffix | `database`, `async-buffer`
+All directories containing crates however, are not. For example:
+
+| Crate Directory                                       | Crate Name            |
+|-------------------------------------------------------|-----------------------|
+| `storage/database`                                    | `cuprate-database`    |
+| `net/levin`                                           | `cuprate-levin`       |
+| `net/monero-wire`                                     | `cuprate-monero-wire` |
 
 ## Coding guidelines
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,11 +35,11 @@ All of Cuprate's crates (libraries) are prefixed with `cuprate-`.
 
 All directories containing crates however, are not. For example:
 
-| Crate Directory                                       | Crate Name            |
-|-------------------------------------------------------|-----------------------|
-| `storage/database`                                    | `cuprate-database`    |
-| `net/levin`                                           | `cuprate-levin`       |
-| `net/monero-wire`                                     | `cuprate-monero-wire` |
+| Crate Directory    | Crate Name         |
+|--------------------|--------------------|
+| `storage/database` | `cuprate-database` |
+| `net/levin`        | `cuprate-levin`    |
+| `net/wire`         | `cuprate-wire`     |
 
 ## Coding guidelines
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ Cuprate's crates (libraries) follows these naming patterns/rules:
 | Pattern                                               | Name             | Example |
 |-------------------------------------------------------|------------------|---------|
 | Crates defining Monero related behavior               | `monero` prefix  | `monero-consensus`
-| Crates specifically for Cuprate's implementation      | `cuprate` prefix | `cuprate-blockchain`
+| Crates specific to Cuprate's implementation      | `cuprate` prefix | `cuprate-blockchain`
 | Monero related code re-written for Cuprate purposes   | `cuprate` suffix | `levin-cuprate`, `cryptonight-cuprate`
 | General crate, not necessarily Monero/Cuprate related | No prefix/suffix | `database`, `async-buffer`
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,16 @@ After that, ensure all lints, tests, and builds are successful by running:
 - `cargo test --all-features --workspace`
 - `cargo build --all-features --all-targets --workspace`
 
+## Crate names
+Cuprate's crates (libraries) follows these naming patterns/rules:
+
+| Pattern                                               | Name             | Example |
+|-------------------------------------------------------|------------------|---------|
+| Crates defining Monero related behavior               | `monero` prefix  | `monero-consensus`
+| Crates specifically for Cuprate's implementation      | `cuprate` prefix | `cuprate-blockchain`
+| Monero related code re-written for Cuprate purposes   | `cuprate` suffix | `levin-cuprate`, `cryptonight-cuprate`
+| General crate, not necessarily Monero/Cuprate related | No prefix/suffix | `database`, `async-buffer`
+
 ## Coding guidelines
 
 - `// Comment like this.` and not `//like this`


### PR DESCRIPTION
Formalizes the naming scheme used for Cuprate's crates.