### PR TITLE
repo: add `Tracking Issue` issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -24,7 +24,7 @@ Example:
 ## Bug
 What is the bug?
 
-### Expected behavior
+## Expected behavior
 What correct beahvior was expected to happen?
 
 ## Steps to reproduce

--- a/.github/ISSUE_TEMPLATE/proposal.md
+++ b/.github/ISSUE_TEMPLATE/proposal.md
@@ -14,11 +14,11 @@ Note: Please search to see if an issue already exists for this proposal.
 ## What
 Describe your proposal.
 
-## Where
-Describe where your proposal will cause changes to.
-
 ## Why
 Describe why the proposal is needed.
+
+## Where
+Describe where your proposal will cause changes to.
 
 ## How
 Describe how the proposal could be implemented.

--- a/.github/ISSUE_TEMPLATE/tracking_issue.md
+++ b/.github/ISSUE_TEMPLATE/tracking_issue.md
@@ -1,54 +1,41 @@
 ---
 name: 🔍 Tracking Issue
-about: Create an issue that tracks an effort or PR(s)
+about: Create an issue that tracks a wider effort
 title: 'Tracking Issue for ...'
 labels: ["C-tracking-issue"]
 assignees: ''
 
 ---
 
-<!--
-Note: Please search to see if an issue already exists for this tracking issue.
-
-About tracking issues:
-
+<!-- Consider keeping the following section in the issue. -->
+### About tracking issues
 Tracking issues are used to record the overall progress of implementation.
 They are also used as hubs connecting to other relevant issues, e.g., bugs or open design questions.
 A tracking issue is however not meant for large scale discussion, questions, or bug reports about a feature.
 Instead, open a dedicated issue for the specific matter.
--->
 
-## What
-Describe the effort being tracked.
+### What
+This is a tracking issue for ...
 
-## Why
-Describe why this effort is needed.
-
-## Where
-Describe where changes will be made.
-
-## How
-If possible, describe how the effort could be implemented.
-
-Include a summarized version of the public API, e.g.
-just the function signatures without their doc comments or implementation.
-
-```rust
-// core::magic
-
-pub struct Magic;
-
-impl Magic {
-    pub fn magic(self);
-}
-```
-
-## Steps
+### Steps
+<!--
 Describe the steps required to bring this effort to completion.
 
 For larger features, more steps might be involved.
 If the feature is changed later, please add those PRs here as well.
+-->
 
 - [ ] Initial implementation: #...
 - [ ] Other code: #...
+- [ ] Multi-PR effort
+    - #...
+    - #...
+    - #...
 - [ ] Finalization PR: #...
+
+### Related
+<!-- Link any related issues/PRs here. -->
+
+- #...
+- #...
+- #...

--- a/.github/ISSUE_TEMPLATE/tracking_issue.md
+++ b/.github/ISSUE_TEMPLATE/tracking_issue.md
@@ -1,0 +1,54 @@
+---
+name: 🔍 Tracking Issue
+about: Create an issue that tracks an effort or PR(s)
+title: 'Tracking Issue for ...'
+labels: ["C-tracking-issue"]
+assignees: ''
+
+---
+
+<!--
+Note: Please search to see if an issue already exists for this tracking issue.
+
+About tracking issues:
+
+Tracking issues are used to record the overall progress of implementation.
+They are also used as hubs connecting to other relevant issues, e.g., bugs or open design questions.
+A tracking issue is however not meant for large scale discussion, questions, or bug reports about a feature.
+Instead, open a dedicated issue for the specific matter.
+-->
+
+## What
+Describe the effort being tracked.
+
+## Why
+Describe why this effort is needed.
+
+## Where
+Describe where changes will be made.
+
+## How
+If possible, describe how the effort could be implemented.
+
+Include a summarized version of the public API, e.g.
+just the function signatures without their doc comments or implementation.
+
+```rust
+// core::magic
+
+pub struct Magic;
+
+impl Magic {
+    pub fn magic(self);
+}
+```
+
+## Steps
+Describe the steps required to bring this effort to completion.
+
+For larger features, more steps might be involved.
+If the feature is changed later, please add those PRs here as well.
+
+- [ ] Initial implementation: #...
+- [ ] Other code: #...
+- [ ] Finalization PR: #...


### PR DESCRIPTION
This adds `.github/ISSUE_TEMPLATE/tracking_issue.md` and fixes some formatting in other templates.

The purpose of this is to track wider efforts that may contain multiple PRs and/or are generally spread out. These don't usually contain the why, but if they do, they are brief. These contain no implementation detail or the how, as those are for the issues/PRs that are being tracked.

For example:
- https://github.com/rust-lang/rust/issues?q=is%3Aissue+is%3Aopen+label%3AC-tracking-issue
- https://github.com/rust-lang/rust/issues/123916

A big difference between this and a proposal is that tracking issues already have consensus, i.e. the thing in question is already decided on. The what/why/where is already answered, all that is left is implementation.