### PR TITLE
Consensus: fix Rx VM initialization

### DIFF
--- a/consensus/src/block.rs
+++ b/consensus/src/block.rs
@@ -16,6 +16,7 @@ use rayon::prelude::*;
 use tower::{Service, ServiceExt};
 use tracing::instrument;
 
+use cuprate_consensus_rules::hard_forks::HardForkError;
 use cuprate_consensus_rules::{
     blocks::{
         calculate_pow_hash, check_block, check_block_pow, is_randomx_seed_height,
@@ -316,6 +317,10 @@ where
         + 'static,
     C::Future: Send + 'static,
 {
+    if blocks.is_empty() {
+        return Err(ExtendedConsensusError::NoBlocksToVerify);
+    }
+
     let (blocks, txs): (Vec<_>, Vec<_>) = blocks.into_iter().unzip();
 
     tracing::debug!("Calculating block hashes.");
@@ -326,6 +331,10 @@ where
             .collect::<Result<Vec<_>, _>>()
     })
     .await?;
+
+    // hard-forks cannot be reversed, so the last block will contain the highest hard fork (provided the
+    // batch is valid).
+    let top_hf_in_batch = blocks.last().unwrap().hf_version;
 
     // A Vec of (timestamp, HF) for each block to calculate the expected difficulty for each block.
     let mut timestamps_hfs = Vec::with_capacity(blocks.len());
@@ -338,6 +347,13 @@ where
         let block_0 = &window[0];
         let block_1 = &window[1];
 
+        // Make sure no blocks in the batch have a higher hard fork than the last block.
+        if block_0.hf_version > top_hf_in_batch {
+            Err(ConsensusError::Block(BlockError::HardForkError(
+                HardForkError::VersionIncorrect,
+            )))?;
+        }
+
         if block_0.block_hash != block_1.block.header.previous
             || block_0.height != block_1.height - 1
         {
@@ -346,7 +362,7 @@ where
         }
 
         // Cache any potential RX VM seeds as we may need them for future blocks in the batch.
-        if is_randomx_seed_height(block_0.height) {
+        if is_randomx_seed_height(block_0.height) && top_hf_in_batch >= HardFork::V12 {
             new_rx_vm = Some((block_0.height, block_0.block_hash));
         }
 
@@ -395,7 +411,20 @@ where
         Err(ConsensusError::Block(BlockError::PreviousIDIncorrect))?;
     }
 
-    let mut rx_vms = context.rx_vms;
+    let mut rx_vms = if top_hf_in_batch < HardFork::V12 {
+        HashMap::new()
+    } else {
+        let BlockChainContextResponse::RxVms(rx_vms) = context_svc
+            .ready()
+            .await?
+            .call(BlockChainContextRequest::GetCurrentRxVm)
+            .await?
+        else {
+            panic!("Blockchain context service returned wrong response!");
+        };
+
+        rx_vms
+    };
 
     // If we have a RX seed in the batch calculate it.
     if let Some((new_vm_height, new_vm_seed)) = new_rx_vm {
@@ -407,9 +436,7 @@ where
         .await;
 
         context_svc
-            .ready()
-            .await?
-            .call(BlockChainContextRequest::NewRXVM((
+            .oneshot(BlockChainContextRequest::NewRXVM((
                 new_vm_seed,
                 new_vm.clone(),
             )))
@@ -501,7 +528,21 @@ where
 
     // Set up the block and just pass it to [`verify_prepped_main_chain_block`]
 
-    let rx_vms = context.rx_vms.clone();
+    // We just use the raw `major_version` here, no need to turn it into a `HardFork`.
+    let rx_vms = if block.header.major_version < 12 {
+        HashMap::new()
+    } else {
+        let BlockChainContextResponse::RxVms(rx_vms) = context_svc
+            .ready()
+            .await?
+            .call(BlockChainContextRequest::GetCurrentRxVm)
+            .await?
+        else {
+            panic!("Blockchain context service returned wrong response!");
+        };
+
+        rx_vms
+    };
 
     let height = context.chain_height;
     let prepped_block = rayon_spawn_async(move || {

--- a/consensus/src/block.rs
+++ b/consensus/src/block.rs
@@ -16,12 +16,12 @@ use rayon::prelude::*;
 use tower::{Service, ServiceExt};
 use tracing::instrument;
 
-use cuprate_consensus_rules::hard_forks::HardForkError;
 use cuprate_consensus_rules::{
     blocks::{
         calculate_pow_hash, check_block, check_block_pow, is_randomx_seed_height,
         randomx_seed_height, BlockError, RandomX,
     },
+    hard_forks::HardForkError,
     miner_tx::MinerTxError,
     ConsensusError, HardFork,
 };

--- a/consensus/src/block.rs
+++ b/consensus/src/block.rs
@@ -317,9 +317,9 @@ where
         + 'static,
     C::Future: Send + 'static,
 {
-    if blocks.is_empty() {
+    let Some(last_block) = blocks.last() else {
         return Err(ExtendedConsensusError::NoBlocksToVerify);
-    }
+    };
 
     let (blocks, txs): (Vec<_>, Vec<_>) = blocks.into_iter().unzip();
 
@@ -334,7 +334,7 @@ where
 
     // hard-forks cannot be reversed, so the last block will contain the highest hard fork (provided the
     // batch is valid).
-    let top_hf_in_batch = blocks.last().unwrap().hf_version;
+    let top_hf_in_batch = last_block.hf_version;
 
     // A Vec of (timestamp, HF) for each block to calculate the expected difficulty for each block.
     let mut timestamps_hfs = Vec::with_capacity(blocks.len());

--- a/consensus/src/block.rs
+++ b/consensus/src/block.rs
@@ -317,10 +317,6 @@ where
         + 'static,
     C::Future: Send + 'static,
 {
-    let Some(last_block) = blocks.last() else {
-        return Err(ExtendedConsensusError::NoBlocksToVerify);
-    };
-
     let (blocks, txs): (Vec<_>, Vec<_>) = blocks.into_iter().unzip();
 
     tracing::debug!("Calculating block hashes.");
@@ -331,6 +327,10 @@ where
             .collect::<Result<Vec<_>, _>>()
     })
     .await?;
+
+    let Some(last_block) = blocks.last() else {
+        return Err(ExtendedConsensusError::NoBlocksToVerify);
+    };
 
     // hard-forks cannot be reversed, so the last block will contain the highest hard fork (provided the
     // batch is valid).

--- a/consensus/src/context/rx_vms.rs
+++ b/consensus/src/context/rx_vms.rs
@@ -125,64 +125,72 @@ impl RandomXVMCache {
     }
 
     /// Get the RandomX VMs.
-    pub fn get_vms(&self) -> HashMap<u64, Arc<RandomXVM>> {
+    pub async fn get_vms(&mut self) -> HashMap<u64, Arc<RandomXVM>> {
+        match self.seeds.len() - self.vms.len() {
+            // No difference in the amount of seeds to VMs.
+            0 => (),
+            // One more seed than VM.
+            1 => {
+                let (seed_height, next_seed_hash) = *self.seeds.front().unwrap();
+
+                let new_vm = 'new_vm_block: {
+                    tracing::debug!(
+                        "Initializing RandomX VM for seed: {}",
+                        hex::encode(next_seed_hash)
+                    );
+
+                    // Check if we have been given the RX VM from another part of Cuprate.
+                    if let Some((cached_hash, cached_vm)) = self.cached_vm.take() {
+                        if cached_hash == next_seed_hash {
+                            tracing::debug!("VM was already created.");
+                            break 'new_vm_block cached_vm;
+                        }
+                    };
+
+                    rayon_spawn_async(move || Arc::new(RandomXVM::new(&next_seed_hash).unwrap()))
+                        .await
+                };
+
+                self.vms.insert(seed_height, new_vm);
+            }
+            // More than one more seed than VM.
+            _ => {
+                // this will only happen when syncing and rx activates.
+                tracing::debug!("RandomX has activated, initialising VMs");
+
+                let seeds_clone = self.seeds.clone();
+                self.vms = rayon_spawn_async(move || {
+                    seeds_clone
+                        .par_iter()
+                        .map(|(height, seed)| {
+                            (
+                                *height,
+                                Arc::new(
+                                    RandomXVM::new(seed).expect("Failed to create RandomX VM!"),
+                                ),
+                            )
+                        })
+                        .collect()
+                })
+                .await
+            }
+        }
+
         self.vms.clone()
     }
 
     /// Add a new block to the VM cache.
     ///
     /// hash is the block hash not the blocks PoW hash.
-    pub async fn new_block(&mut self, height: u64, hash: &[u8; 32], hf: &HardFork) {
-        let should_make_vms = hf >= &HardFork::V12;
-        if should_make_vms && self.vms.len() != self.seeds.len() {
-            // this will only happen when syncing and rx activates.
-            tracing::debug!("RandomX has activated, initialising VMs");
-
-            let seeds_clone = self.seeds.clone();
-            self.vms = rayon_spawn_async(move || {
-                seeds_clone
-                    .par_iter()
-                    .map(|(height, seed)| {
-                        (
-                            *height,
-                            Arc::new(RandomXVM::new(seed).expect("Failed to create RandomX VM!")),
-                        )
-                    })
-                    .collect()
-            })
-            .await
-        }
-
+    pub fn new_block(&mut self, height: u64, hash: &[u8; 32]) {
         if is_randomx_seed_height(height) {
             tracing::debug!("Block {height} is a randomX seed height, adding it to the cache.",);
 
             self.seeds.push_front((height, *hash));
 
-            if should_make_vms {
-                let new_vm = 'new_vm_block: {
-                    tracing::debug!(
-                        "Past hard-fork 12 initializing VM for seed: {}",
-                        hex::encode(hash)
-                    );
-
-                    // Check if we have been given the RX VM from another part of Cuprate.
-                    if let Some((cached_hash, cached_vm)) = self.cached_vm.take() {
-                        if &cached_hash == hash {
-                            tracing::debug!("VM was already created.");
-                            break 'new_vm_block cached_vm;
-                        }
-                    };
-
-                    let hash_clone = *hash;
-                    rayon_spawn_async(move || Arc::new(RandomXVM::new(&hash_clone).unwrap())).await
-                };
-
-                self.vms.insert(height, new_vm);
-            }
-
             if self.seeds.len() > RX_SEEDS_CACHED {
                 self.seeds.pop_back();
-                // TODO: This is really not efficient but the amount of VMs cached is not a lot.
+                // HACK: This is really inefficient but the amount of VMs cached is not a lot.
                 self.vms.retain(|height, _| {
                     self.seeds
                         .iter()

--- a/consensus/src/context/rx_vms.rs
+++ b/consensus/src/context/rx_vms.rs
@@ -126,11 +126,11 @@ impl RandomXVMCache {
 
     /// Get the RandomX VMs.
     pub async fn get_vms(&mut self) -> HashMap<u64, Arc<RandomXVM>> {
-        match self.seeds.len() - self.vms.len() {
+        match self.seeds.len().checked_sub(self.vms.len()) {
             // No difference in the amount of seeds to VMs.
-            0 => (),
+            Some(0) => (),
             // One more seed than VM.
-            1 => {
+            Some(1) => {
                 let (seed_height, next_seed_hash) = *self.seeds.front().unwrap();
 
                 let new_vm = 'new_vm_block: {
@@ -166,7 +166,6 @@ impl RandomXVMCache {
                             let vm = RandomXVM::new(seed).expect("Failed to create RandomX VM!");
                             let vm = Arc::new(vm);
                             (*height, vm)
-                        })
                         })
                         .collect()
                 })

--- a/consensus/src/context/rx_vms.rs
+++ b/consensus/src/context/rx_vms.rs
@@ -163,12 +163,10 @@ impl RandomXVMCache {
                     seeds_clone
                         .par_iter()
                         .map(|(height, seed)| {
-                            (
-                                *height,
-                                Arc::new(
-                                    RandomXVM::new(seed).expect("Failed to create RandomX VM!"),
-                                ),
-                            )
+                            let vm = RandomXVM::new(seed).expect("Failed to create RandomX VM!");
+                            let vm = Arc::new(vm);
+                            (*height, vm)
+                        })
                         })
                         .collect()
                 })

--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -44,6 +44,9 @@ pub enum ExtendedConsensusError {
     /// One or more statements in the batch verifier was invalid.
     #[error("One or more statements in the batch verifier was invalid.")]
     OneOrMoreBatchVerificationStatementsInvalid,
+    /// A request to verify a batch of blocks had no blocks in the batch.
+    #[error("A request to verify a batch of blocks had no blocks in the batch.")]
+    NoBlocksToVerify,
 }
 
 /// Initialize the 2 verifier [`tower::Service`]s (block and transaction).

--- a/consensus/src/tests/context/rx_vms.rs
+++ b/consensus/src/tests/context/rx_vms.rs
@@ -47,7 +47,9 @@ async fn rx_vm_created_on_hf_12() {
         .unwrap();
 
     assert!(cache.vms.is_empty());
-    cache.new_block(11, &[30; 32], &HardFork::V12).await;
+    cache.new_block(11, &[30; 32]);
+    cache.get_vms().await;
+
     assert!(!cache.vms.is_empty());
 }
 


### PR DESCRIPTION

### What

Currently RandomX VM initialization is broken, specifically if you request to verify a batch of blocks and RX activates somewhere in the batch and the RX seed height is outside the batch, the VM wont be initialized and we will panic.

### How

I separated RX VMs from the rest of the context service, this will also benefit fast sync as we no longer need to initialize VMs unless specifically requested. 
