### PR TITLE
Storage: add blockchain history requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -506,6 +506,7 @@ dependencies = [
  "monero-serai",
  "paste",
  "pretty_assertions",
+ "proptest",
  "rayon",
  "tempfile",
  "thread_local",

--- a/p2p/p2p/src/block_downloader.rs
+++ b/p2p/p2p/src/block_downloader.rs
@@ -121,7 +121,7 @@ pub enum ChainSvcResponse {
     /// The response for [`ChainSvcRequest::FindFirstUnknown`].
     ///
     /// Contains the index of the first unknown block and its expected height.
-    FindFirstUnknown(usize, u64),
+    FindFirstUnknown(Option<(usize, u64)>),
     /// The response for [`ChainSvcRequest::CumulativeDifficulty`].
     ///
     /// The current cumulative difficulty of our chain.

--- a/p2p/p2p/src/block_downloader/tests.rs
+++ b/p2p/p2p/src/block_downloader/tests.rs
@@ -314,7 +314,9 @@ impl Service<ChainSvcRequest> for OurChainSvc {
                     block_ids: vec![genesis],
                     cumulative_difficulty: 1,
                 },
-                ChainSvcRequest::FindFirstUnknown(_) => ChainSvcResponse::FindFirstUnknown(1, 1),
+                ChainSvcRequest::FindFirstUnknown(_) => {
+                    ChainSvcResponse::FindFirstUnknown(Some((1, 1)))
+                }
                 ChainSvcRequest::CumulativeDifficulty => ChainSvcResponse::CumulativeDifficulty(1),
             })
         }

--- a/storage/blockchain/Cargo.toml
+++ b/storage/blockchain/Cargo.toml
@@ -45,8 +45,8 @@ rayon        = { workspace = true, optional = true }
 cuprate-helper     = { path = "../../helper", features = ["thread"] }
 cuprate-test-utils = { path = "../../test-utils" }
 
-bytemuck          = { version = "1.14.3", features = ["must_cast", "derive", "min_const_generics", "extern_crate_alloc"] }
 tempfile          = { version = "3.10.0" }
 pretty_assertions = { workspace = true }
+proptest          = { workspace = true }
 hex               = { workspace = true }
 hex-literal       = { workspace = true }

--- a/storage/blockchain/src/service/free.rs
+++ b/storage/blockchain/src/service/free.rs
@@ -59,10 +59,10 @@ pub(crate) fn compact_history_genesis_not_included<const INITIAL_BLOCKS: u64>(
     // Otherwise, we use the fact that to reach the genesis block this statement must be true (for a
     // single `i`):
     //
-    // `chain_height - INITIAL_BLOCKS - 2^i + 2 = 0`
+    // `top_block_height - INITIAL_BLOCKS - 2^i + 2 == 0`
     // which then means:
-    // `chain_height - INITIAL_BLOCKS + 2 = 2^i`
-    // So if `chain_height - INITIAL_BLOCKS + 2` is a power of 2 then the genesis block is in
+    // `top_block_height - INITIAL_BLOCKS + 2 == 2^i`
+    // So if `top_block_height - INITIAL_BLOCKS + 2` is a power of 2 then the genesis block is in
     // the compact history already.
     top_block_height > INITIAL_BLOCKS && !(top_block_height - INITIAL_BLOCKS + 2).is_power_of_two()
 }
@@ -71,13 +71,13 @@ pub(crate) fn compact_history_genesis_not_included<const INITIAL_BLOCKS: u64>(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
     use proptest::prelude::*;
+
+    use super::*;
 
     proptest! {
         #[test]
-        fn compact_history_always_includes_genesis(top_height in 0_u64..500_000_000) {
+        fn compact_history(top_height in 0_u64..500_000_000) {
             let mut heights = (0..)
                 .map(compact_history_index_to_height_offset::<11>)
                 .map_while(|i| top_height.checked_sub(i))
@@ -87,6 +87,7 @@ mod tests {
                 heights.push(0);
             }
 
+            // Make sure the genesis and top block are always included.
             assert_eq!(*heights.last().unwrap(), 0);
             assert_eq!(*heights.first().unwrap(), top_height);
 

--- a/storage/blockchain/src/service/free.rs
+++ b/storage/blockchain/src/service/free.rs
@@ -33,11 +33,14 @@ pub fn init(config: Config) -> Result<(DatabaseReadHandle, DatabaseWriteHandle),
     Ok((readers, writer))
 }
 
+//---------------------------------------------------------------------------------------------------- Compact history
 /// Given a position in the compact history, returns the height offset that should be in that position.
 ///
 /// The height offset is the difference between the top block's height and the block height that should be in that position.
 #[inline]
-pub(crate) fn compact_history_index_to_height_offset<const INITIAL_BLOCKS: u64>(i: u64) -> u64 {
+pub(super) const fn compact_history_index_to_height_offset<const INITIAL_BLOCKS: u64>(
+    i: u64,
+) -> u64 {
     // If the position is below the initial blocks just return the position back
     if i <= INITIAL_BLOCKS {
         i
@@ -52,7 +55,7 @@ pub(crate) fn compact_history_index_to_height_offset<const INITIAL_BLOCKS: u64>(
 ///
 /// The genesis must always be included in the compact history.
 #[inline]
-pub(crate) fn compact_history_genesis_not_included<const INITIAL_BLOCKS: u64>(
+pub(super) const fn compact_history_genesis_not_included<const INITIAL_BLOCKS: u64>(
     top_block_height: u64,
 ) -> bool {
     // If the top block height is less than the initial blocks then it will always be included.

--- a/storage/blockchain/src/service/free.rs
+++ b/storage/blockchain/src/service/free.rs
@@ -47,6 +47,7 @@ pub(super) const fn compact_history_index_to_height_offset<const INITIAL_BLOCKS:
     } else {
         // Otherwise we go with power of 2 offsets, the same as monerod.
         // So (INITIAL_BLOCKS + 2), (INITIAL_BLOCKS + 2 + 4), (INITIAL_BLOCKS + 2 + 4 + 8)
+        // ref: <https://github.com/monero-project/monero/blob/cc73fe71162d564ffda8e549b79a350bca53c454/src/cryptonote_core/blockchain.cpp#L727>
         INITIAL_BLOCKS + (2 << (i - INITIAL_BLOCKS)) - 2
     }
 }

--- a/storage/blockchain/src/service/read.rs
+++ b/storage/blockchain/src/service/read.rs
@@ -215,7 +215,7 @@ fn map_request(
         R::NumberOutputsWithAmount(vec) => number_outputs_with_amount(env, vec),
         R::KeyImagesSpent(set) => key_images_spent(env, set),
         R::CompactChainHistory => compact_chain_history(env),
-        R::FindFirstUnknown(block_ids) => find_first_unknown(env, block_ids),
+        R::FindFirstUnknown(block_ids) => find_first_unknown(env, &block_ids),
     };
 
     if let Err(e) = response_sender.send(response) {
@@ -567,7 +567,7 @@ fn compact_chain_history(env: &ConcreteEnv) -> ResponseResult {
 }
 
 /// [`BCReadRequest::FindFirstUnknown`]
-fn find_first_unknown(env: &ConcreteEnv, block_ids: Vec<BlockHash>) -> ResponseResult {
+fn find_first_unknown(env: &ConcreteEnv, block_ids: &[BlockHash]) -> ResponseResult {
     let env_inner = env.env_inner();
     let tx_ro = env_inner.tx_ro()?;
 

--- a/storage/blockchain/src/service/read.rs
+++ b/storage/blockchain/src/service/read.rs
@@ -207,7 +207,7 @@ fn map_request(
     let response = match request {
         R::BlockExtendedHeader(block) => block_extended_header(env, block),
         R::BlockHash(block) => block_hash(env, block),
-        R::FilterUnknownHashes(hashes) => filter_unknown_hahses(env, hashes),
+        R::FilterUnknownHashes(hashes) => filter_unknown_hashes(env, hashes),
         R::BlockExtendedHeaderInRange(range) => block_extended_header_in_range(env, range),
         R::ChainHeight => chain_height(env),
         R::GeneratedCoins => generated_coins(env),
@@ -325,7 +325,7 @@ fn block_hash(env: &ConcreteEnv, block_height: BlockHeight) -> ResponseResult {
 
 /// [`BCReadRequest::FilterUnknownHashes`].
 #[inline]
-fn filter_unknown_hahses(env: &ConcreteEnv, mut hashes: HashSet<BlockHash>) -> ResponseResult {
+fn filter_unknown_hashes(env: &ConcreteEnv, mut hashes: HashSet<BlockHash>) -> ResponseResult {
     // Single-threaded, no `ThreadLocal` required.
     let env_inner = env.env_inner();
     let tx_ro = env_inner.tx_ro()?;

--- a/storage/blockchain/src/service/read.rs
+++ b/storage/blockchain/src/service/read.rs
@@ -550,6 +550,7 @@ fn compact_chain_history(env: &ConcreteEnv) -> ResponseResult {
     /// The amount of top block IDs in the compact chain.
     const INITIAL_BLOCKS: u64 = 11;
 
+    // rayon is not used here because the amount of block IDs is expected to be small.
     let mut block_ids = (0..)
         .map(compact_history_index_to_height_offset::<INITIAL_BLOCKS>)
         .map_while(|i| top_block_height.checked_sub(i))

--- a/storage/blockchain/src/service/read.rs
+++ b/storage/blockchain/src/service/read.rs
@@ -567,6 +567,11 @@ fn compact_chain_history(env: &ConcreteEnv) -> ResponseResult {
 }
 
 /// [`BCReadRequest::FindFirstUnknown`]
+///
+/// # Invariant
+/// `block_ids` must be sorted in chronological block order, or else
+/// the returned result is unspecified and meaningless, as this function
+/// performs a binary search.
 fn find_first_unknown(env: &ConcreteEnv, block_ids: &[BlockHash]) -> ResponseResult {
     let env_inner = env.env_inner();
     let tx_ro = env_inner.tx_ro()?;

--- a/storage/blockchain/src/service/read.rs
+++ b/storage/blockchain/src/service/read.rs
@@ -14,20 +14,19 @@ use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 use tokio_util::sync::PollSemaphore;
 
 use cuprate_database::{ConcreteEnv, DatabaseRo, Env, EnvInner, RuntimeError};
-use cuprate_helper::asynch::InfallibleOneshotReceiver;
-use cuprate_helper::map::combine_low_high_bits_to_u128;
+use cuprate_helper::{asynch::InfallibleOneshotReceiver, map::combine_low_high_bits_to_u128};
 use cuprate_types::{
     blockchain::{BCReadRequest, BCResponse},
     ExtendedBlockHeader, OutputOnChain,
 };
 
-use crate::ops::block::get_block_height;
 use crate::{
     config::ReaderThreads,
     open_tables::OpenTables,
-    ops::block::block_exists,
     ops::{
-        block::{get_block_extended_header_from_height, get_block_info},
+        block::{
+            block_exists, get_block_extended_header_from_height, get_block_height, get_block_info,
+        },
         blockchain::{cumulative_generated_coins, top_block_height},
         key_image::key_image_exists,
         output::id_to_output_on_chain,
@@ -37,8 +36,7 @@ use crate::{
         types::{ResponseReceiver, ResponseResult, ResponseSender},
     },
     tables::{BlockHeights, BlockInfos, Tables},
-    types::BlockHash,
-    types::{Amount, AmountIndex, BlockHeight, KeyImage, PreRctOutputId},
+    types::{Amount, AmountIndex, BlockHash, BlockHeight, KeyImage, PreRctOutputId},
 };
 
 //---------------------------------------------------------------------------------------------------- DatabaseReadHandle
@@ -552,7 +550,7 @@ fn compact_chain_history(env: &ConcreteEnv) -> ResponseResult {
     /// The amount of top block IDs in the compact chain.
     const INITIAL_BLOCKS: u64 = 11;
 
-    let mut block_ids = (0_u64..)
+    let mut block_ids = (0..)
         .map(compact_history_index_to_height_offset::<INITIAL_BLOCKS>)
         .map_while(|i| top_block_height.checked_sub(i))
         .map(|height| Ok(get_block_info(&height, &table_block_infos)?.block_hash))

--- a/types/src/blockchain.rs
+++ b/types/src/blockchain.rs
@@ -83,10 +83,16 @@ pub enum BCReadRequest {
     /// The input is a list of output amounts.
     NumberOutputsWithAmount(Vec<u64>),
 
-    /// Check that all key images within a set arer not spent.
+    /// Check that all key images within a set are not spent.
     ///
     /// Input is a set of key images.
     KeyImagesSpent(HashSet<[u8; 32]>),
+
+    /// A request for the compact chain history
+    CompactChainHistory,
+
+    /// A request to find the first unknown block ID in a list of block IDs.
+    FindFirstUnknown(Vec<[u8; 32]>),
 }
 
 //---------------------------------------------------------------------------------------------------- WriteRequest
@@ -163,6 +169,21 @@ pub enum BCResponse {
     ///
     /// The inner value is `false` if _none_ of the key images were spent.
     KeyImagesSpent(bool),
+
+    /// Response to [`BCReadRequest::CompactChainHistory`].
+    CompactChainHistory {
+        /// A list of blocks IDs in our chain, starting with the most recent block, all the way to the genesis block.
+        ///
+        /// These blocks should be in reverse chronological order, not every block is needed.
+        block_ids: Vec<[u8; 32]>,
+        /// The current cumulative difficulty of the chain.
+        cumulative_difficulty: u128,
+    },
+
+    /// The response for [`BCReadRequest::FindFirstUnknown`].
+    ///
+    /// Contains the index of the first unknown block and its expected height.
+    FindFirstUnknown(Option<(usize, u64)>),
 
     //------------------------------------------------------ Writes
     /// Response to [`BCWriteRequest::WriteBlock`].

--- a/types/src/blockchain.rs
+++ b/types/src/blockchain.rs
@@ -88,7 +88,7 @@ pub enum BCReadRequest {
     /// Input is a set of key images.
     KeyImagesSpent(HashSet<[u8; 32]>),
 
-    /// A request for the compact chain history
+    /// A request for the compact chain history.
     CompactChainHistory,
 
     /// A request to find the first unknown block ID in a list of block IDs.
@@ -183,6 +183,8 @@ pub enum BCResponse {
     /// The response for [`BCReadRequest::FindFirstUnknown`].
     ///
     /// Contains the index of the first unknown block and its expected height.
+    ///
+    /// This will be [`None`] if all blocks were known.
     FindFirstUnknown(Option<(usize, u64)>),
 
     //------------------------------------------------------ Writes

--- a/types/src/blockchain.rs
+++ b/types/src/blockchain.rs
@@ -92,6 +92,11 @@ pub enum BCReadRequest {
     CompactChainHistory,
 
     /// A request to find the first unknown block ID in a list of block IDs.
+    ////
+    /// # Invariant
+    /// The [`Vec`] containing the block IDs must be sorted in chronological block
+    /// order, or else the returned response is unspecified and meaningless,
+    /// as this request performs a binary search.
     FindFirstUnknown(Vec<[u8; 32]>),
 }
 


### PR DESCRIPTION

### What

Adds the DB requests and handlers for blockchain history, this history is sent to peers so they can send us their chain to sync from.

### How

Uses the same technique as monerod, choosing the first 11 blocks from the top of the chain and then power of 2 offsets from there.
