### PR TITLE
P2P: fix block downloader test 

### DIFF
--- a/p2p/p2p/src/block_downloader/tests.rs
+++ b/p2p/p2p/src/block_downloader/tests.rs
@@ -95,7 +95,7 @@ prop_compose! {
     fn dummy_transaction_stragtegy(height: u64)
         (
             extra in vec(any::<u8>(), 0..1_000),
-            timelock in 0_usize..50_000_000,
+            timelock in 1_usize..50_000_000,
         )
     -> Transaction {
         Transaction {


### PR DESCRIPTION

### What

Fixes the fail here: https://github.com/Cuprate/cuprate/actions/runs/9732240689/job/26857645273

Changes the test to never generate a zero timelock as that gets interpreted as `None` instead of `Block` e deserialized. 