### PR TITLE
P2P: Fix freeze in D++

### DIFF
--- a/p2p/dandelion-tower/Cargo.toml
+++ b/p2p/dandelion-tower/Cargo.toml
@@ -10,7 +10,7 @@ default = ["txpool"]
 txpool = ["dep:rand_distr", "dep:tokio-util", "dep:tokio"]
 
 [dependencies]
-tower = { workspace = true, features = ["discover", "util"] }
+tower = { workspace = true, features = ["util"] }
 tracing = { workspace = true, features = ["std"] }
 
 futures = { workspace = true, features = ["std"] }

--- a/p2p/dandelion-tower/src/lib.rs
+++ b/p2p/dandelion-tower/src/lib.rs
@@ -26,9 +26,9 @@
 //! The diffuse service should have a request of [`DiffuseRequest`](traits::DiffuseRequest) and it's error
 //! should be [`tower::BoxError`].
 //!
-//! ## Outbound Peer Discoverer
+//! ## Outbound Peer TryStream
 //!
-//! The outbound peer [`Discover`](tower::discover::Discover) should provide a stream of randomly selected outbound
+//! The outbound peer [`TryStream`](futures::TryStream) should provide a stream of randomly selected outbound
 //! peers, these peers will then be used to route stem txs to.
 //!
 //! The peers will not be returned anywhere, so it is recommended to wrap them in some sort of drop guard that returns
@@ -37,10 +37,10 @@
 //! ## Peer Service
 //!
 //! This service represents a connection to an individual peer, this should be returned from the Outbound Peer
-//! Discover. This should immediately send the transaction to the peer when requested, i.e. it should _not_ set
+//! TryStream. This should immediately send the transaction to the peer when requested, it should _not_ set
 //! a timer.
 //!
-//! The diffuse service should have a request of [`StemRequest`](traits::StemRequest) and it's error
+//! The peer service should have a request of [`StemRequest`](traits::StemRequest) and it's error
 //! should be [`tower::BoxError`].
 //!
 //! ## Backing Pool

--- a/p2p/dandelion-tower/src/lib.rs
+++ b/p2p/dandelion-tower/src/lib.rs
@@ -40,7 +40,7 @@
 //! TryStream. This should immediately send the transaction to the peer when requested, it should _not_ set
 //! a timer.
 //!
-//! The peer service should have a request of [`StemRequest`](traits::StemRequest) and it's error
+//! The peer service should have a request of [`StemRequest`](traits::StemRequest) and its error
 //! should be [`tower::BoxError`].
 //!
 //! ## Backing Pool

--- a/p2p/dandelion-tower/src/router.rs
+++ b/p2p/dandelion-tower/src/router.rs
@@ -10,7 +10,6 @@
 //!
 use std::{
     collections::HashMap,
-    future::Future,
     hash::Hash,
     marker::PhantomData,
     pin::Pin,
@@ -18,12 +17,9 @@ use std::{
     time::Instant,
 };
 
-use futures::{future::BoxFuture, FutureExt, Stream, StreamExt, TryFutureExt, TryStream};
+use futures::{future::BoxFuture, FutureExt, TryFutureExt, TryStream};
 use rand::{distributions::Bernoulli, prelude::*, thread_rng};
-use tower::{
-    discover::{Change, Discover},
-    Service,
-};
+use tower::Service;
 
 use crate::{
     traits::{DiffuseRequest, StemRequest},

--- a/p2p/dandelion-tower/src/router.rs
+++ b/p2p/dandelion-tower/src/router.rs
@@ -40,9 +40,9 @@ pub enum DandelionRouterError {
     /// The broadcast service returned an error.
     #[error("Broadcast service returned an err: {0}.")]
     BroadcastError(tower::BoxError),
-    /// The outbound peer discoverer returned an error, this is critical.
-    #[error("The outbound peer discoverer returned an err: {0}.")]
-    OutboundPeerDiscoverError(tower::BoxError),
+    /// The outbound peer stream returned an error, this is critical.
+    #[error("The outbound peer stream returned an err: {0}.")]
+    OutboundPeerStreamError(tower::BoxError),
     /// The outbound peer discoverer returned [`None`].
     #[error("The outbound peer discoverer exited.")]
     OutboundPeerDiscoverExited,
@@ -177,7 +177,7 @@ where
                 .outbound_peer_discover
                 .as_mut()
                 .try_poll_next(cx)
-                .map_err(DandelionRouterError::OutboundPeerDiscoverError))
+                .map_err(DandelionRouterError::OutboundPeerStreamError))
             .ok_or(DandelionRouterError::OutboundPeerDiscoverExited)??
             {
                 OutboundPeer::Peer(key, svc) => {

--- a/p2p/dandelion-tower/src/router.rs
+++ b/p2p/dandelion-tower/src/router.rs
@@ -18,8 +18,7 @@ use std::{
     time::Instant,
 };
 
-use futures::future::BoxFuture;
-use futures::{FutureExt, Stream, StreamExt, TryFutureExt, TryStream};
+use futures::{future::BoxFuture, FutureExt, Stream, StreamExt, TryFutureExt, TryStream};
 use rand::{distributions::Bernoulli, prelude::*, thread_rng};
 use tower::{
     discover::{Change, Discover},


### PR DESCRIPTION

### What

Fixes: #177 

This prevent freezing in the d++ router by changing the peer discover to a stream that returns an enum with a variant to tell the router there are no more outbound peers.