### PR TITLE
epee: unseal `trait EpeeValue`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -341,7 +341,7 @@ version = "4.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c780290ccf4fb26629baa7a1081e68ced113f1d3ec302fa5948f1c381ebf06c6"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
  "syn 2.0.66",
@@ -815,7 +815,6 @@ dependencies = [
  "hex",
  "paste",
  "ref-cast",
- "sealed",
  "thiserror",
 ]
 
@@ -1061,12 +1060,6 @@ dependencies = [
  "byteorder",
  "num-traits",
 ]
-
-[[package]]
-name = "heck"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "heck"
@@ -2160,18 +2153,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "sealed"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4a8caec23b7800fb97971a1c6ae365b6239aaeddfb934d6265f8505e795699d"
-dependencies = [
- "heck 0.4.1",
- "proc-macro2",
- "quote",
- "syn 2.0.66",
-]
 
 [[package]]
 name = "security-framework"

--- a/net/epee-encoding/Cargo.toml
+++ b/net/epee-encoding/Cargo.toml
@@ -17,7 +17,6 @@ std = ["dep:thiserror", "bytes/std", "fixed-bytes/std"]
 [dependencies]
 fixed-bytes = { path = "../fixed-bytes", default-features = false }
 
-sealed = "0.5.0"
 paste = "1.0.14"
 ref-cast = "1.0.22"
 bytes = { workspace = true }

--- a/net/epee-encoding/src/container_as_blob.rs
+++ b/net/epee-encoding/src/container_as_blob.rs
@@ -26,7 +26,6 @@ impl<'a, T: Containerable + EpeeValue> From<&'a Vec<T>> for &'a ContainerAsBlob<
     }
 }
 
-#[sealed]
 impl<T: Containerable + EpeeValue> EpeeValue for ContainerAsBlob<T> {
     const MARKER: Marker = Marker::new(InnerMarker::String);
 

--- a/net/epee-encoding/src/container_as_blob.rs
+++ b/net/epee-encoding/src/container_as_blob.rs
@@ -1,8 +1,7 @@
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 use ref_cast::RefCast;
-use sealed::sealed;
 
-use crate::{error::*, value::*, EpeeValue, InnerMarker, Marker};
+use crate::{error::*, EpeeValue, InnerMarker, Marker};
 
 #[derive(RefCast)]
 #[repr(transparent)]

--- a/net/epee-encoding/src/value.rs
+++ b/net/epee-encoding/src/value.rs
@@ -1,10 +1,10 @@
+//! This module contains a [`EpeeValue`] trait and
+//! impls for some possible base epee values.
+
 use alloc::{string::String, vec::Vec};
-/// This module contains a `sealed` [`EpeeValue`] trait and different impls for
-/// the different possible base epee values.
 use core::fmt::Debug;
 
 use bytes::{Buf, BufMut, Bytes, BytesMut};
-use sealed::sealed;
 
 use fixed_bytes::{ByteArray, ByteArrayVec};
 
@@ -12,10 +12,9 @@ use crate::{
     io::*, varint::*, EpeeObject, Error, InnerMarker, Marker, Result, MAX_STRING_LEN_POSSIBLE,
 };
 
-/// A trait for epee values, this trait is sealed as all possible epee values are
-/// defined in the lib, to make an [`EpeeValue`] outside the lib you will need to
-/// use the trait [`EpeeObject`].
-#[sealed(pub(crate))]
+/// A trait for epee values.
+///
+/// All [`EpeeObject`] objects automatically implement [`EpeeValue`].
 pub trait EpeeValue: Sized {
     const MARKER: Marker;
 
@@ -37,7 +36,6 @@ pub trait EpeeValue: Sized {
     fn write<B: BufMut>(self, w: &mut B) -> Result<()>;
 }
 
-#[sealed]
 impl<T: EpeeObject> EpeeValue for T {
     const MARKER: Marker = Marker::new(InnerMarker::Object);
 
@@ -56,7 +54,6 @@ impl<T: EpeeObject> EpeeValue for T {
     }
 }
 
-#[sealed]
 impl<T: EpeeObject> EpeeValue for Vec<T> {
     const MARKER: Marker = T::MARKER.into_seq();
 
@@ -94,7 +91,6 @@ impl<T: EpeeObject> EpeeValue for Vec<T> {
     }
 }
 
-#[sealed]
 impl<T: EpeeObject + Debug, const N: usize> EpeeValue for [T; N] {
     const MARKER: Marker = <T>::MARKER.into_seq();
 
@@ -119,7 +115,6 @@ impl<T: EpeeObject + Debug, const N: usize> EpeeValue for [T; N] {
 
 macro_rules! epee_numb {
     ($numb:ty, $marker:ident, $read_fn:ident, $write_fn:ident) => {
-        #[sealed]
         impl EpeeValue for $numb {
             const MARKER: Marker = Marker::new(InnerMarker::$marker);
 
@@ -148,7 +143,6 @@ epee_numb!(u32, U32, get_u32_le, put_u32_le);
 epee_numb!(u64, U64, get_u64_le, put_u64_le);
 epee_numb!(f64, F64, get_f64_le, put_f64_le);
 
-#[sealed]
 impl EpeeValue for bool {
     const MARKER: Marker = Marker::new(InnerMarker::Bool);
 
@@ -165,7 +159,6 @@ impl EpeeValue for bool {
     }
 }
 
-#[sealed]
 impl EpeeValue for Vec<u8> {
     const MARKER: Marker = Marker::new(InnerMarker::String);
 
@@ -209,7 +202,6 @@ impl EpeeValue for Vec<u8> {
     }
 }
 
-#[sealed::sealed]
 impl EpeeValue for Bytes {
     const MARKER: Marker = Marker::new(InnerMarker::String);
 
@@ -250,7 +242,6 @@ impl EpeeValue for Bytes {
     }
 }
 
-#[sealed::sealed]
 impl EpeeValue for BytesMut {
     const MARKER: Marker = Marker::new(InnerMarker::String);
 
@@ -294,7 +285,6 @@ impl EpeeValue for BytesMut {
     }
 }
 
-#[sealed::sealed]
 impl<const N: usize> EpeeValue for ByteArrayVec<N> {
     const MARKER: Marker = Marker::new(InnerMarker::String);
 
@@ -338,7 +328,6 @@ impl<const N: usize> EpeeValue for ByteArrayVec<N> {
     }
 }
 
-#[sealed::sealed]
 impl<const N: usize> EpeeValue for ByteArray<N> {
     const MARKER: Marker = Marker::new(InnerMarker::String);
 
@@ -374,7 +363,6 @@ impl<const N: usize> EpeeValue for ByteArray<N> {
     }
 }
 
-#[sealed]
 impl EpeeValue for String {
     const MARKER: Marker = Marker::new(InnerMarker::String);
 
@@ -403,7 +391,6 @@ impl EpeeValue for String {
     }
 }
 
-#[sealed]
 impl<const N: usize> EpeeValue for [u8; N] {
     const MARKER: Marker = Marker::new(InnerMarker::String);
 
@@ -429,7 +416,6 @@ impl<const N: usize> EpeeValue for [u8; N] {
     }
 }
 
-#[sealed]
 impl<const N: usize> EpeeValue for Vec<[u8; N]> {
     const MARKER: Marker = <[u8; N]>::MARKER.into_seq();
 
@@ -470,7 +456,6 @@ impl<const N: usize> EpeeValue for Vec<[u8; N]> {
 
 macro_rules! epee_seq {
     ($val:ty) => {
-        #[sealed]
         impl EpeeValue for Vec<$val> {
             const MARKER: Marker = <$val>::MARKER.into_seq();
 
@@ -509,7 +494,6 @@ macro_rules! epee_seq {
             }
         }
 
-        #[sealed]
         impl<const N: usize> EpeeValue for [$val; N] {
             const MARKER: Marker = <$val>::MARKER.into_seq();
 
@@ -548,7 +532,6 @@ epee_seq!(String);
 epee_seq!(Bytes);
 epee_seq!(BytesMut);
 
-#[sealed]
 impl<T: EpeeValue> EpeeValue for Option<T> {
     const MARKER: Marker = T::MARKER;
 


### PR DESCRIPTION
Allows implementing `epee_encoding::EpeeValue` on outside types.

Context:
```
hinto: boog900: do I have to manually create a tagged `struct` when using `epee_encoding` with an enum?
boog900: yes ... what type do you need an enum for?
hinto: https://github.com/hinto-janai/cuprate/blob/9d262719d7074a9a4cfb06b6943f79d97af3b7a2/rpc/types/src/status.rs#L59
boog900:  or you could manually implement the `EpeeObject` trait
boog900: is that used in the binary responses?
hinto: yes, it's the `status` field in almost every response
hinto: it's technically an optimization since that field could be a `String`, but most of the time the string is known
boog900: you would have to manually implement `EpeeObject` there
boog900: wait no it's not an object
hinto: it's just a string, but `EpeeValue` is sealed
hinto: `Cow<'static, str>` would work too (less clear imo) but that isn't implemented either
boog900: I guess it makes sense to unseal `EpeeValue`
hinto: should I do that?
hinto: #147 is blocked otherwise, or it gets merged without epee support
hinto: up to you
boog900: Yeah, I think it's probably best to do this now
```