### PR TITLE
epee: make `{read,write}_varint` public, create `write_{bytes,container}`

### DIFF
--- a/net/epee-encoding/src/lib.rs
+++ b/net/epee-encoding/src/lib.rs
@@ -242,7 +242,7 @@ pub fn write_bytes<T: AsRef<[u8]>, B: BufMut>(t: T, w: &mut B) -> Result<()> {
     Ok(())
 }
 
-/// Write a container of [`EpeeValue`]s to `w` with [`write_varint`].
+/// Write an [`Iterator`] of [`EpeeValue`]s to `w` with [`write_varint`].
 ///
 /// This function:
 /// - Writes the length of `i`'s bytes into `w` using [`write_varint`]
@@ -255,7 +255,7 @@ pub fn write_bytes<T: AsRef<[u8]>, B: BufMut>(t: T, w: &mut B) -> Result<()> {
 /// This will error if:
 /// - [`write_varint`] fails
 /// - [`EpeeValue::<T>::write`] fails
-pub fn write_container<T, I, B>(iterator: I, w: &mut B) -> Result<()>
+pub fn write_iterator<T, I, B>(iterator: I, w: &mut B) -> Result<()>
 where
     T: EpeeValue,
     I: Iterator<Item = T> + ExactSizeIterator,

--- a/net/epee-encoding/src/lib.rs
+++ b/net/epee-encoding/src/lib.rs
@@ -256,7 +256,7 @@ pub fn write_bytes<T: AsRef<[u8]>, B: BufMut>(t: T, w: &mut B) -> Result<()> {
 /// Write an [`Iterator`] of [`EpeeValue`]s to `w` with [`write_varint`].
 ///
 /// This function:
-/// - Writes the length of `i`'s bytes into `w` using [`write_varint`]
+/// - Writes the length of the `iterator`, into `w` using [`write_varint`]
 /// - [`EpeeValue::write`]s each `T` of the iterator into `w`
 ///
 /// It is used as the internal [`EpeeValue::write`]

--- a/net/epee-encoding/src/lib.rs
+++ b/net/epee-encoding/src/lib.rs
@@ -227,6 +227,17 @@ fn write_epee_value<T: EpeeValue, B: BufMut>(val: T, w: &mut B) -> Result<()> {
 /// This will error if:
 /// - [`write_varint`] fails
 /// - `w` does not have enough capacity
+///
+/// # Example
+/// ```rust
+/// let t: [u8; 8] = [3, 0, 0, 0, 1, 0, 0, 0];
+/// let mut w = vec![];
+///
+/// epee_encoding::write_bytes(t, &mut w).unwrap();
+///
+/// assert_eq!(w.len(), 9); // length of bytes + bytes
+/// assert_eq!(w[1..], t);
+/// ```
 pub fn write_bytes<T: AsRef<[u8]>, B: BufMut>(t: T, w: &mut B) -> Result<()> {
     let bytes = t.as_ref();
     let len = bytes.len();
@@ -255,6 +266,20 @@ pub fn write_bytes<T: AsRef<[u8]>, B: BufMut>(t: T, w: &mut B) -> Result<()> {
 /// This will error if:
 /// - [`write_varint`] fails
 /// - [`EpeeValue::<T>::write`] fails
+///
+/// # Example
+/// ```rust
+/// let t: u64 = 3;
+/// let vec: Vec<u64> = vec![t, t];
+/// let mut w = vec![];
+///
+/// let iter: std::vec::IntoIter<u64> = vec.into_iter();
+/// epee_encoding::write_iterator(iter, &mut w).unwrap();
+///
+/// assert_eq!(w.len(), 17);
+/// assert_eq!(w[1..9], [3, 0, 0, 0, 0, 0, 0, 0]);
+/// assert_eq!(w[9..], [3, 0, 0, 0, 0, 0, 0, 0]);
+/// ```
 pub fn write_iterator<T, I, B>(iterator: I, w: &mut B) -> Result<()>
 where
     T: EpeeValue,

--- a/net/epee-encoding/src/value.rs
+++ b/net/epee-encoding/src/value.rs
@@ -11,7 +11,7 @@ use fixed_bytes::{ByteArray, ByteArrayVec};
 use crate::{
     io::{checked_read_primitive, checked_write_primitive},
     varint::{read_varint, write_varint},
-    write_bytes, write_container, EpeeObject, Error, InnerMarker, Marker, Result,
+    write_bytes, write_iterator, EpeeObject, Error, InnerMarker, Marker, Result,
     MAX_STRING_LEN_POSSIBLE,
 };
 
@@ -86,7 +86,7 @@ impl<T: EpeeObject> EpeeValue for Vec<T> {
     }
 
     fn write<B: BufMut>(self, w: &mut B) -> Result<()> {
-        write_container(self.into_iter(), w)
+        write_iterator(self.into_iter(), w)
     }
 }
 
@@ -104,7 +104,7 @@ impl<T: EpeeObject + Debug, const N: usize> EpeeValue for [T; N] {
     }
 
     fn write<B: BufMut>(self, w: &mut B) -> Result<()> {
-        write_container(self.into_iter(), w)
+        write_iterator(self.into_iter(), w)
     }
 }
 
@@ -390,7 +390,7 @@ impl<const N: usize> EpeeValue for Vec<[u8; N]> {
     }
 
     fn write<B: BufMut>(self, w: &mut B) -> Result<()> {
-        write_container(self.into_iter(), w)
+        write_iterator(self.into_iter(), w)
     }
 }
 
@@ -426,7 +426,7 @@ macro_rules! epee_seq {
             }
 
             fn write<B: BufMut>(self, w: &mut B) -> Result<()> {
-                write_container(self.into_iter(), w)
+                write_iterator(self.into_iter(), w)
             }
         }
 
@@ -444,7 +444,7 @@ macro_rules! epee_seq {
             }
 
             fn write<B: BufMut>(self, w: &mut B) -> Result<()> {
-                write_container(self.into_iter(), w)
+                write_iterator(self.into_iter(), w)
             }
         }
     };

--- a/net/epee-encoding/src/value.rs
+++ b/net/epee-encoding/src/value.rs
@@ -9,7 +9,10 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use fixed_bytes::{ByteArray, ByteArrayVec};
 
 use crate::{
-    io::*, varint::*, EpeeObject, Error, InnerMarker, Marker, Result, MAX_STRING_LEN_POSSIBLE,
+    io::{checked_read_primitive, checked_write_primitive},
+    varint::{read_varint, write_varint},
+    write_bytes, write_container, EpeeObject, Error, InnerMarker, Marker, Result,
+    MAX_STRING_LEN_POSSIBLE,
 };
 
 /// A trait for epee values.
@@ -83,11 +86,7 @@ impl<T: EpeeObject> EpeeValue for Vec<T> {
     }
 
     fn write<B: BufMut>(self, w: &mut B) -> Result<()> {
-        write_varint(self.len().try_into()?, w)?;
-        for item in self.into_iter() {
-            item.write(w)?;
-        }
-        Ok(())
+        write_container(self.into_iter(), w)
     }
 }
 
@@ -105,11 +104,7 @@ impl<T: EpeeObject + Debug, const N: usize> EpeeValue for [T; N] {
     }
 
     fn write<B: BufMut>(self, w: &mut B) -> Result<()> {
-        write_varint(self.len().try_into()?, w)?;
-        for item in self.into_iter() {
-            item.write(w)?;
-        }
-        Ok(())
+        write_container(self.into_iter(), w)
     }
 }
 
@@ -191,14 +186,7 @@ impl EpeeValue for Vec<u8> {
     }
 
     fn write<B: BufMut>(self, w: &mut B) -> Result<()> {
-        write_varint(self.len().try_into()?, w)?;
-
-        if w.remaining_mut() < self.len() {
-            return Err(Error::IO("Not enough capacity to write bytes"));
-        }
-
-        w.put_slice(&self);
-        Ok(())
+        write_bytes(self, w)
     }
 }
 
@@ -231,14 +219,7 @@ impl EpeeValue for Bytes {
     }
 
     fn write<B: BufMut>(self, w: &mut B) -> Result<()> {
-        write_varint(self.len().try_into()?, w)?;
-
-        if w.remaining_mut() < self.len() {
-            return Err(Error::IO("Not enough capacity to write bytes"));
-        }
-
-        w.put(self);
-        Ok(())
+        write_bytes(self, w)
     }
 }
 
@@ -274,14 +255,7 @@ impl EpeeValue for BytesMut {
     }
 
     fn write<B: BufMut>(self, w: &mut B) -> Result<()> {
-        write_varint(self.len().try_into()?, w)?;
-
-        if w.remaining_mut() < self.len() {
-            return Err(Error::IO("Not enough capacity to write bytes"));
-        }
-
-        w.put(self);
-        Ok(())
+        write_bytes(self, w)
     }
 }
 
@@ -316,15 +290,7 @@ impl<const N: usize> EpeeValue for ByteArrayVec<N> {
 
     fn write<B: BufMut>(self, w: &mut B) -> Result<()> {
         let bytes = self.take_bytes();
-
-        write_varint(bytes.len().try_into()?, w)?;
-
-        if w.remaining_mut() < bytes.len() {
-            return Err(Error::IO("Not enough capacity to write bytes"));
-        }
-
-        w.put(bytes);
-        Ok(())
+        write_bytes(bytes, w)
     }
 }
 
@@ -351,15 +317,7 @@ impl<const N: usize> EpeeValue for ByteArray<N> {
 
     fn write<B: BufMut>(self, w: &mut B) -> Result<()> {
         let bytes = self.take_bytes();
-
-        write_varint(N.try_into().unwrap(), w)?;
-
-        if w.remaining_mut() < N {
-            return Err(Error::IO("Not enough capacity to write bytes"));
-        }
-
-        w.put(bytes);
-        Ok(())
+        write_bytes(bytes, w)
     }
 }
 
@@ -380,14 +338,7 @@ impl EpeeValue for String {
     }
 
     fn write<B: BufMut>(self, w: &mut B) -> Result<()> {
-        write_varint(self.len().try_into()?, w)?;
-
-        if w.remaining_mut() < self.len() {
-            return Err(Error::IO("Not enough capacity to write bytes"));
-        }
-
-        w.put_slice(self.as_bytes());
-        Ok(())
+        write_bytes(self, w)
     }
 }
 
@@ -405,14 +356,7 @@ impl<const N: usize> EpeeValue for [u8; N] {
     }
 
     fn write<B: BufMut>(self, w: &mut B) -> Result<()> {
-        write_varint(self.len().try_into()?, w)?;
-
-        if w.remaining_mut() < self.len() {
-            return Err(Error::IO("Not enough capacity to write bytes"));
-        }
-
-        w.put_slice(&self);
-        Ok(())
+        write_bytes(self, w)
     }
 }
 
@@ -446,11 +390,7 @@ impl<const N: usize> EpeeValue for Vec<[u8; N]> {
     }
 
     fn write<B: BufMut>(self, w: &mut B) -> Result<()> {
-        write_varint(self.len().try_into()?, w)?;
-        for item in self.into_iter() {
-            item.write(w)?;
-        }
-        Ok(())
+        write_container(self.into_iter(), w)
     }
 }
 
@@ -486,11 +426,7 @@ macro_rules! epee_seq {
             }
 
             fn write<B: BufMut>(self, w: &mut B) -> Result<()> {
-                write_varint(self.len().try_into()?, w)?;
-                for item in self.into_iter() {
-                    item.write(w)?;
-                }
-                Ok(())
+                write_container(self.into_iter(), w)
             }
         }
 
@@ -508,11 +444,7 @@ macro_rules! epee_seq {
             }
 
             fn write<B: BufMut>(self, w: &mut B) -> Result<()> {
-                write_varint(self.len().try_into()?, w)?;
-                for item in self.into_iter() {
-                    item.write(w)?;
-                }
-                Ok(())
+                write_container(self.into_iter(), w)
             }
         }
     };

--- a/net/epee-encoding/src/varint.rs
+++ b/net/epee-encoding/src/varint.rs
@@ -7,6 +7,7 @@ const FITS_IN_ONE_BYTE: u64 = 2_u64.pow(8 - SIZE_OF_SIZE_MARKER) - 1;
 const FITS_IN_TWO_BYTES: u64 = 2_u64.pow(16 - SIZE_OF_SIZE_MARKER) - 1;
 const FITS_IN_FOUR_BYTES: u64 = 2_u64.pow(32 - SIZE_OF_SIZE_MARKER) - 1;
 
+/// Read a variable sized integer from `r`.
 pub fn read_varint<B: Buf>(r: &mut B) -> Result<u64> {
     if !r.has_remaining() {
         Err(Error::IO("Not enough bytes to build VarInt"))?
@@ -26,6 +27,7 @@ pub fn read_varint<B: Buf>(r: &mut B) -> Result<u64> {
     Ok(vi)
 }
 
+/// Write a variable sized integer into `w`.
 pub fn write_varint<B: BufMut>(number: u64, w: &mut B) -> Result<()> {
     let size_marker = match number {
         0..=FITS_IN_ONE_BYTE => 0,


### PR DESCRIPTION
- `epee_encoding::varint::{read,write}_varint()` is made public
- The duplicated inner implementations of some `EpeeValue` objects are extracted into `epee_encoding::write_{bytes,iterator}` and made public and generic

For example, a custom `EpeeValue` implementor can now do:
```rust
impl EpeeValue for CustomStr {
    /* ... */

    fn write<B: BufMut>(self, w: &mut B) -> Result<()> {
        epee_encoding::write_bytes(self, w)
    }
}
```