### PR TITLE
repo: add `.github/pull_request_template.md`

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,35 @@
+<!--
+PR titles should be:
+<AREA>: <SHORT_DESCRIPTION>
+
+For example:
+books: fix typo
+-->
+
+<!--
+If your pull request is long and/or has sections
+that need clarifying, consider leaving a review on
+your own PR with comments explaining the changes.
+-->
+
+### What
+<!--
+If applicable, close a related issue with:
+
+Fixes #<BUG_ISSUE_NUMBER>
+
+...or...
+
+Closes #<FEATURE_ISSUE_NUMBER>
+-->
+
+<!-- Describe the pull request in detail. -->
+
+### Why
+<!-- If applicable, describe why this pull request exists. -->
+
+### Where
+<!-- If applicable, describe the places this pull request affects. -->
+
+### How
+<!-- If applicable, describe how this pull request works. -->


### PR DESCRIPTION
The text inside `pull_request_template.md` auto-fills the description when creating the PRs.

Unfortunately I don't think pull request templates allow auto-filling title+label with nice menus like issues: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository.

Example: https://github.com/hinto-janai/labeler-test/compare/test?expand=1