### PR TITLE
rpc: add feature flags

### DIFF
--- a/rpc/types/Cargo.toml
+++ b/rpc/types/Cargo.toml
@@ -9,14 +9,19 @@ repository  = "https://github.com/Cuprate/cuprate/tree/main/rpc/types"
 keywords    = ["cuprate", "rpc", "types", "monero"]
 
 [features]
-default = []
+default = ["json", "bin", "other", "serde", "epee"]
+json    = []
+bin     = []
+other   = []
+serde   = ["dep:serde"]
+epee    = ["dep:cuprate-epee-encoding"]
 
 [dependencies]
-cuprate-epee-encoding = { path = "../../net/epee-encoding" }
+cuprate-epee-encoding = { path = "../../net/epee-encoding", optional = true }
 
 monero-serai = { workspace = true }
 paste        = { workspace = true }
-serde        = { workspace = true }
+serde        = { workspace = true, optional = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }

--- a/rpc/types/README.md
+++ b/rpc/types/README.md
@@ -60,3 +60,16 @@ values inside JSON strings, for example:
 `binary` here is (de)serialized as a normal [`String`]. In order to be clear on which fields contain binary data, the struct fields that have them will use [`crate::BinaryString`] instead of [`String`].
 
 TODO: list the specific types.
+
+# Feature flags
+List of feature flags for `cuprate-rpc-types`.
+
+All are enabled by default.
+
+| Feature flag | Does what |
+|--------------|-----------|
+| `json`       | Enables the [`crate::json`] module
+| `bin`        | Enables the [`crate::bin`] module
+| `other`      | Enables the [`crate::other`] module
+| `serde`      | Implements `serde` on all types
+| `epee`       | Implements `epee_encoding` on all types

--- a/rpc/types/README.md
+++ b/rpc/types/README.md
@@ -68,8 +68,8 @@ All are enabled by default.
 
 | Feature flag | Does what |
 |--------------|-----------|
-| `json`       | Enables the [`crate::json`] module
-| `bin`        | Enables the [`crate::bin`] module
-| `other`      | Enables the [`crate::other`] module
+| `json`       | Enables the `crate::json` module
+| `bin`        | Enables the `crate::bin` module
+| `other`      | Enables the `crate::other` module
 | `serde`      | Implements `serde` on all types
-| `epee`       | Implements `epee_encoding` on all types
+| `epee`       | Implements `cuprate_epee_encoding` on all types

--- a/rpc/types/src/base.rs
+++ b/rpc/types/src/base.rs
@@ -39,7 +39,7 @@ macro_rules! monero_rpc_base_link {
 ///
 #[doc = monero_rpc_base_link!(95..=99)]
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct EmptyRequestBase;
 
 #[cfg(feature = "epee")]
@@ -51,7 +51,7 @@ epee_object! {
 ///
 #[doc = monero_rpc_base_link!(114..=122)]
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct AccessRequestBase {
     /// The RPC payment client.
     pub client: String,
@@ -70,7 +70,7 @@ epee_object! {
 /// any extra fields, e.g. TODO.
 // [`CalcPowResponse`](crate::json::CalcPowResponse).
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct EmptyResponseBase;
 
 #[cfg(feature = "epee")]
@@ -82,7 +82,7 @@ epee_object! {
 ///
 #[doc = monero_rpc_base_link!(101..=112)]
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct ResponseBase {
     /// General RPC error code. [`Status::Ok`] means everything looks good.
     pub status: Status,
@@ -103,7 +103,7 @@ epee_object! {
 ///
 #[doc = monero_rpc_base_link!(124..=136)]
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct AccessResponseBase {
     /// A flattened [`ResponseBase`].
     #[cfg_attr(feature = "serde", serde(flatten))]

--- a/rpc/types/src/base.rs
+++ b/rpc/types/src/base.rs
@@ -12,8 +12,10 @@
 //! - <https://github.com/monero-project/monero/pull/8843>
 
 //---------------------------------------------------------------------------------------------------- Import
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
+#[cfg(feature = "epee")]
 use cuprate_epee_encoding::epee_object;
 
 use crate::Status;
@@ -36,25 +38,27 @@ macro_rules! monero_rpc_base_link {
 /// The most common base for responses (nothing).
 ///
 #[doc = monero_rpc_base_link!(95..=99)]
-#[derive(
-    Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize,
-)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct EmptyRequestBase;
 
-cuprate_epee_encoding::epee_object! {
+#[cfg(feature = "epee")]
+epee_object! {
     EmptyRequestBase,
 }
 
 /// A base for RPC request types that support RPC payment.
 ///
 #[doc = monero_rpc_base_link!(114..=122)]
-#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AccessRequestBase {
     /// The RPC payment client.
     pub client: String,
 }
 
-cuprate_epee_encoding::epee_object! {
+#[cfg(feature = "epee")]
+epee_object! {
     AccessRequestBase,
     client: String,
 }
@@ -65,21 +69,20 @@ cuprate_epee_encoding::epee_object! {
 /// This is for response types that do not contain
 /// any extra fields, e.g. TODO.
 // [`CalcPowResponse`](crate::json::CalcPowResponse).
-#[derive(
-    Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize,
-)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct EmptyResponseBase;
 
-cuprate_epee_encoding::epee_object! {
+#[cfg(feature = "epee")]
+epee_object! {
     EmptyResponseBase,
 }
 
 /// The most common base for responses.
 ///
 #[doc = monero_rpc_base_link!(101..=112)]
-#[derive(
-    Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize,
-)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ResponseBase {
     /// General RPC error code. [`Status::Ok`] means everything looks good.
     pub status: Status,
@@ -89,6 +92,7 @@ pub struct ResponseBase {
     pub untrusted: bool,
 }
 
+#[cfg(feature = "epee")]
 epee_object! {
     ResponseBase,
     status: Status,
@@ -98,10 +102,11 @@ epee_object! {
 /// A base for RPC response types that support RPC payment.
 ///
 #[doc = monero_rpc_base_link!(124..=136)]
-#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AccessResponseBase {
     /// A flattened [`ResponseBase`].
-    #[serde(flatten)]
+    #[cfg_attr(feature = "serde", serde(flatten))]
     pub response_base: ResponseBase,
     /// If payment for RPC is enabled, the number of credits
     /// available to the requesting client. Otherwise, `0`.
@@ -111,6 +116,7 @@ pub struct AccessResponseBase {
     pub top_hash: String,
 }
 
+#[cfg(feature = "epee")]
 epee_object! {
     AccessResponseBase,
     credits: u64,

--- a/rpc/types/src/json.rs
+++ b/rpc/types/src/json.rs
@@ -113,11 +113,11 @@ define_request_and_response! {
     OnGetBlockHash,
     #[derive(Copy)]
     EmptyRequestBase {
-        #[serde(flatten)]
+        #[cfg_attr(feature = "serde", serde(flatten))]
         block_height: u64,
     },
     EmptyResponseBase {
-        #[serde(flatten)]
+        #[cfg_attr(feature = "serde", serde(flatten))]
         block_hash: String,
     }
 }

--- a/rpc/types/src/lib.rs
+++ b/rpc/types/src/lib.rs
@@ -1,4 +1,5 @@
 #![doc = include_str!("../README.md")]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 //---------------------------------------------------------------------------------------------------- Lints
 // Forbid lints.
 // Our code, and code generated (e.g macros) cannot overrule these.
@@ -111,6 +112,12 @@ pub use constants::{
 pub use status::Status;
 
 pub mod base;
+#[cfg(feature = "bin")]
+#[cfg_attr(docsrs, doc(cfg(feature = "bin")))]
 pub mod bin;
+#[cfg(feature = "json")]
+#[cfg_attr(docsrs, doc(cfg(feature = "json")))]
 pub mod json;
+#[cfg(feature = "other")]
+#[cfg_attr(docsrs, doc(cfg(feature = "other")))]
 pub mod other;

--- a/rpc/types/src/macros.rs
+++ b/rpc/types/src/macros.rs
@@ -87,7 +87,7 @@ macro_rules! define_request_and_response {
 
         #[allow(dead_code)]
         #[allow(missing_docs)]
-        #[derive(serde::Serialize, serde::Deserialize)]
+        #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
         #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
         $( #[$response_type_attr] )*
         #[doc = $crate::macros::define_request_and_response_doc!(
@@ -101,7 +101,7 @@ macro_rules! define_request_and_response {
             [<$type_name Response>],
         )]
         pub struct [<$type_name Response>] {
-            #[serde(flatten)]
+            #[cfg_attr(feature = "serde", serde(flatten))]
             pub base: $response_base_type,
 
             $(
@@ -110,6 +110,7 @@ macro_rules! define_request_and_response {
             )*
         }
 
+        #[cfg(feature = "epee")]
         ::cuprate_epee_encoding::epee_object! {
             [<$type_name Response>],
             $(
@@ -158,7 +159,7 @@ macro_rules! define_request_and_response {
     ) => { paste::paste! {
         #[allow(dead_code)]
         #[allow(missing_docs)]
-        #[derive(serde::Serialize, serde::Deserialize)]
+        #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
         #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
         $( #[$request_type_attr] )*
         #[doc = $crate::macros::define_request_and_response_doc!(
@@ -172,7 +173,7 @@ macro_rules! define_request_and_response {
             [<$type_name Request>],
         )]
         pub struct [<$type_name Request>] {
-            #[serde(flatten)]
+            #[cfg_attr(feature = "serde", serde(flatten))]
             pub base: $request_base_type,
 
             $(
@@ -181,6 +182,7 @@ macro_rules! define_request_and_response {
             )*
         }
 
+        #[cfg(feature = "epee")]
         ::cuprate_epee_encoding::epee_object! {
             [<$type_name Request>],
             $(
@@ -191,7 +193,7 @@ macro_rules! define_request_and_response {
 
         #[allow(dead_code)]
         #[allow(missing_docs)]
-        #[derive(serde::Serialize, serde::Deserialize)]
+        #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
         #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
         $( #[$response_type_attr] )*
         #[doc = $crate::macros::define_request_and_response_doc!(
@@ -205,7 +207,7 @@ macro_rules! define_request_and_response {
             [<$type_name Response>],
         )]
         pub struct [<$type_name Response>] {
-            #[serde(flatten)]
+            #[cfg_attr(feature = "serde", serde(flatten))]
             pub base: $response_base_type,
 
             $(
@@ -214,6 +216,7 @@ macro_rules! define_request_and_response {
             )*
         }
 
+        #[cfg(feature = "epee")]
         ::cuprate_epee_encoding::epee_object! {
             [<$type_name Response>],
             $(

--- a/rpc/types/src/status.rs
+++ b/rpc/types/src/status.rs
@@ -62,7 +62,7 @@ use crate::constants::{
 /// assert_eq!(format!("{:?}", unknown),                 "Unknown");
 /// ```
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum Status {
     // FIXME:
     // `#[serde(rename = "")]` only takes raw string literals?

--- a/rpc/types/src/status.rs
+++ b/rpc/types/src/status.rs
@@ -3,8 +3,10 @@
 //---------------------------------------------------------------------------------------------------- Import
 use std::fmt::Display;
 
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
+#[cfg(feature = "epee")]
 use cuprate_epee_encoding::{
     macros::bytes::{Buf, BufMut},
     EpeeValue, Marker,
@@ -59,28 +61,27 @@ use crate::constants::{
 /// assert_eq!(format!("{:?}", Status::PaymentRequired), "PaymentRequired");
 /// assert_eq!(format!("{:?}", unknown),                 "Unknown");
 /// ```
-#[derive(
-    Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize,
-)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Status {
     // FIXME:
     // `#[serde(rename = "")]` only takes raw string literals?
     // We have to re-type the constants here...
     /// Successful RPC response, everything is OK; [`CORE_RPC_STATUS_OK`].
-    #[serde(rename = "OK")]
+    #[cfg_attr(feature = "serde", serde(rename = "OK"))]
     #[default]
     Ok,
 
     /// The daemon is busy, try later; [`CORE_RPC_STATUS_BUSY`].
-    #[serde(rename = "BUSY")]
+    #[cfg_attr(feature = "serde", serde(rename = "BUSY"))]
     Busy,
 
     /// The daemon is not mining; [`CORE_RPC_STATUS_NOT_MINING`].
-    #[serde(rename = "NOT MINING")]
+    #[cfg_attr(feature = "serde", serde(rename = "NOT MINING"))]
     NotMining,
 
     /// Payment is required for RPC; [`CORE_RPC_STATUS_PAYMENT_REQUIRED`].
-    #[serde(rename = "PAYMENT REQUIRED")]
+    #[cfg_attr(feature = "serde", serde(rename = "PAYMENT REQUIRED"))]
     PaymentRequired,
 
     /// Some unknown other string; [`CORE_RPC_STATUS_UNKNOWN`].
@@ -91,8 +92,8 @@ pub enum Status {
     /// The reason this isn't `Unknown(String)` is because that
     /// disallows [`Status`] to be [`Copy`], and thus other types
     /// that contain it.
-    #[serde(other)]
-    #[serde(rename = "UNKNOWN")]
+    #[cfg_attr(feature = "serde", serde(other))]
+    #[cfg_attr(feature = "serde", serde(rename = "UNKNOWN"))]
     Unknown,
 }
 
@@ -132,6 +133,7 @@ impl Display for Status {
 //
 // See below for more impl info:
 // <https://github.com/Cuprate/cuprate/blob/bef2a2cbd4e1194991751d1fbc96603cba8c7a51/net/epee-encoding/src/value.rs#L366-L392>.
+#[cfg(feature = "epee")]
 impl EpeeValue for Status {
     const MARKER: Marker = <String as EpeeValue>::MARKER;
 
@@ -161,6 +163,7 @@ mod test {
 
     // Test epee (de)serialization works.
     #[test]
+    #[cfg(feature = "epee")]
     fn epee() {
         for status in [
             Status::Ok,


### PR DESCRIPTION
### What
Adds and enforces these feature flags in `cuprate-rpc-types`:

| Feature flag | Does what |
|--------------|-----------|
| `json`       | Enables the `crate::json` module
| `bin`        | Enables the `crate::bin` module
| `other`      | Enables the `crate::other` module
| `serde`      | Implements `serde` on all types
| `epee`       | Implements `epee_encoding` on all types

All are enabled by default.
