### PR TITLE
ci: update `actions/cache` -> `v4`

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
     - name: Cache
-      uses: actions/cache@v3.2.3
+      uses: actions/cache@v4
       with:
         path: |
           ~/.cargo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
         components: clippy
 
     - name: Cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: target
         key: ${{ matrix.os }}

--- a/.github/workflows/deny.yml
+++ b/.github/workflows/deny.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
     - name: Cache
-      uses: actions/cache@v3.2.3
+      uses: actions/cache@v4
       with:
         path: |
           ~/.cargo


### PR DESCRIPTION
Fixes:

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/cache@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
