### PR TITLE
Consensus: add alt-chain handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -538,6 +538,7 @@ dependencies = [
  "thiserror",
  "thread_local",
  "tokio",
+ "tokio-test",
  "tokio-util",
  "tower",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -533,6 +533,7 @@ dependencies = [
  "multiexp",
  "proptest",
  "proptest-derive",
+ "rand",
  "randomx-rs",
  "rayon",
  "thiserror",

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -37,5 +37,6 @@ cuprate-consensus-rules =  {path = "./rules", features = ["proptest"]}
 hex-literal = { workspace = true }
 
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"]}
+tokio-test = { workspace = true }
 proptest = { workspace = true }
 proptest-derive = { workspace = true }

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -29,6 +29,7 @@ tokio = { workspace = true, features = ["rt"] }
 tokio-util = { workspace = true }
 
 hex = { workspace = true }
+rand = { workspace = true }
 
 [dev-dependencies]
 cuprate-test-utils = { path = "../test-utils" }

--- a/consensus/fast-sync/src/create.rs
+++ b/consensus/fast-sync/src/create.rs
@@ -6,7 +6,7 @@ use tower::{Service, ServiceExt};
 use cuprate_blockchain::{
     config::ConfigBuilder, cuprate_database::RuntimeError, service::DatabaseReadHandle,
 };
-use cuprate_types::blockchain::{BCReadRequest, BCResponse};
+use cuprate_types::blockchain::{BCReadRequest, BCResponse, Chain};
 
 use cuprate_fast_sync::{hash_of_hashes, BlockId, HashOfHashes};
 
@@ -19,7 +19,7 @@ async fn read_batch(
     let mut block_ids = Vec::<BlockId>::with_capacity(BATCH_SIZE as usize);
 
     for height in height_from..(height_from + BATCH_SIZE) {
-        let request = BCReadRequest::BlockHash(height);
+        let request = BCReadRequest::BlockHash(height, Chain::Main);
         let response_channel = handle.ready().await?.call(request);
         let response = response_channel.await?;
 

--- a/consensus/fast-sync/src/create.rs
+++ b/consensus/fast-sync/src/create.rs
@@ -6,7 +6,10 @@ use tower::{Service, ServiceExt};
 use cuprate_blockchain::{
     config::ConfigBuilder, cuprate_database::RuntimeError, service::DatabaseReadHandle,
 };
-use cuprate_types::blockchain::{BCReadRequest, BCResponse, Chain};
+use cuprate_types::{
+    blockchain::{BCReadRequest, BCResponse},
+    Chain,
+};
 
 use cuprate_fast_sync::{hash_of_hashes, BlockId, HashOfHashes};
 

--- a/consensus/rules/src/blocks.rs
+++ b/consensus/rules/src/blocks.rs
@@ -184,7 +184,7 @@ fn check_prev_id(block: &Block, top_hash: &[u8; 32]) -> Result<(), BlockError> {
 /// Checks the blocks timestamp is in the valid range.
 ///
 /// ref: <https://monero-book.cuprate.org/consensus_rules/blocks.html#timestamp>
-fn check_timestamp(block: &Block, median_timestamp: u64) -> Result<(), BlockError> {
+pub fn check_timestamp(block: &Block, median_timestamp: u64) -> Result<(), BlockError> {
     if block.header.timestamp < median_timestamp
         || block.header.timestamp > current_unix_timestamp() + BLOCK_FUTURE_TIME_LIMIT
     {

--- a/consensus/rules/src/blocks.rs
+++ b/consensus/rules/src/blocks.rs
@@ -148,7 +148,7 @@ fn block_size_sanity_check(
 /// Sanity check on the block weight.
 ///
 /// ref: <https://monero-book.cuprate.org/consensus_rules/blocks.html#block-weight-and-size>
-fn check_block_weight(
+pub fn check_block_weight(
     block_weight: usize,
     median_for_block_reward: usize,
 ) -> Result<(), BlockError> {

--- a/consensus/rules/src/hard_forks.rs
+++ b/consensus/rules/src/hard_forks.rs
@@ -38,7 +38,7 @@ pub enum HardForkError {
 }
 
 /// Information about a given hard-fork.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub struct HFInfo {
     height: u64,
     threshold: u64,
@@ -50,7 +50,7 @@ impl HFInfo {
 }
 
 /// Information about every hard-fork Monero has had.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub struct HFsInfo([HFInfo; NUMB_OF_HARD_FORKS]);
 
 impl HFsInfo {
@@ -243,7 +243,7 @@ impl HardFork {
 }
 
 /// A struct holding the current voting state of the blockchain.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct HFVotes {
     votes: [u64; NUMB_OF_HARD_FORKS],
     vote_list: VecDeque<HardFork>,

--- a/consensus/rules/src/hard_forks.rs
+++ b/consensus/rules/src/hard_forks.rs
@@ -293,6 +293,28 @@ impl HFVotes {
         }
     }
 
+    /// Pop a number of blocks from the top of the cache and push some values into the front of the cache,
+    /// i.e. the oldest blocks.
+    ///
+    /// `old_block_votes` should contain the HFs below the window that now will be in the window after popping
+    /// blocks from the top.
+    ///
+    /// # Panics
+    ///
+    /// This will panic if `old_block_votes` contains more HFs than `numb_blocks`.
+    pub fn reverse_blocks(&mut self, numb_blocks: usize, old_block_votes: Self) {
+        assert!(old_block_votes.vote_list.len() <= numb_blocks);
+
+        for hf in self.vote_list.drain(self.vote_list.len() - numb_blocks..) {
+            self.votes[hf as usize - 1] -= 1;
+        }
+
+        for old_vote in old_block_votes.vote_list.into_iter().rev() {
+            self.vote_list.push_front(old_vote);
+            self.votes[old_vote as usize - 1] += 1;
+        }
+    }
+
     /// Returns the total votes for a hard-fork.
     ///
     /// ref: <https://monero-book.cuprate.org/consensus_rules/hardforks.html#accepting-a-fork>

--- a/consensus/src/block.rs
+++ b/consensus/src/block.rs
@@ -30,18 +30,22 @@ use cuprate_types::{
     AltBlockInformation, VerifiedBlockInformation, VerifiedTransactionInformation,
 };
 
-use crate::context::AltChainRequestToken;
 use crate::{
     context::{
-        rx_vms::RandomXVM, BlockChainContextRequest, BlockChainContextResponse,
-        RawBlockChainContext,
+        rx_vms::RandomXVM, AltChainRequestToken, BlockChainContextRequest,
+        BlockChainContextResponse, RawBlockChainContext,
     },
     transactions::{TransactionVerificationData, VerifyTxRequest, VerifyTxResponse},
     Database, ExtendedConsensusError,
 };
 
 mod alt_block;
+mod batch_prepare;
+mod free;
+
+use crate::block::free::pull_ordered_transactions;
 use alt_block::sanity_check_alt_block;
+use batch_prepare::batch_prepare_main_chain_block;
 
 /// A pre-prepared block with all data needed to verify it, except the block's proof of work.
 #[derive(Debug)]
@@ -197,6 +201,7 @@ pub enum VerifyBlockRequest {
         /// The already prepared block.
         block: PreparedBlock,
         /// The full list of transactions for this block, in the order given in `block`.
+        // TODO: Remove the Arc here
         txs: Vec<Arc<TransactionVerificationData>>,
     },
     /// Batch prepares a list of blocks and transactions for verification.
@@ -204,9 +209,14 @@ pub enum VerifyBlockRequest {
         /// The list of blocks and their transactions (not necessarily in the order given in the block).
         blocks: Vec<(Block, Vec<Transaction>)>,
     },
-
+    /// A request to sanity check an alt block, also returning the cumulative difficulty of the alt chain.
+    ///
+    /// Unlike requests to verify main chain blocks, you do not need to add the returned block to the context
+    /// service, you will still have to add it to the database though.
     AltChain {
+        /// The alt block to sanity check.
         block: Block,
+        /// The alt transactions.
         prepared_txs: HashMap<[u8; 32], TransactionVerificationData>,
     },
 }
@@ -216,6 +226,7 @@ pub enum VerifyBlockRequest {
 pub enum VerifyBlockResponse {
     /// This block is valid.
     MainChain(VerifiedBlockInformation),
+    /// The sanity checked alt block.
     AltChain(AltBlockInformation),
     /// A list of prepared blocks for verification, you should call [`VerifyBlockRequest::MainChainPrepped`] on each of the returned
     /// blocks to fully verify them.
@@ -318,196 +329,6 @@ where
     }
 }
 
-/// Batch prepares a list of blocks for verification.
-#[instrument(level = "debug", name = "batch_prep_blocks", skip_all, fields(amt = blocks.len()))]
-async fn batch_prepare_main_chain_block<C>(
-    blocks: Vec<(Block, Vec<Transaction>)>,
-    mut context_svc: C,
-) -> Result<VerifyBlockResponse, ExtendedConsensusError>
-where
-    C: Service<
-            BlockChainContextRequest,
-            Response = BlockChainContextResponse,
-            Error = tower::BoxError,
-        > + Send
-        + 'static,
-    C::Future: Send + 'static,
-{
-    let (blocks, txs): (Vec<_>, Vec<_>) = blocks.into_iter().unzip();
-
-    tracing::debug!("Calculating block hashes.");
-    let blocks: Vec<PreparedBlockExPow> = rayon_spawn_async(|| {
-        blocks
-            .into_iter()
-            .map(PreparedBlockExPow::new)
-            .collect::<Result<Vec<_>, _>>()
-    })
-    .await?;
-
-    let Some(last_block) = blocks.last() else {
-        return Err(ExtendedConsensusError::NoBlocksToVerify);
-    };
-
-    // hard-forks cannot be reversed, so the last block will contain the highest hard fork (provided the
-    // batch is valid).
-    let top_hf_in_batch = last_block.hf_version;
-
-    // A Vec of (timestamp, HF) for each block to calculate the expected difficulty for each block.
-    let mut timestamps_hfs = Vec::with_capacity(blocks.len());
-    let mut new_rx_vm = None;
-
-    tracing::debug!("Checking blocks follow each other.");
-
-    // For every block make sure they have the correct height and previous ID
-    for window in blocks.windows(2) {
-        let block_0 = &window[0];
-        let block_1 = &window[1];
-
-        // Make sure no blocks in the batch have a higher hard fork than the last block.
-        if block_0.hf_version > top_hf_in_batch {
-            Err(ConsensusError::Block(BlockError::HardForkError(
-                HardForkError::VersionIncorrect,
-            )))?;
-        }
-
-        if block_0.block_hash != block_1.block.header.previous
-            || block_0.height != block_1.height - 1
-        {
-            tracing::debug!("Blocks do not follow each other, verification failed.");
-            Err(ConsensusError::Block(BlockError::PreviousIDIncorrect))?;
-        }
-
-        // Cache any potential RX VM seeds as we may need them for future blocks in the batch.
-        if is_randomx_seed_height(block_0.height) && top_hf_in_batch >= HardFork::V12 {
-            new_rx_vm = Some((block_0.height, block_0.block_hash));
-        }
-
-        timestamps_hfs.push((block_0.block.header.timestamp, block_0.hf_version))
-    }
-
-    // Get the current blockchain context.
-    let BlockChainContextResponse::Context(checked_context) = context_svc
-        .ready()
-        .await?
-        .call(BlockChainContextRequest::GetContext)
-        .await
-        .map_err(Into::<ExtendedConsensusError>::into)?
-    else {
-        panic!("Context service returned wrong response!");
-    };
-
-    // Calculate the expected difficulties for each block in the batch.
-    let BlockChainContextResponse::BatchDifficulties(difficulties) = context_svc
-        .ready()
-        .await?
-        .call(BlockChainContextRequest::BatchGetDifficulties(
-            timestamps_hfs,
-        ))
-        .await
-        .map_err(Into::<ExtendedConsensusError>::into)?
-    else {
-        panic!("Context service returned wrong response!");
-    };
-
-    let context = checked_context.unchecked_blockchain_context().clone();
-
-    // Make sure the blocks follow the main chain.
-
-    if context.chain_height != blocks[0].height {
-        tracing::debug!("Blocks do not follow main chain, verification failed.");
-
-        Err(ConsensusError::Block(BlockError::MinerTxError(
-            MinerTxError::InputsHeightIncorrect,
-        )))?;
-    }
-
-    if context.top_hash != blocks[0].block.header.previous {
-        tracing::debug!("Blocks do not follow main chain, verification failed.");
-
-        Err(ConsensusError::Block(BlockError::PreviousIDIncorrect))?;
-    }
-
-    let mut rx_vms = if top_hf_in_batch < HardFork::V12 {
-        HashMap::new()
-    } else {
-        let BlockChainContextResponse::RxVms(rx_vms) = context_svc
-            .ready()
-            .await?
-            .call(BlockChainContextRequest::GetCurrentRxVm)
-            .await?
-        else {
-            panic!("Blockchain context service returned wrong response!");
-        };
-
-        rx_vms
-    };
-
-    // If we have a RX seed in the batch calculate it.
-    if let Some((new_vm_height, new_vm_seed)) = new_rx_vm {
-        tracing::debug!("New randomX seed in batch, initialising VM");
-
-        let new_vm = rayon_spawn_async(move || {
-            Arc::new(RandomXVM::new(&new_vm_seed).expect("RandomX VM gave an error on set up!"))
-        })
-        .await;
-
-        context_svc
-            .oneshot(BlockChainContextRequest::NewRXVM((
-                new_vm_seed,
-                new_vm.clone(),
-            )))
-            .await
-            .map_err(Into::<ExtendedConsensusError>::into)?;
-
-        rx_vms.insert(new_vm_height, new_vm);
-    }
-
-    tracing::debug!("Calculating PoW and prepping transaction");
-
-    let blocks = rayon_spawn_async(move || {
-        blocks
-            .into_par_iter()
-            .zip(difficulties)
-            .zip(txs)
-            .map(|((block, difficultly), txs)| {
-                // Calculate the PoW for the block.
-                let height = block.height;
-                let block = PreparedBlock::new_prepped(
-                    block,
-                    rx_vms.get(&randomx_seed_height(height)).map(AsRef::as_ref),
-                )?;
-
-                // Check the PoW
-                check_block_pow(&block.pow_hash, difficultly).map_err(ConsensusError::Block)?;
-
-                // Now setup the txs.
-                let mut txs = txs
-                    .into_par_iter()
-                    .map(|tx| {
-                        let tx = TransactionVerificationData::new(tx)?;
-                        Ok::<_, ConsensusError>((tx.tx_hash, tx))
-                    })
-                    .collect::<Result<HashMap<_, _>, _>>()?;
-
-                // Order the txs correctly.
-                let mut ordered_txs = Vec::with_capacity(txs.len());
-
-                for tx_hash in &block.block.txs {
-                    let tx = txs
-                        .remove(tx_hash)
-                        .ok_or(ExtendedConsensusError::TxsIncludedWithBlockIncorrect)?;
-                    ordered_txs.push(Arc::new(tx));
-                }
-
-                Ok((block, ordered_txs))
-            })
-            .collect::<Result<Vec<_>, ExtendedConsensusError>>()
-    })
-    .await?;
-
-    Ok(VerifyBlockResponse::MainChainBatchPrepped(blocks))
-}
-
 /// Verifies a prepared block.
 async fn verify_main_chain_block<C, TxV>(
     block: Block,
@@ -573,20 +394,11 @@ where
         .map_err(ConsensusError::Block)?;
 
     // Check that the txs included are what we need and that there are not any extra.
-
-    let mut ordered_txs = Vec::with_capacity(txs.len());
-
-    tracing::debug!("Ordering transactions for block.");
-
-    if !prepped_block.block.txs.is_empty() {
-        for tx_hash in &prepped_block.block.txs {
-            let tx = txs
-                .remove(tx_hash)
-                .ok_or(ExtendedConsensusError::TxsIncludedWithBlockIncorrect)?;
-            ordered_txs.push(Arc::new(tx));
-        }
-        drop(txs);
-    }
+    // TODO: Remove the Arc here
+    let ordered_txs = pull_ordered_transactions(&block, txs)?
+        .into_iter()
+        .map(Arc::new)
+        .collect();
 
     verify_prepped_main_chain_block(
         prepped_block,
@@ -620,8 +432,7 @@ where
     } else {
         let BlockChainContextResponse::Context(checked_context) = context_svc
             .oneshot(BlockChainContextRequest::GetContext)
-            .await
-            .map_err(Into::<ExtendedConsensusError>::into)?
+            .await?
         else {
             panic!("Context service returned wrong response!");
         };

--- a/consensus/src/block.rs
+++ b/consensus/src/block.rs
@@ -12,29 +12,23 @@ use monero_serai::{
     block::Block,
     transaction::{Input, Transaction},
 };
-use rayon::prelude::*;
 use tower::{Service, ServiceExt};
-use tracing::instrument;
 
-use cuprate_consensus_rules::{
-    blocks::{
-        calculate_pow_hash, check_block, check_block_pow, is_randomx_seed_height,
-        randomx_seed_height, BlockError, RandomX,
-    },
-    hard_forks::HardForkError,
-    miner_tx::MinerTxError,
-    ConsensusError, HardFork,
-};
 use cuprate_helper::asynch::rayon_spawn_async;
 use cuprate_types::{
     AltBlockInformation, VerifiedBlockInformation, VerifiedTransactionInformation,
 };
 
-use crate::{
-    context::{
-        rx_vms::RandomXVM, AltChainRequestToken, BlockChainContextRequest,
-        BlockChainContextResponse, RawBlockChainContext,
+use cuprate_consensus_rules::{
+    blocks::{
+        calculate_pow_hash, check_block, check_block_pow, randomx_seed_height, BlockError, RandomX,
     },
+    miner_tx::MinerTxError,
+    ConsensusError, HardFork,
+};
+
+use crate::{
+    context::{BlockChainContextRequest, BlockChainContextResponse, RawBlockChainContext},
     transactions::{TransactionVerificationData, VerifyTxRequest, VerifyTxResponse},
     Database, ExtendedConsensusError,
 };
@@ -332,7 +326,7 @@ where
 /// Verifies a prepared block.
 async fn verify_main_chain_block<C, TxV>(
     block: Block,
-    mut txs: HashMap<[u8; 32], TransactionVerificationData>,
+    txs: HashMap<[u8; 32], TransactionVerificationData>,
     mut context_svc: C,
     tx_verifier_svc: TxV,
 ) -> Result<VerifyBlockResponse, ExtendedConsensusError>
@@ -395,7 +389,7 @@ where
 
     // Check that the txs included are what we need and that there are not any extra.
     // TODO: Remove the Arc here
-    let ordered_txs = pull_ordered_transactions(&block, txs)?
+    let ordered_txs = pull_ordered_transactions(&prepped_block.block, txs)?
         .into_iter()
         .map(Arc::new)
         .collect();

--- a/consensus/src/block.rs
+++ b/consensus/src/block.rs
@@ -37,9 +37,9 @@ mod alt_block;
 mod batch_prepare;
 mod free;
 
-use crate::block::free::pull_ordered_transactions;
 use alt_block::sanity_check_alt_block;
 use batch_prepare::batch_prepare_main_chain_block;
+use free::pull_ordered_transactions;
 
 /// A pre-prepared block with all data needed to verify it, except the block's proof of work.
 #[derive(Debug)]

--- a/consensus/src/block/alt_block.rs
+++ b/consensus/src/block/alt_block.rs
@@ -1,0 +1,277 @@
+use crate::block::PreparedBlock;
+use crate::context::difficulty::DifficultyCache;
+use crate::context::rx_vms::RandomXVM;
+use crate::context::weight::BlockWeightsCache;
+use crate::context::{weight, AltChainContextCache, AltChainRequestToken};
+use crate::transactions::TransactionVerificationData;
+use crate::{
+    BlockChainContextRequest, BlockChainContextResponse, ExtendedConsensusError,
+    VerifyBlockResponse, VerifyTxRequest,
+};
+use cuprate_consensus_rules::blocks::{
+    check_block, check_block_pow, check_block_weight, randomx_seed_height, BlockError,
+};
+use cuprate_consensus_rules::miner_tx::MinerTxError;
+use cuprate_consensus_rules::ConsensusError;
+use cuprate_helper::asynch::rayon_spawn_async;
+use cuprate_types::{
+    AltBlockInformation, Chain, ChainID, VerifiedBlockInformation, VerifiedTransactionInformation,
+};
+use monero_serai::block::Block;
+use monero_serai::transaction::Input;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tower::{Service, ServiceExt};
+
+pub async fn sanity_check_alt_block<C>(
+    block: Block,
+    mut txs: HashMap<[u8; 32], TransactionVerificationData>,
+    mut context_svc: C,
+) -> Result<VerifyBlockResponse, ExtendedConsensusError>
+where
+    C: Service<
+            BlockChainContextRequest,
+            Response = BlockChainContextResponse,
+            Error = tower::BoxError,
+        > + Send
+        + 'static,
+    C::Future: Send + 'static,
+{
+    let BlockChainContextResponse::AltChainContextCache(mut alt_context_cache) = context_svc
+        .ready()
+        .await?
+        .call(BlockChainContextRequest::AltChainContextCache {
+            prev_id: block.header.previous,
+            _token: AltChainRequestToken,
+        })
+        .await?
+    else {
+        panic!("Context service returned wrong response!");
+    };
+
+    let [Input::Gen(height)] = &block.miner_tx.prefix.inputs[..] else {
+        Err(ConsensusError::Block(BlockError::MinerTxError(
+            MinerTxError::InputNotOfTypeGen,
+        )))?
+    };
+
+    if *height != alt_context_cache.chain_height {
+        Err(ConsensusError::Block(BlockError::MinerTxError(
+            MinerTxError::InputsHeightIncorrect,
+        )))?
+    }
+
+    let prepped_block = {
+        let rx_vm = alt_rx_vm(
+            alt_context_cache.chain_height,
+            block.header.major_version,
+            alt_context_cache.parent_chain,
+            &mut alt_context_cache,
+            &mut context_svc,
+        )
+        .await?;
+
+        rayon_spawn_async(move || PreparedBlock::new(block, rx_vm.as_deref())).await?
+    };
+
+    let difficulty_cache = alt_difficulty_cache(
+        prepped_block.block.header.previous,
+        &mut alt_context_cache,
+        &mut context_svc,
+    )
+    .await?;
+
+    let next_difficulty = difficulty_cache.next_difficulty(&prepped_block.hf_version);
+
+    check_block_pow(&prepped_block.pow_hash, next_difficulty).map_err(ConsensusError::Block)?;
+
+    let cumulative_difficulty = difficulty_cache.cumulative_difficulty() + next_difficulty;
+
+    if prepped_block.block.txs.len() != txs.len() {
+        return Err(ExtendedConsensusError::TxsIncludedWithBlockIncorrect);
+    }
+
+    // Check that the txs included are what we need and that there are not any extra.
+
+    let mut ordered_txs = Vec::with_capacity(txs.len());
+
+    tracing::debug!("Ordering transactions for block.");
+
+    if !prepped_block.block.txs.is_empty() {
+        for tx_hash in &prepped_block.block.txs {
+            let tx = txs
+                .remove(tx_hash)
+                .ok_or(ExtendedConsensusError::TxsIncludedWithBlockIncorrect)?;
+            ordered_txs.push(Arc::new(tx));
+        }
+        drop(txs);
+    }
+
+    let block_weight =
+        prepped_block.miner_tx_weight + ordered_txs.iter().map(|tx| tx.tx_weight).sum::<usize>();
+
+    let alt_weight_cache = alt_weight_cache(
+        prepped_block.block.header.previous,
+        &mut alt_context_cache,
+        &mut context_svc,
+    )
+    .await?;
+
+    check_block_weight(
+        block_weight,
+        alt_weight_cache.median_for_block_reward(&prepped_block.hf_version),
+    )
+    .map_err(ConsensusError::Block)?;
+
+    let long_term_weight = weight::calculate_block_long_term_weight(
+        &prepped_block.hf_version,
+        block_weight,
+        alt_weight_cache.median_long_term_weight(),
+    );
+
+    let chain_id = *alt_context_cache
+        .chain_id
+        .get_or_insert_with(|| ChainID(rand::random()));
+
+    Ok(VerifyBlockResponse::AltChain(AltBlockInformation {
+        block_hash: prepped_block.block_hash,
+        block: prepped_block.block,
+        block_blob: prepped_block.block_blob,
+        txs: ordered_txs
+            .into_iter()
+            .map(|tx| {
+                // Note: it would be possible for the transaction verification service to hold onto the tx after the call
+                // if one of txs was invalid and the rest are still in rayon threads.
+                let tx = Arc::into_inner(tx).expect(
+                    "Transaction verification service should not hold onto valid transactions.",
+                );
+
+                VerifiedTransactionInformation {
+                    tx_blob: tx.tx_blob,
+                    tx_weight: tx.tx_weight,
+                    fee: tx.fee,
+                    tx_hash: tx.tx_hash,
+                    tx: tx.tx,
+                }
+            })
+            .collect(),
+        pow_hash: prepped_block.pow_hash,
+        weight: block_weight,
+        height: alt_context_cache.chain_height,
+        long_term_weight,
+        cumulative_difficulty,
+        chain_id,
+    }))
+}
+
+async fn alt_rx_vm<C>(
+    block_height: u64,
+    hf: u8,
+    parent_chain: Chain,
+    alt_chain_context: &mut AltChainContextCache,
+    context_svc: C,
+) -> Result<Option<Arc<RandomXVM>>, ExtendedConsensusError>
+where
+    C: Service<
+            BlockChainContextRequest,
+            Response = BlockChainContextResponse,
+            Error = tower::BoxError,
+        > + Send,
+    C::Future: Send + 'static,
+{
+    if hf < 12 {
+        return Ok(None);
+    }
+
+    let seed_height = randomx_seed_height(block_height);
+
+    let cached_vm = match alt_chain_context
+        .cached_rx_vm
+        .take()
+        .filter(|(cached_seed_height, _)| seed_height == *cached_seed_height)
+    {
+        Some((cached_seed_height, vm)) if seed_height == cached_seed_height => {
+            (cached_seed_height, vm)
+        }
+        _ => {
+            let BlockChainContextResponse::AltChainRxVM(vm) = context_svc
+                .oneshot(BlockChainContextRequest::AltChainRxVM {
+                    height: block_height,
+                    chain: parent_chain,
+                    _token: AltChainRequestToken,
+                })
+                .await?
+            else {
+                panic!("Context service returned wrong response!");
+            };
+
+            (seed_height, vm)
+        }
+    };
+
+    Ok(Some(
+        alt_chain_context.cached_rx_vm.insert(cached_vm).1.clone(),
+    ))
+}
+
+async fn alt_difficulty_cache<C>(
+    prev_id: [u8; 32],
+    alt_chain_context: &mut AltChainContextCache,
+    context_svc: C,
+) -> Result<&mut DifficultyCache, ExtendedConsensusError>
+where
+    C: Service<
+            BlockChainContextRequest,
+            Response = BlockChainContextResponse,
+            Error = tower::BoxError,
+        > + Send,
+    C::Future: Send + 'static,
+{
+    match &mut alt_chain_context.difficulty_cache {
+        Some(cache) => Ok(cache),
+        difficulty_cache => {
+            let BlockChainContextResponse::AltChainDifficultyCache(cache) = context_svc
+                .oneshot(BlockChainContextRequest::AltChainDifficultyCache {
+                    prev_id,
+                    _token: AltChainRequestToken,
+                })
+                .await?
+            else {
+                panic!("Context service returned wrong response!");
+            };
+
+            Ok(difficulty_cache.insert(cache))
+        }
+    }
+}
+
+async fn alt_weight_cache<C>(
+    prev_id: [u8; 32],
+    alt_chain_context: &mut AltChainContextCache,
+    context_svc: C,
+) -> Result<&mut BlockWeightsCache, ExtendedConsensusError>
+where
+    C: Service<
+            BlockChainContextRequest,
+            Response = BlockChainContextResponse,
+            Error = tower::BoxError,
+        > + Send,
+    C::Future: Send + 'static,
+{
+    match &mut alt_chain_context.weight_cache {
+        Some(cache) => Ok(cache),
+        weight_cache => {
+            let BlockChainContextResponse::AltChainWeightCache(cache) = context_svc
+                .oneshot(BlockChainContextRequest::AltChainWeightCache {
+                    prev_id,
+                    _token: AltChainRequestToken,
+                })
+                .await?
+            else {
+                panic!("Context service returned wrong response!");
+            };
+
+            Ok(weight_cache.insert(cache))
+        }
+    }
+}

--- a/consensus/src/block/alt_block.rs
+++ b/consensus/src/block/alt_block.rs
@@ -110,7 +110,7 @@ where
 
     let cumulative_difficulty = difficulty_cache.cumulative_difficulty() + next_difficulty;
 
-    let mut ordered_txs = pull_ordered_transactions(&prepped_block.block, txs)?;
+    let ordered_txs = pull_ordered_transactions(&prepped_block.block, txs)?;
 
     let block_weight =
         prepped_block.miner_tx_weight + ordered_txs.iter().map(|tx| tx.tx_weight).sum::<usize>();

--- a/consensus/src/block/alt_block.rs
+++ b/consensus/src/block/alt_block.rs
@@ -15,7 +15,7 @@ use cuprate_consensus_rules::{
     ConsensusError,
 };
 use cuprate_helper::asynch::rayon_spawn_async;
-use cuprate_types::{AltBlockInformation, Chain, ChainID, VerifiedTransactionInformation};
+use cuprate_types::{AltBlockInformation, Chain, ChainId, VerifiedTransactionInformation};
 
 use crate::{
     block::{free::pull_ordered_transactions, PreparedBlock},
@@ -138,7 +138,7 @@ where
     // Get the chainID or generate a new one if this is the first alt block in this alt chain.
     let chain_id = *alt_context_cache
         .chain_id
-        .get_or_insert_with(|| ChainID(rand::random()));
+        .get_or_insert_with(|| ChainId(rand::random()));
 
     // Create the alt block info.
     let block_info = AltBlockInformation {

--- a/consensus/src/block/alt_block.rs
+++ b/consensus/src/block/alt_block.rs
@@ -34,7 +34,7 @@ use crate::{
 ///
 /// Returns [`AltBlockInformation`], which contains the cumulative difficulty of the alt chain.
 ///
-/// This function only checks the blocks PoW and its weight.
+/// This function only checks the block's PoW and its weight.
 pub async fn sanity_check_alt_block<C>(
     block: Block,
     txs: HashMap<[u8; 32], TransactionVerificationData>,
@@ -62,7 +62,7 @@ where
         panic!("Context service returned wrong response!");
     };
 
-    // Check the blocks miner input if formed correctly.
+    // Check if the block's miner input is formed correctly.
     let [Input::Gen(height)] = &block.miner_tx.prefix.inputs[..] else {
         Err(ConsensusError::Block(BlockError::MinerTxError(
             MinerTxError::InputNotOfTypeGen,

--- a/consensus/src/block/batch_prepare.rs
+++ b/consensus/src/block/batch_prepare.rs
@@ -1,0 +1,207 @@
+use std::{collections::HashMap, sync::Arc};
+
+use monero_serai::{block::Block, transaction::Transaction};
+use rayon::prelude::*;
+use tower::{Service, ServiceExt};
+use tracing::instrument;
+
+use cuprate_consensus_rules::{
+    blocks::{check_block_pow, is_randomx_seed_height, randomx_seed_height, BlockError},
+    hard_forks::HardForkError,
+    miner_tx::MinerTxError,
+    ConsensusError, HardFork,
+};
+use cuprate_helper::asynch::rayon_spawn_async;
+
+use crate::{
+    block::{free::pull_ordered_transactions, PreparedBlock, PreparedBlockExPow},
+    context::rx_vms::RandomXVM,
+    transactions::TransactionVerificationData,
+    BlockChainContextRequest, BlockChainContextResponse, ExtendedConsensusError,
+    VerifyBlockResponse,
+};
+
+/// Batch prepares a list of blocks for verification.
+#[instrument(level = "debug", name = "batch_prep_blocks", skip_all, fields(amt = blocks.len()))]
+pub(crate) async fn batch_prepare_main_chain_block<C>(
+    blocks: Vec<(Block, Vec<Transaction>)>,
+    mut context_svc: C,
+) -> Result<VerifyBlockResponse, ExtendedConsensusError>
+where
+    C: Service<
+            BlockChainContextRequest,
+            Response = BlockChainContextResponse,
+            Error = tower::BoxError,
+        > + Send
+        + 'static,
+    C::Future: Send + 'static,
+{
+    let (blocks, txs): (Vec<_>, Vec<_>) = blocks.into_iter().unzip();
+
+    tracing::debug!("Calculating block hashes.");
+    let blocks: Vec<PreparedBlockExPow> = rayon_spawn_async(|| {
+        blocks
+            .into_iter()
+            .map(PreparedBlockExPow::new)
+            .collect::<Result<Vec<_>, _>>()
+    })
+    .await?;
+
+    let Some(last_block) = blocks.last() else {
+        return Err(ExtendedConsensusError::NoBlocksToVerify);
+    };
+
+    // hard-forks cannot be reversed, so the last block will contain the highest hard fork (provided the
+    // batch is valid).
+    let top_hf_in_batch = last_block.hf_version;
+
+    // A Vec of (timestamp, HF) for each block to calculate the expected difficulty for each block.
+    let mut timestamps_hfs = Vec::with_capacity(blocks.len());
+    let mut new_rx_vm = None;
+
+    tracing::debug!("Checking blocks follow each other.");
+
+    // For every block make sure they have the correct height and previous ID
+    for window in blocks.windows(2) {
+        let block_0 = &window[0];
+        let block_1 = &window[1];
+
+        // Make sure no blocks in the batch have a higher hard fork than the last block.
+        if block_0.hf_version > top_hf_in_batch {
+            Err(ConsensusError::Block(BlockError::HardForkError(
+                HardForkError::VersionIncorrect,
+            )))?;
+        }
+
+        if block_0.block_hash != block_1.block.header.previous
+            || block_0.height != block_1.height - 1
+        {
+            tracing::debug!("Blocks do not follow each other, verification failed.");
+            Err(ConsensusError::Block(BlockError::PreviousIDIncorrect))?;
+        }
+
+        // Cache any potential RX VM seeds as we may need them for future blocks in the batch.
+        if is_randomx_seed_height(block_0.height) && top_hf_in_batch >= HardFork::V12 {
+            new_rx_vm = Some((block_0.height, block_0.block_hash));
+        }
+
+        timestamps_hfs.push((block_0.block.header.timestamp, block_0.hf_version))
+    }
+
+    // Get the current blockchain context.
+    let BlockChainContextResponse::Context(checked_context) = context_svc
+        .ready()
+        .await?
+        .call(BlockChainContextRequest::GetContext)
+        .await?
+    else {
+        panic!("Context service returned wrong response!");
+    };
+
+    // Calculate the expected difficulties for each block in the batch.
+    let BlockChainContextResponse::BatchDifficulties(difficulties) = context_svc
+        .ready()
+        .await?
+        .call(BlockChainContextRequest::BatchGetDifficulties(
+            timestamps_hfs,
+        ))
+        .await?
+    else {
+        panic!("Context service returned wrong response!");
+    };
+
+    let context = checked_context.unchecked_blockchain_context().clone();
+
+    // Make sure the blocks follow the main chain.
+
+    if context.chain_height != blocks[0].height {
+        tracing::debug!("Blocks do not follow main chain, verification failed.");
+
+        Err(ConsensusError::Block(BlockError::MinerTxError(
+            MinerTxError::InputsHeightIncorrect,
+        )))?;
+    }
+
+    if context.top_hash != blocks[0].block.header.previous {
+        tracing::debug!("Blocks do not follow main chain, verification failed.");
+
+        Err(ConsensusError::Block(BlockError::PreviousIDIncorrect))?;
+    }
+
+    let mut rx_vms = if top_hf_in_batch < HardFork::V12 {
+        HashMap::new()
+    } else {
+        let BlockChainContextResponse::RxVms(rx_vms) = context_svc
+            .ready()
+            .await?
+            .call(BlockChainContextRequest::GetCurrentRxVm)
+            .await?
+        else {
+            panic!("Blockchain context service returned wrong response!");
+        };
+
+        rx_vms
+    };
+
+    // If we have a RX seed in the batch calculate it.
+    if let Some((new_vm_height, new_vm_seed)) = new_rx_vm {
+        tracing::debug!("New randomX seed in batch, initialising VM");
+
+        let new_vm = rayon_spawn_async(move || {
+            Arc::new(RandomXVM::new(&new_vm_seed).expect("RandomX VM gave an error on set up!"))
+        })
+        .await;
+
+        // Give the new VM to the context service, so it can cache it.
+        context_svc
+            .oneshot(BlockChainContextRequest::NewRXVM((
+                new_vm_seed,
+                new_vm.clone(),
+            )))
+            .await?;
+
+        rx_vms.insert(new_vm_height, new_vm);
+    }
+
+    tracing::debug!("Calculating PoW and prepping transaction");
+
+    let blocks = rayon_spawn_async(move || {
+        blocks
+            .into_par_iter()
+            .zip(difficulties)
+            .zip(txs)
+            .map(|((block, difficultly), txs)| {
+                // Calculate the PoW for the block.
+                let height = block.height;
+                let block = PreparedBlock::new_prepped(
+                    block,
+                    rx_vms.get(&randomx_seed_height(height)).as_ref(),
+                )?;
+
+                // Check the PoW
+                check_block_pow(&block.pow_hash, difficultly).map_err(ConsensusError::Block)?;
+
+                // Now setup the txs.
+                let txs = txs
+                    .into_par_iter()
+                    .map(|tx| {
+                        let tx = TransactionVerificationData::new(tx)?;
+                        Ok::<_, ConsensusError>((tx.tx_hash, tx))
+                    })
+                    .collect::<Result<HashMap<_, _>, _>>()?;
+
+                // Order the txs correctly.
+                // TODO: Remove the Arc here
+                let mut ordered_txs = pull_ordered_transactions(&block.block, txs)?
+                    .into_iter()
+                    .map(Arc::new)
+                    .collect();
+
+                Ok((block, ordered_txs))
+            })
+            .collect::<Result<Vec<_>, ExtendedConsensusError>>()
+    })
+    .await?;
+
+    Ok(VerifyBlockResponse::MainChainBatchPrepped(blocks))
+}

--- a/consensus/src/block/batch_prepare.rs
+++ b/consensus/src/block/batch_prepare.rs
@@ -175,7 +175,7 @@ where
                 let height = block.height;
                 let block = PreparedBlock::new_prepped(
                     block,
-                    rx_vms.get(&randomx_seed_height(height)).as_ref(),
+                    rx_vms.get(&randomx_seed_height(height)).map(AsRef::as_ref),
                 )?;
 
                 // Check the PoW
@@ -192,7 +192,7 @@ where
 
                 // Order the txs correctly.
                 // TODO: Remove the Arc here
-                let mut ordered_txs = pull_ordered_transactions(&block.block, txs)?
+                let ordered_txs = pull_ordered_transactions(&block.block, txs)?
                     .into_iter()
                     .map(Arc::new)
                     .collect();

--- a/consensus/src/block/free.rs
+++ b/consensus/src/block/free.rs
@@ -1,0 +1,32 @@
+//! Free functions for block verification
+use std::collections::HashMap;
+
+use monero_serai::block::Block;
+
+use crate::{transactions::TransactionVerificationData, ExtendedConsensusError};
+
+/// Returns a list of transactions, pulled from `txs` in the order they are in the [`Block`].
+///
+/// Will error if a tx need is not in `txs` or if `txs` contain more txs than needed.
+pub(crate) fn pull_ordered_transactions(
+    block: &Block,
+    mut txs: HashMap<[u8; 32], TransactionVerificationData>,
+) -> Result<Vec<TransactionVerificationData>, ExtendedConsensusError> {
+    if block.txs.len() != txs.len() {
+        return Err(ExtendedConsensusError::TxsIncludedWithBlockIncorrect);
+    }
+
+    let mut ordered_txs = Vec::with_capacity(txs.len());
+
+    if !block.txs.is_empty() {
+        for tx_hash in &block.txs {
+            let tx = txs
+                .remove(tx_hash)
+                .ok_or(ExtendedConsensusError::TxsIncludedWithBlockIncorrect)?;
+            ordered_txs.push(tx);
+        }
+        drop(txs);
+    }
+
+    Ok(ordered_txs)
+}

--- a/consensus/src/context.rs
+++ b/consensus/src/context.rs
@@ -248,6 +248,8 @@ pub enum BlockChainContextRequest {
         /// This will panic if the number of blocks will pop the genesis block.
         numb_blocks: u64,
     },
+    /// Clear the alt chain context caches.
+    ClearAltCache,
     //----------------------------------------------------------------------------------------------------------- AltChainRequests
     /// A request for an alt chain context cache.
     ///

--- a/consensus/src/context.rs
+++ b/consensus/src/context.rs
@@ -31,10 +31,10 @@ mod alt_chains;
 mod task;
 mod tokens;
 
-use crate::context::alt_chains::sealed::AltChainRequestToken;
-use crate::context::alt_chains::AltChainContextCache;
 use crate::context::difficulty::DifficultyCache;
 use crate::context::weight::BlockWeightsCache;
+pub(crate) use alt_chains::{sealed::AltChainRequestToken, AltChainContextCache};
+use cuprate_types::Chain;
 pub use difficulty::DifficultyCacheConfig;
 pub use hardforks::HardForkConfig;
 use rx_vms::RandomXVM;
@@ -251,6 +251,11 @@ pub enum BlockChainContextRequest {
         prev_id: [u8; 32],
         _token: AltChainRequestToken,
     },
+    AltChainRxVM {
+        height: u64,
+        chain: Chain,
+        _token: AltChainRequestToken,
+    },
     AddAltChainContextCache {
         prev_id: [u8; 32],
         cache: AltChainContextCache,
@@ -268,6 +273,7 @@ pub enum BlockChainContextResponse {
 
     AltChainContextCache(AltChainContextCache),
     AltChainDifficultyCache(DifficultyCache),
+    AltChainRxVM(Arc<RandomXVM>),
     AltChainWeightCache(BlockWeightsCache),
     /// Ok response.
     Ok,

--- a/consensus/src/context.rs
+++ b/consensus/src/context.rs
@@ -300,7 +300,7 @@ pub enum BlockChainContextRequest {
         /// The previous block field in a [`BlockHeader`](monero_serai::block::BlockHeader).
         prev_id: [u8; 32],
         /// The cache.
-        cache: AltChainContextCache,
+        cache: Box<AltChainContextCache>,
         /// An internal token to prevent external crates calling this request.
         _token: AltChainRequestToken,
     },
@@ -314,7 +314,7 @@ pub enum BlockChainContextResponse {
     /// A list of difficulties.
     BatchDifficulties(Vec<u128>),
     /// An [`AltChainContextCache`].
-    AltChainContextCache(AltChainContextCache),
+    AltChainContextCache(Box<AltChainContextCache>),
     /// A [`DifficultyCache`] for an alt chain.
     AltChainDifficultyCache(DifficultyCache),
     /// A [`RandomXVM`] for an alt chain.

--- a/consensus/src/context.rs
+++ b/consensus/src/context.rs
@@ -238,6 +238,15 @@ pub enum BlockChainContextRequest {
     NewRXVM(([u8; 32], Arc<RandomXVM>)),
     /// A request to add a new block to the cache.
     Update(NewBlockData),
+    /// Pop blocks from the cache to the specified height.
+    PopBlocks {
+        /// The number of blocks to pop from the top of the chain.
+        ///
+        /// # Panics
+        ///
+        /// This will panic if the number of blocks will pop the genesis block.
+        numb_blocks: u64,
+    },
     //----------------------------------------------------------------------------------------------------------- AltChainRequests
     /// A request for an [`AltChainContextCache`].
     ///
@@ -276,13 +285,23 @@ pub enum BlockChainContextRequest {
     /// This variant is private and is not callable from outside this crate, the block verifier service will
     /// handle getting the randomX VM of an alt chain.
     AltChainRxVM {
+        /// The height the RandomX VM is needed for.
         height: u64,
+        /// The chain to look in for the seed.
         chain: Chain,
+        /// An internal token to prevent external crates calling this request.
         _token: AltChainRequestToken,
     },
+    /// A request to add an [`AltChainContextCache`] to the context cache.
+    ///
+    /// This variant is private and is not callable from outside this crate, the block verifier service will
+    /// handle returning the alt cache to the context service.
     AddAltChainContextCache {
+        /// The previous block field in a [`BlockHeader`](monero_serai::block::BlockHeader).
         prev_id: [u8; 32],
+        /// The cache.
         cache: AltChainContextCache,
+        /// An internal token to prevent external crates calling this request.
         _token: AltChainRequestToken,
     },
 }
@@ -294,12 +313,15 @@ pub enum BlockChainContextResponse {
     RxVms(HashMap<u64, Arc<RandomXVM>>),
     /// A list of difficulties.
     BatchDifficulties(Vec<u128>),
-
+    /// An [`AltChainContextCache`].
     AltChainContextCache(AltChainContextCache),
+    /// A [`DifficultyCache`] for an alt chain.
     AltChainDifficultyCache(DifficultyCache),
+    /// A [`RandomXVM`] for an alt chain.
     AltChainRxVM(Arc<RandomXVM>),
+    /// A [`BlockWeightsCache`] for an alt chain
     AltChainWeightCache(BlockWeightsCache),
-    /// Ok response.
+    /// A generic Ok response.
     Ok,
 }
 

--- a/consensus/src/context.rs
+++ b/consensus/src/context.rs
@@ -31,6 +31,10 @@ mod alt_chains;
 mod task;
 mod tokens;
 
+use crate::context::alt_chains::sealed::AltChainRequestToken;
+use crate::context::alt_chains::AltChainContextCache;
+use crate::context::difficulty::DifficultyCache;
+use crate::context::weight::BlockWeightsCache;
 pub use difficulty::DifficultyCacheConfig;
 pub use hardforks::HardForkConfig;
 use rx_vms::RandomXVM;
@@ -234,6 +238,24 @@ pub enum BlockChainContextRequest {
     NewRXVM(([u8; 32], Arc<RandomXVM>)),
     /// A request to add a new block to the cache.
     Update(NewBlockData),
+
+    AltChainContextCache {
+        prev_id: [u8; 32],
+        _token: AltChainRequestToken,
+    },
+    AltChainDifficultyCache {
+        prev_id: [u8; 32],
+        _token: AltChainRequestToken,
+    },
+    AltChainWeightCache {
+        prev_id: [u8; 32],
+        _token: AltChainRequestToken,
+    },
+    AddAltChainContextCache {
+        prev_id: [u8; 32],
+        cache: AltChainContextCache,
+        _token: AltChainRequestToken,
+    },
 }
 
 pub enum BlockChainContextResponse {
@@ -243,6 +265,10 @@ pub enum BlockChainContextResponse {
     RxVms(HashMap<u64, Arc<RandomXVM>>),
     /// A list of difficulties.
     BatchDifficulties(Vec<u128>),
+
+    AltChainContextCache(AltChainContextCache),
+    AltChainDifficultyCache(DifficultyCache),
+    AltChainWeightCache(BlockWeightsCache),
     /// Ok response.
     Ok,
 }

--- a/consensus/src/context.rs
+++ b/consensus/src/context.rs
@@ -41,7 +41,7 @@ use rx_vms::RandomXVM;
 pub use tokens::*;
 pub use weight::BlockWeightsCacheConfig;
 
-const BLOCKCHAIN_TIMESTAMP_CHECK_WINDOW: u64 = 60;
+pub(crate) const BLOCKCHAIN_TIMESTAMP_CHECK_WINDOW: u64 = 60;
 
 /// Config for the context service.
 pub struct ContextConfig {

--- a/consensus/src/context.rs
+++ b/consensus/src/context.rs
@@ -31,13 +31,14 @@ mod alt_chains;
 mod task;
 mod tokens;
 
-use crate::context::difficulty::DifficultyCache;
-use crate::context::weight::BlockWeightsCache;
-pub(crate) use alt_chains::{sealed::AltChainRequestToken, AltChainContextCache};
 use cuprate_types::Chain;
+use difficulty::DifficultyCache;
+use rx_vms::RandomXVM;
+use weight::BlockWeightsCache;
+
+pub(crate) use alt_chains::{sealed::AltChainRequestToken, AltChainContextCache};
 pub use difficulty::DifficultyCacheConfig;
 pub use hardforks::HardForkConfig;
-use rx_vms::RandomXVM;
 pub use tokens::*;
 pub use weight::BlockWeightsCacheConfig;
 
@@ -248,7 +249,7 @@ pub enum BlockChainContextRequest {
         numb_blocks: u64,
     },
     //----------------------------------------------------------------------------------------------------------- AltChainRequests
-    /// A request for an [`AltChainContextCache`].
+    /// A request for an alt chain context cache.
     ///
     /// This variant is private and is not callable from outside this crate, the block verifier service will
     /// handle getting the alt cache.
@@ -258,7 +259,7 @@ pub enum BlockChainContextRequest {
         /// An internal token to prevent external crates calling this request.
         _token: AltChainRequestToken,
     },
-    /// A request for a [`DifficultyCache`] of an alternative chin.
+    /// A request for a difficulty cache of an alternative chin.
     ///
     /// This variant is private and is not callable from outside this crate, the block verifier service will
     /// handle getting the difficulty cache of an alt chain.
@@ -268,7 +269,7 @@ pub enum BlockChainContextRequest {
         /// An internal token to prevent external crates calling this request.
         _token: AltChainRequestToken,
     },
-    /// A request for a [`BlockWeightsCache`] of an alternative chin.
+    /// A request for a block weight cache of an alternative chin.
     ///
     /// This variant is private and is not callable from outside this crate, the block verifier service will
     /// handle getting the weight cache of an alt chain.
@@ -278,7 +279,7 @@ pub enum BlockChainContextRequest {
         /// An internal token to prevent external crates calling this request.
         _token: AltChainRequestToken,
     },
-    /// A request for a [`RandomXVM`] for an alternative chin.
+    /// A request for a RX VM for an alternative chin.
     ///
     /// Response variant: [`BlockChainContextResponse::AltChainRxVM`].
     ///
@@ -292,7 +293,7 @@ pub enum BlockChainContextRequest {
         /// An internal token to prevent external crates calling this request.
         _token: AltChainRequestToken,
     },
-    /// A request to add an [`AltChainContextCache`] to the context cache.
+    /// A request to add an alt chain context cache to the context cache.
     ///
     /// This variant is private and is not callable from outside this crate, the block verifier service will
     /// handle returning the alt cache to the context service.
@@ -313,13 +314,13 @@ pub enum BlockChainContextResponse {
     RxVms(HashMap<u64, Arc<RandomXVM>>),
     /// A list of difficulties.
     BatchDifficulties(Vec<u128>),
-    /// An [`AltChainContextCache`].
+    /// An alt chain context cache.
     AltChainContextCache(Box<AltChainContextCache>),
-    /// A [`DifficultyCache`] for an alt chain.
+    /// A difficulty cache for an alt chain.
     AltChainDifficultyCache(DifficultyCache),
-    /// A [`RandomXVM`] for an alt chain.
+    /// A randomX VM for an alt chain.
     AltChainRxVM(Arc<RandomXVM>),
-    /// A [`BlockWeightsCache`] for an alt chain
+    /// A weight cache for an alt chain
     AltChainWeightCache(BlockWeightsCache),
     /// A generic Ok response.
     Ok,

--- a/consensus/src/context.rs
+++ b/consensus/src/context.rs
@@ -27,6 +27,7 @@ pub(crate) mod hardforks;
 pub(crate) mod rx_vms;
 pub(crate) mod weight;
 
+mod alt_chains;
 mod task;
 mod tokens;
 

--- a/consensus/src/context.rs
+++ b/consensus/src/context.rs
@@ -238,19 +238,43 @@ pub enum BlockChainContextRequest {
     NewRXVM(([u8; 32], Arc<RandomXVM>)),
     /// A request to add a new block to the cache.
     Update(NewBlockData),
-
+    //----------------------------------------------------------------------------------------------------------- AltChainRequests
+    /// A request for an [`AltChainContextCache`].
+    ///
+    /// This variant is private and is not callable from outside this crate, the block verifier service will
+    /// handle getting the alt cache.
     AltChainContextCache {
+        /// The previous block field in a [`BlockHeader`](monero_serai::block::BlockHeader).
         prev_id: [u8; 32],
+        /// An internal token to prevent external crates calling this request.
         _token: AltChainRequestToken,
     },
+    /// A request for a [`DifficultyCache`] of an alternative chin.
+    ///
+    /// This variant is private and is not callable from outside this crate, the block verifier service will
+    /// handle getting the difficulty cache of an alt chain.
     AltChainDifficultyCache {
+        /// The previous block field in a [`BlockHeader`](monero_serai::block::BlockHeader).
         prev_id: [u8; 32],
+        /// An internal token to prevent external crates calling this request.
         _token: AltChainRequestToken,
     },
+    /// A request for a [`BlockWeightsCache`] of an alternative chin.
+    ///
+    /// This variant is private and is not callable from outside this crate, the block verifier service will
+    /// handle getting the weight cache of an alt chain.
     AltChainWeightCache {
+        /// The previous block field in a [`BlockHeader`](monero_serai::block::BlockHeader).
         prev_id: [u8; 32],
+        /// An internal token to prevent external crates calling this request.
         _token: AltChainRequestToken,
     },
+    /// A request for a [`RandomXVM`] for an alternative chin.
+    ///
+    /// Response variant: [`BlockChainContextResponse::AltChainRxVM`].
+    ///
+    /// This variant is private and is not callable from outside this crate, the block verifier service will
+    /// handle getting the randomX VM of an alt chain.
     AltChainRxVM {
         height: u64,
         chain: Chain,

--- a/consensus/src/context/alt_chains.rs
+++ b/consensus/src/context/alt_chains.rs
@@ -5,7 +5,7 @@ use tower::ServiceExt;
 use cuprate_consensus_rules::{blocks::BlockError, ConsensusError};
 use cuprate_types::{
     blockchain::{BCReadRequest, BCResponse},
-    Chain, ChainID,
+    Chain, ChainId,
 };
 
 use crate::{
@@ -39,7 +39,7 @@ pub struct AltChainContextCache {
     /// The top hash of the alt chain.
     pub top_hash: [u8; 32],
     /// The [`ChainID`] of the alt chain.
-    pub chain_id: Option<ChainID>,
+    pub chain_id: Option<ChainId>,
     /// The parent [`Chain`] of this alt chain.
     pub parent_chain: Chain,
 }

--- a/consensus/src/context/alt_chains.rs
+++ b/consensus/src/context/alt_chains.rs
@@ -1,0 +1,146 @@
+use std::collections::HashMap;
+
+use tower::{Service, ServiceExt};
+
+use cuprate_consensus_rules::{blocks::BlockError, ConsensusError, HardFork};
+use cuprate_types::blockchain::{BCReadRequest, BCResponse, Chain, ChainID};
+
+use crate::{
+    ExtendedConsensusError,
+    __private::Database,
+    context::{difficulty::DifficultyCache, weight::BlockWeightsCache},
+};
+
+pub(crate) mod sealed {
+    #[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
+    pub struct AltChainRequestToken;
+}
+
+#[derive(Debug, Clone)]
+pub struct AltChainContextCache {
+    weight_cache: Option<BlockWeightsCache>,
+    difficulty_cache: Option<DifficultyCache>,
+
+    chain_height: Option<u64>,
+    top_hash: Option<[u8; 32]>,
+    chain_id: Option<ChainID>,
+}
+
+impl AltChainContextCache {}
+
+pub struct AltChainMap {
+    alt_cache_map: HashMap<[u8; 32], AltChainContextCache>,
+}
+
+impl AltChainMap {
+    pub fn new() -> AltChainMap {
+        AltChainMap {
+            alt_cache_map: HashMap::new(),
+        }
+    }
+
+    pub fn get_alt_chain_context(&mut self, prev_id: [u8; 32]) -> AltChainContextCache {
+        self.alt_cache_map
+            .remove(&prev_id)
+            .unwrap_or(AltChainContextCache {
+                weight_cache: None,
+                difficulty_cache: None,
+                chain_height: None,
+                top_hash: None,
+                chain_id: None,
+            })
+    }
+}
+
+pub async fn get_alt_chain_difficulty_cache<D: Database>(
+    prev_id: [u8; 32],
+    main_chain_difficulty_cache: &DifficultyCache,
+    mut database: D,
+) -> Result<DifficultyCache, ExtendedConsensusError> {
+    // find the block with hash == prev_id.
+    let BCResponse::FindBlock(res) = database
+        .ready()
+        .await?
+        .call(BCReadRequest::FindBlock(prev_id))
+        .await?
+    else {
+        panic!("Database returned wrong response");
+    };
+
+    let Some((chain, top_height)) = res else {
+        // Can't find prev_id
+        Err(ConsensusError::Block(BlockError::PreviousIDIncorrect))?
+    };
+
+    Ok(match chain {
+        Chain::Main => {
+            // prev_id is in main chain, we can use the fast path and clone the main chain cache.
+            let mut difficulty_cache = main_chain_difficulty_cache.clone();
+            difficulty_cache
+                .pop_blocks_main_chain(
+                    difficulty_cache.last_accounted_height - top_height,
+                    database.clone(),
+                )
+                .await?;
+
+            difficulty_cache
+        }
+        chain @ Chain::Alt(_) => {
+            // prev_id is in an alt chain, completely rebuild the cache.
+            let difficulty_cache = DifficultyCache::init_from_chain_height(
+                top_height + 1,
+                main_chain_difficulty_cache.config,
+                database.clone(),
+                chain,
+            )
+            .await?;
+
+            difficulty_cache
+        }
+    })
+}
+
+pub async fn get_alt_chain_weight_cache<D: Database>(
+    prev_id: [u8; 32],
+    main_chain_weight_cache: &BlockWeightsCache,
+    mut database: D,
+) -> Result<BlockWeightsCache, ExtendedConsensusError> {
+    // find the block with hash == prev_id.
+    let BCResponse::FindBlock(res) = database
+        .ready()
+        .await?
+        .call(BCReadRequest::FindBlock(prev_id))
+        .await?
+    else {
+        panic!("Database returned wrong response");
+    };
+
+    let Some((chain, top_height)) = res else {
+        // Can't find prev_id
+        Err(ConsensusError::Block(BlockError::PreviousIDIncorrect))?
+    };
+
+    Ok(match chain {
+        Chain::Main => {
+            // prev_id is in main chain, we can use the fast path and clone the main chain cache.
+            let mut weight_cache = main_chain_weight_cache.clone();
+            weight_cache
+                .pop_blocks_main_chain(weight_cache.tip_height - top_height, database.clone())
+                .await?;
+
+            weight_cache
+        }
+        chain @ Chain::Alt(_) => {
+            // prev_id is in an alt chain, completely rebuild the cache.
+            let weight_cache = BlockWeightsCache::init_from_chain_height(
+                top_height + 1,
+                main_chain_weight_cache.config,
+                database.clone(),
+                chain,
+            )
+            .await?;
+
+            weight_cache
+        }
+    })
+}

--- a/consensus/src/context/alt_chains.rs
+++ b/consensus/src/context/alt_chains.rs
@@ -79,6 +79,10 @@ impl AltChainMap {
         }
     }
 
+    pub fn clear(&mut self) {
+        self.alt_cache_map.clear();
+    }
+
     /// Add an alt chain cache to the map.
     pub fn add_alt_cache(&mut self, prev_id: [u8; 32], alt_cache: AltChainContextCache) {
         self.alt_cache_map.insert(prev_id, alt_cache);

--- a/consensus/src/context/alt_chains.rs
+++ b/consensus/src/context/alt_chains.rs
@@ -26,9 +26,9 @@ pub(crate) mod sealed {
 /// The context cache of an alternative chain.
 #[derive(Debug, Clone)]
 pub struct AltChainContextCache {
-    /// The alt chain weight cache, if it has been built yet.
+    /// The alt chain weight cache, [`None`] if it has not been built yet.
     pub weight_cache: Option<BlockWeightsCache>,
-    /// The alt chain difficulty cache, if it has been built yet.
+    /// The alt chain difficulty cache, [`None`] if it has not been built yet.
     pub difficulty_cache: Option<DifficultyCache>,
 
     /// A cached RX VM.
@@ -73,8 +73,8 @@ pub struct AltChainMap {
 }
 
 impl AltChainMap {
-    pub fn new() -> AltChainMap {
-        AltChainMap {
+    pub fn new() -> Self {
+        Self {
             alt_cache_map: HashMap::new(),
         }
     }
@@ -157,7 +157,7 @@ pub async fn get_alt_chain_difficulty_cache<D: Database + Clone>(
 
             difficulty_cache
         }
-        chain @ Chain::Alt(_) => {
+        Chain::Alt(_) => {
             // prev_id is in an alt chain, completely rebuild the cache.
             DifficultyCache::init_from_chain_height(
                 top_height + 1,
@@ -201,7 +201,7 @@ pub async fn get_alt_chain_weight_cache<D: Database + Clone>(
 
             weight_cache
         }
-        chain @ Chain::Alt(_) => {
+        Chain::Alt(_) => {
             // prev_id is in an alt chain, completely rebuild the cache.
             BlockWeightsCache::init_from_chain_height(
                 top_height + 1,

--- a/consensus/src/context/difficulty.rs
+++ b/consensus/src/context/difficulty.rs
@@ -12,7 +12,10 @@ use tower::ServiceExt;
 use tracing::instrument;
 
 use cuprate_helper::num::median;
-use cuprate_types::blockchain::{BCReadRequest, BCResponse, Chain};
+use cuprate_types::{
+    blockchain::{BCReadRequest, BCResponse},
+    Chain,
+};
 
 use crate::{Database, ExtendedConsensusError, HardFork};
 
@@ -68,7 +71,7 @@ impl DifficultyCacheConfig {
 /// This struct is able to calculate difficulties from blockchain information.
 ///
 #[derive(Debug, Clone, Eq, PartialEq)]
-pub(crate) struct DifficultyCache {
+pub struct DifficultyCache {
     /// The list of timestamps in the window.
     /// len <= [`DIFFICULTY_BLOCKS_COUNT`]
     pub(crate) timestamps: VecDeque<u64>,

--- a/consensus/src/context/hardforks.rs
+++ b/consensus/src/context/hardforks.rs
@@ -18,7 +18,7 @@ const DEFAULT_WINDOW_SIZE: u64 = 10080; // supermajority window check length - a
 
 /// Configuration for hard-forks.
 ///
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub struct HardForkConfig {
     /// The network we are on.
     pub(crate) info: HFsInfo,
@@ -53,7 +53,7 @@ impl HardForkConfig {
 }
 
 /// A struct that keeps track of the current hard-fork and current votes.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct HardForkState {
     /// The current active hard-fork.
     pub(crate) current_hardfork: HardFork,

--- a/consensus/src/context/hardforks.rs
+++ b/consensus/src/context/hardforks.rs
@@ -4,7 +4,10 @@ use tower::ServiceExt;
 use tracing::instrument;
 
 use cuprate_consensus_rules::{HFVotes, HFsInfo, HardFork};
-use cuprate_types::blockchain::{BCReadRequest, BCResponse, Chain};
+use cuprate_types::{
+    blockchain::{BCReadRequest, BCResponse},
+    Chain,
+};
 
 use crate::{Database, ExtendedConsensusError};
 

--- a/consensus/src/context/hardforks.rs
+++ b/consensus/src/context/hardforks.rs
@@ -4,7 +4,7 @@ use tower::ServiceExt;
 use tracing::instrument;
 
 use cuprate_consensus_rules::{HFVotes, HFsInfo, HardFork};
-use cuprate_types::blockchain::{BCReadRequest, BCResponse};
+use cuprate_types::blockchain::{BCReadRequest, BCResponse, Chain};
 
 use crate::{Database, ExtendedConsensusError};
 
@@ -168,7 +168,10 @@ async fn get_votes_in_range<D: Database>(
     let mut votes = HFVotes::new(window_size);
 
     let BCResponse::BlockExtendedHeaderInRange(vote_list) = database
-        .oneshot(BCReadRequest::BlockExtendedHeaderInRange(block_heights))
+        .oneshot(BCReadRequest::BlockExtendedHeaderInRange(
+            block_heights,
+            Chain::Main,
+        ))
         .await?
     else {
         panic!("Database sent incorrect response!");

--- a/consensus/src/context/rx_vms.rs
+++ b/consensus/src/context/rx_vms.rs
@@ -3,7 +3,6 @@
 //! This module keeps track of the RandomX VM to calculate the next blocks PoW, if the block needs a randomX VM and potentially
 //! more VMs around this height.
 //!
-use std::collections::HashSet;
 use std::{
     collections::{HashMap, VecDeque},
     sync::Arc,
@@ -13,7 +12,7 @@ use futures::{stream::FuturesOrdered, StreamExt};
 use randomx_rs::{RandomXCache, RandomXError, RandomXFlag, RandomXVM as VMInner};
 use rayon::prelude::*;
 use thread_local::ThreadLocal;
-use tower::{Service, ServiceExt};
+use tower::ServiceExt;
 use tracing::instrument;
 
 use cuprate_consensus_rules::blocks::randomx_seed_height;
@@ -148,7 +147,7 @@ impl RandomXVMCache {
 
         for (vm_main_chain_height, vm_seed_hash) in &self.seeds {
             if vm_seed_hash == &seed_hash {
-                let Some(vm) = self.vms.get(&vm_main_chain_height) else {
+                let Some(vm) = self.vms.get(vm_main_chain_height) else {
                     break;
                 };
 

--- a/consensus/src/context/rx_vms.rs
+++ b/consensus/src/context/rx_vms.rs
@@ -3,6 +3,7 @@
 //! This module keeps track of the RandomX VM to calculate the next blocks PoW, if the block needs a randomX VM and potentially
 //! more VMs around this height.
 //!
+use std::collections::HashSet;
 use std::{
     collections::{HashMap, VecDeque},
     sync::Arc,
@@ -12,15 +13,16 @@ use futures::{stream::FuturesOrdered, StreamExt};
 use randomx_rs::{RandomXCache, RandomXError, RandomXFlag, RandomXVM as VMInner};
 use rayon::prelude::*;
 use thread_local::ThreadLocal;
-use tower::ServiceExt;
+use tower::{Service, ServiceExt};
 use tracing::instrument;
 
+use cuprate_consensus_rules::blocks::randomx_seed_height;
 use cuprate_consensus_rules::{
     blocks::{is_randomx_seed_height, RandomX, RX_SEEDHASH_EPOCH_BLOCKS},
     HardFork,
 };
 use cuprate_helper::asynch::rayon_spawn_async;
-use cuprate_types::blockchain::{BCReadRequest, BCResponse};
+use cuprate_types::blockchain::{BCReadRequest, BCResponse, Chain};
 
 use crate::{Database, ExtendedConsensusError};
 
@@ -74,6 +76,9 @@ pub struct RandomXVMCache {
     /// The VMs for `seeds` (if after hf 12, otherwise this will be empty).
     pub(crate) vms: HashMap<u64, Arc<RandomXVM>>,
 
+    /// VMs for alt chains.
+    pub(crate) alt_vms: HashMap<[u8; 32], Arc<RandomXVM>>,
+
     /// A single cached VM that was given to us from a part of Cuprate.
     pub(crate) cached_vm: Option<([u8; 32], Arc<RandomXVM>)>,
 }
@@ -114,6 +119,7 @@ impl RandomXVMCache {
 
         Ok(RandomXVMCache {
             seeds,
+            alt_vms: HashMap::new(),
             vms,
             cached_vm: None,
         })
@@ -124,7 +130,44 @@ impl RandomXVMCache {
         self.cached_vm.replace(vm);
     }
 
-    /// Get the RandomX VMs.
+    pub async fn get_alt_vm<D: Database>(
+        &mut self,
+        height: u64,
+        chain: Chain,
+        database: D,
+    ) -> Result<Arc<RandomXVM>, ExtendedConsensusError> {
+        let seed_height = randomx_seed_height(height);
+
+        let BCResponse::BlockHash(seed_hash) = database
+            .oneshot(BCReadRequest::BlockHash(seed_height, chain))
+            .await?
+        else {
+            panic!("Database returned wrong response!");
+        };
+
+        if let Some(vm) = self.alt_vms.get(&seed_hash) {
+            return Ok(vm.clone());
+        };
+
+        for (vm_main_chain_height, vm_seed_hash) in &self.seeds {
+            if vm_seed_hash == &seed_hash {
+                let Some(vm) = self.vms.get(&vm_main_chain_height) else {
+                    break;
+                };
+
+                self.alt_vms.insert(seed_hash, vm.clone());
+                return Ok(vm.clone());
+            }
+        }
+
+        let alt_vm = rayon_spawn_async(move || Arc::new(RandomXVM::new(&seed_hash).unwrap())).await;
+
+        self.alt_vms.insert(seed_hash, alt_vm.clone());
+
+        Ok(alt_vm)
+    }
+
+    /// Get the main-chain RandomX VMs.
     pub async fn get_vms(&mut self) -> HashMap<u64, Arc<RandomXVM>> {
         match self.seeds.len().checked_sub(self.vms.len()) {
             // No difference in the amount of seeds to VMs.
@@ -231,8 +274,10 @@ async fn get_block_hashes<D: Database + Clone>(
     for height in heights {
         let db = database.clone();
         fut.push_back(async move {
-            let BCResponse::BlockHash(hash) =
-                db.clone().oneshot(BCReadRequest::BlockHash(height)).await?
+            let BCResponse::BlockHash(hash) = db
+                .clone()
+                .oneshot(BCReadRequest::BlockHash(height, Chain::Main))
+                .await?
             else {
                 panic!("Database sent incorrect response!");
             };

--- a/consensus/src/context/rx_vms.rs
+++ b/consensus/src/context/rx_vms.rs
@@ -129,6 +129,8 @@ impl RandomXVMCache {
         self.cached_vm.replace(vm);
     }
 
+    /// Creates a RX VM for an alt chain, looking at the main chain RX VMs to see if we can use one
+    /// of them first.
     pub async fn get_alt_vm<D: Database>(
         &mut self,
         height: u64,
@@ -209,6 +211,12 @@ impl RandomXVMCache {
         }
 
         self.vms.clone()
+    }
+
+    /// Removes all the RandomX VMs above the `new_height`.
+    pub fn pop_blocks_main_chain(&mut self, new_height: u64) {
+        self.seeds.retain(|(height, _)| *height < new_height);
+        self.vms.retain(|height, _| *height < new_height);
     }
 
     /// Add a new block to the VM cache.

--- a/consensus/src/context/task.rs
+++ b/consensus/src/context/task.rs
@@ -9,7 +9,7 @@ use tower::ServiceExt;
 use tracing::Instrument;
 
 use cuprate_consensus_rules::blocks::ContextToVerifyBlock;
-use cuprate_types::blockchain::{BCReadRequest, BCResponse};
+use cuprate_types::blockchain::{BCReadRequest, BCResponse, Chain};
 
 use super::{
     difficulty, hardforks, rx_vms, weight, BlockChainContext, BlockChainContextRequest,
@@ -95,14 +95,24 @@ impl ContextTask {
 
         let db = database.clone();
         let difficulty_cache_handle = tokio::spawn(async move {
-            difficulty::DifficultyCache::init_from_chain_height(chain_height, difficulty_cfg, db)
-                .await
+            difficulty::DifficultyCache::init_from_chain_height(
+                chain_height,
+                difficulty_cfg,
+                db,
+                Chain::Main,
+            )
+            .await
         });
 
         let db = database.clone();
         let weight_cache_handle = tokio::spawn(async move {
-            weight::BlockWeightsCache::init_from_chain_height(chain_height, weights_config, db)
-                .await
+            weight::BlockWeightsCache::init_from_chain_height(
+                chain_height,
+                weights_config,
+                db,
+                Chain::Main,
+            )
+            .await
         });
 
         // Wait for the hardfork state to finish first as we need it to start the randomX VM cache.

--- a/consensus/src/context/task.rs
+++ b/consensus/src/context/task.rs
@@ -274,6 +274,11 @@ impl<D: Database + Clone + Send + 'static> ContextTask<D> {
 
                 BlockChainContextResponse::Ok
             }
+            BlockChainContextRequest::ClearAltCache => {
+                self.alt_chain_cache_map.clear();
+
+                BlockChainContextResponse::Ok
+            }
             BlockChainContextRequest::AltChainContextCache { prev_id, _token } => {
                 BlockChainContextResponse::AltChainContextCache(
                     self.alt_chain_cache_map

--- a/consensus/src/context/task.rs
+++ b/consensus/src/context/task.rs
@@ -230,6 +230,8 @@ impl<D: Database + Clone + Send + 'static> ContextTask<D> {
                 BlockChainContextResponse::Ok
             }
             BlockChainContextRequest::PopBlocks { numb_blocks } => {
+                assert!(numb_blocks < self.chain_height);
+
                 self.difficulty_cache
                     .pop_blocks_main_chain(numb_blocks, self.database.clone())
                     .await?;

--- a/consensus/src/context/task.rs
+++ b/consensus/src/context/task.rs
@@ -264,7 +264,14 @@ impl<D: Database + Clone + Send + 'static> ContextTask<D> {
                     .get_alt_vm(height, chain, &mut self.database)
                     .await?,
             ),
-            BlockChainContextRequest::AddAltChainContextCache { .. } => todo!(),
+            BlockChainContextRequest::AddAltChainContextCache {
+                prev_id,
+                cache,
+                _token,
+            } => {
+                self.alt_chain_cache_map.add_alt_cache(prev_id, cache);
+                BlockChainContextResponse::Ok
+            }
         })
     }
 

--- a/consensus/src/context/weight.rs
+++ b/consensus/src/context/weight.rs
@@ -16,7 +16,10 @@ use tracing::instrument;
 
 use cuprate_consensus_rules::blocks::{penalty_free_zone, PENALTY_FREE_ZONE_5};
 use cuprate_helper::{asynch::rayon_spawn_async, num::RollingMedian};
-use cuprate_types::blockchain::{BCReadRequest, BCResponse, Chain};
+use cuprate_types::{
+    blockchain::{BCReadRequest, BCResponse},
+    Chain,
+};
 
 use crate::{Database, ExtendedConsensusError, HardFork};
 
@@ -120,7 +123,7 @@ impl BlockWeightsCache {
     ///
     /// The cache will be returned to the state it would have been in `numb_blocks` ago.
     #[instrument(name = "pop_blocks_weight_cache", skip_all, fields(numb_blocks = numb_blocks))]
-    pub async fn pop_blocks<D: Database + Clone>(
+    pub async fn pop_blocks_main_chain<D: Database + Clone>(
         &mut self,
         numb_blocks: u64,
         database: D,

--- a/consensus/src/context/weight.rs
+++ b/consensus/src/context/weight.rs
@@ -64,7 +64,7 @@ pub struct BlockWeightsCache {
     long_term_weights: RollingMedian<usize>,
 
     /// The height of the top block.
-    tip_height: u64,
+    pub(crate) tip_height: u64,
 
     pub(crate) config: BlockWeightsCacheConfig,
 }

--- a/consensus/src/tests/context/difficulty.rs
+++ b/consensus/src/tests/context/difficulty.rs
@@ -225,7 +225,7 @@ proptest! {
                 new_cache.new_block(new_cache.last_accounted_height+1, timestamp, cumulative_difficulty);
             }
 
-            new_cache.pop_blocks(blocks_to_pop as u64, database).await?;
+            new_cache.pop_blocks_main_chain(blocks_to_pop as u64, database).await?;
 
             prop_assert_eq!(new_cache, old_cache);
 
@@ -249,7 +249,7 @@ proptest! {
                 new_cache.new_block(new_cache.last_accounted_height+1, timestamp, cumulative_difficulty);
             }
 
-            new_cache.pop_blocks(blocks_to_pop as u64, database).await?;
+            new_cache.pop_blocks_main_chain(blocks_to_pop as u64, database).await?;
 
             prop_assert_eq!(new_cache, old_cache);
 

--- a/consensus/src/tests/context/difficulty.rs
+++ b/consensus/src/tests/context/difficulty.rs
@@ -3,13 +3,13 @@ use std::collections::VecDeque;
 use proptest::collection::{size_range, vec};
 use proptest::{prelude::*, prop_assert_eq, prop_compose, proptest};
 
-use cuprate_helper::num::median;
-
 use crate::{
     context::difficulty::*,
     tests::{context::data::DIF_3000000_3002000, mock_db::*},
     HardFork,
 };
+use cuprate_helper::num::median;
+use cuprate_types::Chain;
 
 const TEST_WINDOW: usize = 72;
 const TEST_CUT: usize = 6;
@@ -26,9 +26,13 @@ async fn first_3_blocks_fixed_difficulty() -> Result<(), tower::BoxError> {
     let genesis = DummyBlockExtendedHeader::default().with_difficulty_info(0, 1);
     db_builder.add_block(genesis);
 
-    let mut difficulty_cache =
-        DifficultyCache::init_from_chain_height(1, TEST_DIFFICULTY_CONFIG, db_builder.finish(None))
-            .await?;
+    let mut difficulty_cache = DifficultyCache::init_from_chain_height(
+        1,
+        TEST_DIFFICULTY_CONFIG,
+        db_builder.finish(None),
+        Chain::Main,
+    )
+    .await?;
 
     for height in 1..3 {
         assert_eq!(difficulty_cache.next_difficulty(&HardFork::V1), 1);
@@ -42,9 +46,13 @@ async fn genesis_block_skipped() -> Result<(), tower::BoxError> {
     let mut db_builder = DummyDatabaseBuilder::default();
     let genesis = DummyBlockExtendedHeader::default().with_difficulty_info(0, 1);
     db_builder.add_block(genesis);
-    let diff_cache =
-        DifficultyCache::init_from_chain_height(1, TEST_DIFFICULTY_CONFIG, db_builder.finish(None))
-            .await?;
+    let diff_cache = DifficultyCache::init_from_chain_height(
+        1,
+        TEST_DIFFICULTY_CONFIG,
+        db_builder.finish(None),
+        Chain::Main,
+    )
+    .await?;
     assert!(diff_cache.cumulative_difficulties.is_empty());
     assert!(diff_cache.timestamps.is_empty());
     Ok(())
@@ -66,8 +74,9 @@ async fn calculate_diff_3000000_3002000() -> Result<(), tower::BoxError> {
 
     let mut diff_cache = DifficultyCache::init_from_chain_height(
         3_000_720,
-        cfg.clone(),
+        cfg,
         db_builder.finish(Some(3_000_720)),
+        Chain::Main,
     )
     .await?;
 
@@ -215,7 +224,7 @@ proptest! {
         new_blocks in vec(any::<(u64, u128)>(), 0..500)
     ) {
         tokio_test::block_on(async move {
-            let old_cache = DifficultyCache::init_from_chain_height(19, TEST_DIFFICULTY_CONFIG, database.clone()).await.unwrap();
+            let old_cache = DifficultyCache::init_from_chain_height(19, TEST_DIFFICULTY_CONFIG, database.clone(), Chain::Main).await.unwrap();
 
             let blocks_to_pop = new_blocks.len();
 
@@ -239,7 +248,7 @@ proptest! {
         new_blocks in vec(any::<(u64, u128)>(), 0..5_000)
     ) {
         tokio_test::block_on(async move {
-            let old_cache = DifficultyCache::init_from_chain_height(1999, TEST_DIFFICULTY_CONFIG, database.clone()).await.unwrap();
+            let old_cache = DifficultyCache::init_from_chain_height(1999, TEST_DIFFICULTY_CONFIG, database.clone(), Chain::Main).await.unwrap();
 
             let blocks_to_pop = new_blocks.len();
 

--- a/consensus/src/tests/context/weight.rs
+++ b/consensus/src/tests/context/weight.rs
@@ -6,6 +6,7 @@ use crate::{
     tests::{context::data::BW_2850000_3050000, mock_db::*},
     HardFork,
 };
+use cuprate_types::Chain;
 
 pub const TEST_WEIGHT_CONFIG: BlockWeightsCacheConfig = BlockWeightsCacheConfig::new(100, 5000);
 
@@ -21,6 +22,7 @@ async fn blocks_out_of_window_not_counted() -> Result<(), tower::BoxError> {
         5000,
         TEST_WEIGHT_CONFIG,
         db_builder.finish(None),
+        Chain::Main,
     )
     .await?;
     assert_eq!(weight_cache.median_long_term_weight(), 2500);
@@ -47,9 +49,13 @@ async fn pop_blocks_greater_than_window() -> Result<(), tower::BoxError> {
 
     let database = db_builder.finish(None);
 
-    let mut weight_cache =
-        BlockWeightsCache::init_from_chain_height(5000, TEST_WEIGHT_CONFIG, database.clone())
-            .await?;
+    let mut weight_cache = BlockWeightsCache::init_from_chain_height(
+        5000,
+        TEST_WEIGHT_CONFIG,
+        database.clone(),
+        Chain::Main,
+    )
+    .await?;
 
     let old_cache = weight_cache.clone();
 
@@ -77,9 +83,13 @@ async fn pop_blocks_less_than_window() -> Result<(), tower::BoxError> {
 
     let database = db_builder.finish(None);
 
-    let mut weight_cache =
-        BlockWeightsCache::init_from_chain_height(500, TEST_WEIGHT_CONFIG, database.clone())
-            .await?;
+    let mut weight_cache = BlockWeightsCache::init_from_chain_height(
+        500,
+        TEST_WEIGHT_CONFIG,
+        database.clone(),
+        Chain::Main,
+    )
+    .await?;
 
     let old_cache = weight_cache.clone();
 
@@ -104,9 +114,13 @@ async fn weight_cache_calculates_correct_median() -> Result<(), tower::BoxError>
     let block = DummyBlockExtendedHeader::default().with_weight_into(0, 0);
     db_builder.add_block(block);
 
-    let mut weight_cache =
-        BlockWeightsCache::init_from_chain_height(1, TEST_WEIGHT_CONFIG, db_builder.finish(None))
-            .await?;
+    let mut weight_cache = BlockWeightsCache::init_from_chain_height(
+        1,
+        TEST_WEIGHT_CONFIG,
+        db_builder.finish(None),
+        Chain::Main,
+    )
+    .await?;
 
     for height in 1..=100 {
         weight_cache.new_block(height as u64, height, height);
@@ -136,6 +150,7 @@ async fn calc_bw_ltw_2850000_3050000() {
         2950000,
         TEST_WEIGHT_CONFIG,
         db_builder.finish(Some(2950000)),
+        Chain::Main,
     )
     .await
     .unwrap();

--- a/consensus/src/tests/context/weight.rs
+++ b/consensus/src/tests/context/weight.rs
@@ -57,7 +57,10 @@ async fn pop_blocks_greater_than_window() -> Result<(), tower::BoxError> {
     weight_cache.new_block(5001, 0, 0);
     weight_cache.new_block(5002, 0, 0);
 
-    weight_cache.pop_blocks(3, database).await.unwrap();
+    weight_cache
+        .pop_blocks_main_chain(3, database)
+        .await
+        .unwrap();
 
     assert_eq!(weight_cache, old_cache);
 
@@ -84,7 +87,10 @@ async fn pop_blocks_less_than_window() -> Result<(), tower::BoxError> {
     weight_cache.new_block(501, 0, 0);
     weight_cache.new_block(502, 0, 0);
 
-    weight_cache.pop_blocks(3, database).await.unwrap();
+    weight_cache
+        .pop_blocks_main_chain(3, database)
+        .await
+        .unwrap();
 
     assert_eq!(weight_cache, old_cache);
 

--- a/consensus/src/tests/mock_db.rs
+++ b/consensus/src/tests/mock_db.rs
@@ -127,6 +127,12 @@ pub struct DummyDatabase {
     dummy_height: Option<usize>,
 }
 
+impl DummyDatabase {
+    pub fn add_block(&mut self, block: DummyBlockExtendedHeader) {
+        self.blocks.write().unwrap().push(block)
+    }
+}
+
 impl Service<BCReadRequest> for DummyDatabase {
     type Response = BCResponse;
     type Error = BoxError;

--- a/consensus/src/tests/mock_db.rs
+++ b/consensus/src/tests/mock_db.rs
@@ -167,12 +167,12 @@ impl Service<BCReadRequest> for DummyDatabase {
                             .ok_or("block not in database!")?,
                     )
                 }
-                BCReadRequest::BlockHash(id) => {
+                BCReadRequest::BlockHash(id, _) => {
                     let mut hash = [0; 32];
                     hash[0..8].copy_from_slice(&id.to_le_bytes());
                     BCResponse::BlockHash(hash)
                 }
-                BCReadRequest::BlockExtendedHeaderInRange(range) => {
+                BCReadRequest::BlockExtendedHeaderInRange(range, _) => {
                     let mut end = usize::try_from(range.end).unwrap();
                     let mut start = usize::try_from(range.start).unwrap();
 
@@ -206,7 +206,7 @@ impl Service<BCReadRequest> for DummyDatabase {
 
                     BCResponse::ChainHeight(height, top_hash)
                 }
-                BCReadRequest::GeneratedCoins => BCResponse::GeneratedCoins(0),
+                BCReadRequest::GeneratedCoins(_) => BCResponse::GeneratedCoins(0),
                 _ => unimplemented!("the context svc should not need these requests!"),
             })
         }

--- a/helper/src/num.rs
+++ b/helper/src/num.rs
@@ -8,12 +8,18 @@ use core::{
     ops::{Add, Div, Mul, Sub},
 };
 
+#[cfg(feature = "std")]
+mod rolling_median;
+
 //---------------------------------------------------------------------------------------------------- Types
 // INVARIANT: must be private.
 // Protects against outside-crate implementations.
 mod private {
     pub trait Sealed: Copy + PartialOrd<Self> + core::fmt::Display {}
 }
+
+#[cfg(feature = "std")]
+pub use rolling_median::RollingMedian;
 
 /// Non-floating point numbers
 ///

--- a/helper/src/num/rolling_median.rs
+++ b/helper/src/num/rolling_median.rs
@@ -66,7 +66,7 @@ where
     /// `target_window` is the maximum amount of items to keep in the rolling window.
     ///
     /// # Panics
-    /// This function panics if the vec is larger than the target window length.
+    /// This function panics if `vec.len() > target_window`.
     pub fn from_vec(vec: Vec<T>, target_window: usize) -> Self {
         assert!(vec.len() <= target_window);
 

--- a/helper/src/num/rolling_median.rs
+++ b/helper/src/num/rolling_median.rs
@@ -76,7 +76,19 @@ where
         }
     }
 
-    /// Push an item to the back of the window.
+    /// Pops the back of the window, i.e. the youngest item.
+    pub fn pop_back(&mut self) {
+        if let Some(item) = self.window.pop_back() {
+            match self.sorted_window.binary_search(&item) {
+                Ok(idx) => {
+                    self.sorted_window.remove(idx);
+                }
+                Err(_) => panic!("Value expected to be in sorted_window was not there"),
+            }
+        }
+    }
+
+    /// Push an item to the _back_ of the window.
     ///
     /// This will pop the oldest item in the window if the target length has been exceeded.
     pub fn push(&mut self, item: T) {
@@ -88,6 +100,28 @@ where
         match self.sorted_window.binary_search(&item) {
             Ok(idx) | Err(idx) => self.sorted_window.insert(idx, item),
         }
+    }
+
+    /// Append some values to the _front_ of the window.
+    ///
+    /// These new values will be the oldest items in the window. The order of the inputted items will be
+    /// kept, i.e. the first item in the [`Vec`] will be the oldest item in the queue.
+    pub fn append_front(&mut self, items: Vec<T>) {
+        for item in items.into_iter().rev() {
+            self.window.push_front(item);
+            match self.sorted_window.binary_search(&item) {
+                Ok(idx) | Err(idx) => self.sorted_window.insert(idx, item),
+            }
+
+            if self.window.len() > self.target_window {
+                self.pop_back();
+            }
+        }
+    }
+
+    /// Returns the number of items currently in the [`RollingMedian`].
+    pub fn window_len(&self) -> usize {
+        self.window.len()
     }
 
     /// Calculated the median of the values currently in the [`RollingMedian`].

--- a/helper/src/num/rolling_median.rs
+++ b/helper/src/num/rolling_median.rs
@@ -1,0 +1,97 @@
+use std::{
+    collections::VecDeque,
+    ops::{Add, Div, Mul, Sub},
+};
+
+use crate::num::median;
+
+/// A rolling median type.
+///
+/// The `RollingMedian` keeps track of window of items and allows calculating the [RollingMedian::median] of them.
+// TODO: a more efficient structure is probably possible.
+#[derive(Debug, Ord, PartialOrd, Eq, PartialEq, Clone)]
+pub struct RollingMedian<T> {
+    /// The window of items, in order of insertion.
+    window: VecDeque<T>,
+    /// The window of items, sorted.
+    sorted_window: Vec<T>,
+
+    /// The target window length.
+    target_window: usize,
+}
+
+impl<T> RollingMedian<T>
+where
+    T: Ord
+        + PartialOrd
+        + Add<Output = T>
+        + Sub<Output = T>
+        + Div<Output = T>
+        + Mul<Output = T>
+        + Copy
+        + From<u8>,
+{
+    /// Creates a new [`RollingMedian`] with a certain target window length.
+    ///
+    /// The target window is the maximum amount of items to keep in the rolling window.
+    pub fn new(target_window: usize) -> RollingMedian<T> {
+        RollingMedian {
+            window: VecDeque::with_capacity(target_window),
+            sorted_window: Vec::with_capacity(target_window),
+            target_window,
+        }
+    }
+
+    /// Creates a new [`RollingMedian`] from a [`Vec`] with a certain target window length.
+    ///
+    /// The target window is the maximum amount of items to keep in the rolling window.
+    ///
+    /// # Panics
+    /// This function panics if the vec is larger than the target window length.
+    pub fn from_vec(value: Vec<T>, target_window: usize) -> RollingMedian<T> {
+        assert!(value.len() <= target_window);
+
+        let mut sorted_window = value.clone();
+        sorted_window.sort_unstable();
+
+        RollingMedian {
+            window: value.into(),
+            sorted_window,
+            target_window,
+        }
+    }
+
+    /// Pops the front of the window, i.e. the oldest item.
+    ///
+    /// This is often not needed [`RollingMedian::push`] will handle popping old values when they fall
+    /// out of the window.
+    pub fn pop_front(&mut self) {
+        if let Some(item) = self.window.pop_front() {
+            match self.sorted_window.binary_search(&item) {
+                Ok(idx) => {
+                    self.sorted_window.remove(idx);
+                }
+                Err(_) => panic!("Value expected to be in sorted_window was not there"),
+            }
+        }
+    }
+
+    /// Push an item to the back of the window.
+    ///
+    /// This will pop the oldest item in the window if the target length has been exceeded.
+    pub fn push(&mut self, item: T) {
+        if self.window.len() > self.target_window {
+            self.pop_front();
+        }
+
+        self.window.push_back(item);
+        match self.sorted_window.binary_search(&item) {
+            Ok(idx) | Err(idx) => self.sorted_window.insert(idx, item),
+        }
+    }
+
+    /// Calculated the median of the values currently in the [`RollingMedian`].
+    pub fn median(&self) -> T {
+        median(&self.sorted_window)
+    }
+}

--- a/helper/src/num/rolling_median.rs
+++ b/helper/src/num/rolling_median.rs
@@ -8,6 +8,25 @@ use crate::num::median;
 /// A rolling median type.
 ///
 /// This keeps track of a window of items and allows calculating the [`RollingMedian::median`] of them.
+///
+/// Example:
+/// ```rust
+/// # use cuprate_helper::num::RollingMedian;
+/// let mut rolling_median = RollingMedian::new(2);
+///
+/// rolling_median.push(1);
+/// assert_eq!(rolling_median.median(), 1);
+/// assert_eq!(rolling_median.window_len(), 1);
+///
+/// rolling_median.push(3);
+/// assert_eq!(rolling_median.median(), 2);
+/// assert_eq!(rolling_median.window_len(), 2);
+///
+/// rolling_median.push(5);
+/// assert_eq!(rolling_median.median(), 4);
+/// assert_eq!(rolling_median.window_len(), 2);
+/// ```
+///
 // TODO: a more efficient structure is probably possible.
 #[derive(Debug, Ord, PartialOrd, Eq, PartialEq, Clone)]
 pub struct RollingMedian<T> {
@@ -33,7 +52,7 @@ where
 {
     /// Creates a new [`RollingMedian`] with a certain target window length.
     ///
-    /// The target window is the maximum amount of items to keep in the rolling window.
+    /// `target_window` is the maximum amount of items to keep in the rolling window.
     pub fn new(target_window: usize) -> Self {
         Self {
             window: VecDeque::with_capacity(target_window),
@@ -44,18 +63,18 @@ where
 
     /// Creates a new [`RollingMedian`] from a [`Vec`] with a certain target window length.
     ///
-    /// The target window is the maximum amount of items to keep in the rolling window.
+    /// `target_window` is the maximum amount of items to keep in the rolling window.
     ///
     /// # Panics
     /// This function panics if the vec is larger than the target window length.
-    pub fn from_vec(value: Vec<T>, target_window: usize) -> RollingMedian<T> {
-        assert!(value.len() <= target_window);
+    pub fn from_vec(vec: Vec<T>, target_window: usize) -> Self {
+        assert!(vec.len() <= target_window);
 
-        let mut sorted_window = value.clone();
+        let mut sorted_window = vec.clone();
         sorted_window.sort_unstable();
 
-        RollingMedian {
-            window: value.into(),
+        Self {
+            window: vec.into(),
             sorted_window,
             target_window,
         }

--- a/helper/src/num/rolling_median.rs
+++ b/helper/src/num/rolling_median.rs
@@ -82,7 +82,7 @@ where
 
     /// Pops the front of the window, i.e. the oldest item.
     ///
-    /// This is often not needed [`RollingMedian::push`] will handle popping old values when they fall
+    /// This is often not needed as [`RollingMedian::push`] will handle popping old values when they fall
     /// out of the window.
     pub fn pop_front(&mut self) {
         if let Some(item) = self.window.pop_front() {

--- a/helper/src/num/rolling_median.rs
+++ b/helper/src/num/rolling_median.rs
@@ -80,7 +80,7 @@ where
     ///
     /// This will pop the oldest item in the window if the target length has been exceeded.
     pub fn push(&mut self, item: T) {
-        if self.window.len() > self.target_window {
+        if self.window.len() >= self.target_window {
             self.pop_front();
         }
 

--- a/helper/src/num/rolling_median.rs
+++ b/helper/src/num/rolling_median.rs
@@ -7,7 +7,7 @@ use crate::num::median;
 
 /// A rolling median type.
 ///
-/// The `RollingMedian` keeps track of window of items and allows calculating the [RollingMedian::median] of them.
+/// This keeps track of a window of items and allows calculating the [`RollingMedian::median`] of them.
 // TODO: a more efficient structure is probably possible.
 #[derive(Debug, Ord, PartialOrd, Eq, PartialEq, Clone)]
 pub struct RollingMedian<T> {
@@ -34,8 +34,8 @@ where
     /// Creates a new [`RollingMedian`] with a certain target window length.
     ///
     /// The target window is the maximum amount of items to keep in the rolling window.
-    pub fn new(target_window: usize) -> RollingMedian<T> {
-        RollingMedian {
+    pub fn new(target_window: usize) -> Self {
+        Self {
             window: VecDeque::with_capacity(target_window),
             sorted_window: Vec::with_capacity(target_window),
             target_window,
@@ -124,7 +124,7 @@ where
         self.window.len()
     }
 
-    /// Calculated the median of the values currently in the [`RollingMedian`].
+    /// Calculates the median of the values currently in the [`RollingMedian`].
     pub fn median(&self) -> T {
         median(&self.sorted_window)
     }

--- a/storage/blockchain/src/service/mod.rs
+++ b/storage/blockchain/src/service/mod.rs
@@ -74,7 +74,6 @@
 //! # #[tokio::main]
 //! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! // Create a configuration for the database environment.
-//! use cuprate_types::Chain;
 //! let tmp_dir = tempfile::tempdir()?;
 //! let db_dir = tmp_dir.path().to_owned();
 //! let config = ConfigBuilder::new()

--- a/storage/blockchain/src/service/mod.rs
+++ b/storage/blockchain/src/service/mod.rs
@@ -63,7 +63,7 @@
 //! use hex_literal::hex;
 //! use tower::{Service, ServiceExt};
 //!
-//! use cuprate_types::blockchain::{BCReadRequest, BCWriteRequest, BCResponse};
+//! use cuprate_types::{blockchain::{BCReadRequest, BCWriteRequest, BCResponse}, Chain};
 //! use cuprate_test_utils::data::block_v16_tx0;
 //!
 //! use cuprate_blockchain::{
@@ -74,6 +74,7 @@
 //! # #[tokio::main]
 //! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! // Create a configuration for the database environment.
+//! use cuprate_types::Chain;
 //! let tmp_dir = tempfile::tempdir()?;
 //! let db_dir = tmp_dir.path().to_owned();
 //! let config = ConfigBuilder::new()
@@ -85,7 +86,7 @@
 //!
 //! // Prepare a request to write block.
 //! let mut block = block_v16_tx0().clone();
-//! # block.height = 0 as u64; // must be 0th height or panic in `add_block()`
+//! # block.height = 0_u64; // must be 0th height or panic in `add_block()`
 //! let request = BCWriteRequest::WriteBlock(block);
 //!
 //! // Send the request.
@@ -100,7 +101,7 @@
 //!
 //! // Now, let's try getting the block hash
 //! // of the block we just wrote.
-//! let request = BCReadRequest::BlockHash(0);
+//! let request = BCReadRequest::BlockHash(0, Chain::Main);
 //! let response_channel = read_handle.ready().await?.call(request);
 //! let response = response_channel.await?;
 //! assert_eq!(

--- a/storage/blockchain/src/service/read.rs
+++ b/storage/blockchain/src/service/read.rs
@@ -15,10 +15,9 @@ use tokio_util::sync::PollSemaphore;
 
 use cuprate_database::{ConcreteEnv, DatabaseRo, Env, EnvInner, RuntimeError};
 use cuprate_helper::{asynch::InfallibleOneshotReceiver, map::combine_low_high_bits_to_u128};
-use cuprate_types::blockchain::Chain;
 use cuprate_types::{
     blockchain::{BCReadRequest, BCResponse},
-    ExtendedBlockHeader, OutputOnChain,
+    Chain, ExtendedBlockHeader, OutputOnChain,
 };
 
 use crate::{

--- a/storage/blockchain/src/service/read.rs
+++ b/storage/blockchain/src/service/read.rs
@@ -207,7 +207,7 @@ fn map_request(
     let response = match request {
         R::BlockExtendedHeader(block) => block_extended_header(env, block),
         R::BlockHash(block, chain) => block_hash(env, block, chain),
-        BCReadRequest::FindBlock(_) => todo!("Add alt blocks to DB"),
+        R::FindBlock(_) => todo!("Add alt blocks to DB"),
         R::FilterUnknownHashes(hashes) => filter_unknown_hashes(env, hashes),
         R::BlockExtendedHeaderInRange(range, chain) => {
             block_extended_header_in_range(env, range, chain)

--- a/storage/blockchain/src/service/read.rs
+++ b/storage/blockchain/src/service/read.rs
@@ -213,7 +213,7 @@ fn map_request(
             block_extended_header_in_range(env, range, chain)
         }
         R::ChainHeight => chain_height(env),
-        R::GeneratedCoins => generated_coins(env),
+        R::GeneratedCoins(height) => generated_coins(env, height),
         R::Outputs(map) => outputs(env, map),
         R::NumberOutputsWithAmount(vec) => number_outputs_with_amount(env, vec),
         R::KeyImagesSpent(set) => key_images_spent(env, set),
@@ -403,17 +403,14 @@ fn chain_height(env: &ConcreteEnv) -> ResponseResult {
 
 /// [`BCReadRequest::GeneratedCoins`].
 #[inline]
-fn generated_coins(env: &ConcreteEnv) -> ResponseResult {
+fn generated_coins(env: &ConcreteEnv, height: u64) -> ResponseResult {
     // Single-threaded, no `ThreadLocal` required.
     let env_inner = env.env_inner();
     let tx_ro = env_inner.tx_ro()?;
-    let table_block_heights = env_inner.open_db_ro::<BlockHeights>(&tx_ro)?;
     let table_block_infos = env_inner.open_db_ro::<BlockInfos>(&tx_ro)?;
 
-    let top_height = top_block_height(&table_block_heights)?;
-
     Ok(BCResponse::GeneratedCoins(cumulative_generated_coins(
-        &top_height,
+        &height,
         &table_block_infos,
     )?))
 }

--- a/storage/blockchain/src/service/tests.rs
+++ b/storage/blockchain/src/service/tests.rs
@@ -19,7 +19,7 @@ use cuprate_database::{ConcreteEnv, DatabaseIter, DatabaseRo, Env, EnvInner, Run
 use cuprate_test_utils::data::{block_v16_tx0, block_v1_tx2, block_v9_tx3};
 use cuprate_types::{
     blockchain::{BCReadRequest, BCResponse, BCWriteRequest},
-    OutputOnChain, VerifiedBlockInformation,
+    Chain, OutputOnChain, VerifiedBlockInformation,
 };
 
 use crate::{
@@ -139,10 +139,15 @@ async fn test_template(
         Err(RuntimeError::KeyNotFound)
     };
 
+    let test_chain_height = chain_height(tables.block_heights()).unwrap();
+
     let chain_height = {
-        let height = chain_height(tables.block_heights()).unwrap();
-        let block_info = get_block_info(&height.saturating_sub(1), tables.block_infos()).unwrap();
-        Ok(BCResponse::ChainHeight(height, block_info.block_hash))
+        let block_info =
+            get_block_info(&test_chain_height.saturating_sub(1), tables.block_infos()).unwrap();
+        Ok(BCResponse::ChainHeight(
+            test_chain_height,
+            block_info.block_hash,
+        ))
     };
 
     let cumulative_generated_coins = Ok(BCResponse::GeneratedCoins(cumulative_generated_coins));
@@ -183,12 +188,21 @@ async fn test_template(
             BCReadRequest::BlockExtendedHeader(1),
             extended_block_header_1,
         ),
-        (BCReadRequest::BlockHash(0), block_hash_0),
-        (BCReadRequest::BlockHash(1), block_hash_1),
-        (BCReadRequest::BlockExtendedHeaderInRange(0..1), range_0_1),
-        (BCReadRequest::BlockExtendedHeaderInRange(0..2), range_0_2),
+        (BCReadRequest::BlockHash(0, Chain::Main), block_hash_0),
+        (BCReadRequest::BlockHash(1, Chain::Main), block_hash_1),
+        (
+            BCReadRequest::BlockExtendedHeaderInRange(0..1, Chain::Main),
+            range_0_1,
+        ),
+        (
+            BCReadRequest::BlockExtendedHeaderInRange(0..2, Chain::Main),
+            range_0_2,
+        ),
         (BCReadRequest::ChainHeight, chain_height),
-        (BCReadRequest::GeneratedCoins, cumulative_generated_coins),
+        (
+            BCReadRequest::GeneratedCoins(test_chain_height),
+            cumulative_generated_coins,
+        ),
         (BCReadRequest::NumberOutputsWithAmount(num_req), num_resp),
         (BCReadRequest::KeyImagesSpent(ki_req), ki_resp),
     ] {

--- a/types/src/blockchain.rs
+++ b/types/src/blockchain.rs
@@ -9,16 +9,7 @@ use std::{
     ops::Range,
 };
 
-use crate::types::{ExtendedBlockHeader, OutputOnChain, VerifiedBlockInformation};
-
-#[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
-pub struct ChainID(pub u64);
-
-#[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
-pub enum Chain {
-    Main,
-    Alt(ChainID),
-}
+use crate::types::{Chain, ExtendedBlockHeader, OutputOnChain, VerifiedBlockInformation};
 
 //---------------------------------------------------------------------------------------------------- ReadRequest
 /// A read request to the blockchain database.

--- a/types/src/blockchain.rs
+++ b/types/src/blockchain.rs
@@ -32,7 +32,7 @@ pub enum BCReadRequest {
     /// The input is the block's height and the chain it is on.
     BlockHash(u64, Chain),
 
-    /// Request to check if we have a block and where it is.
+    /// Request to check if we have a block and which [`Chain`] it is on.
     ///
     /// The input is the block's hash.
     FindBlock([u8; 32]),

--- a/types/src/blockchain.rs
+++ b/types/src/blockchain.rs
@@ -52,8 +52,8 @@ pub enum BCReadRequest {
     /// Note that this is not the top-block height.
     ChainHeight,
 
-    /// Request the total amount of generated coins (atomic units) so far.
-    GeneratedCoins,
+    /// Request the total amount of generated coins (atomic units) at this height.
+    GeneratedCoins(u64),
 
     /// Request data for multiple outputs.
     ///

--- a/types/src/blockchain.rs
+++ b/types/src/blockchain.rs
@@ -134,6 +134,9 @@ pub enum BCResponse {
     /// Inner value is the hash of the requested block.
     BlockHash([u8; 32]),
 
+    /// Response to [`BCReadRequest::FindBlock`].
+    ///
+    /// Inner value is the chain and height of the block if found.
     FindBlock(Option<(Chain, u64)>),
 
     /// Response to [`BCReadRequest::FilterUnknownHashes`].

--- a/types/src/blockchain.rs
+++ b/types/src/blockchain.rs
@@ -38,8 +38,8 @@ pub enum BCReadRequest {
 
     /// Request a block's hash.
     ///
-    /// The input is the block's height.
-    BlockHash(u64),
+    /// The input is the block's height and the chain it is on.
+    BlockHash(u64, Chain),
 
     /// Request to check if we have a block and where it is.
     ///

--- a/types/src/blockchain.rs
+++ b/types/src/blockchain.rs
@@ -156,7 +156,7 @@ pub enum BCResponse {
 
     /// Response to [`BCReadRequest::GeneratedCoins`].
     ///
-    /// Inner value is the total amount of generated coins so far, in atomic units.
+    /// Inner value is the total amount of generated coins up to and including the chosen height, in atomic units.
     GeneratedCoins(u64),
 
     /// Response to [`BCReadRequest::Outputs`].

--- a/types/src/blockchain.rs
+++ b/types/src/blockchain.rs
@@ -11,6 +11,15 @@ use std::{
 
 use crate::types::{ExtendedBlockHeader, OutputOnChain, VerifiedBlockInformation};
 
+#[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
+pub struct ChainID(pub u64);
+
+#[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
+pub enum Chain {
+    Main,
+    Alt(ChainID),
+}
+
 //---------------------------------------------------------------------------------------------------- ReadRequest
 /// A read request to the blockchain database.
 ///
@@ -32,6 +41,11 @@ pub enum BCReadRequest {
     /// The input is the block's height.
     BlockHash(u64),
 
+    /// Request to check if we have a block and where it is.
+    ///
+    /// The input is the block's hash.
+    FindBlock([u8; 32]),
+
     /// Removes the block hashes that are not in the _main_ chain.
     ///
     /// This should filter (remove) hashes in alt-blocks as well.
@@ -40,7 +54,7 @@ pub enum BCReadRequest {
     /// Request a range of block extended headers.
     ///
     /// The input is a range of block heights.
-    BlockExtendedHeaderInRange(Range<u64>),
+    BlockExtendedHeaderInRange(Range<u64>, Chain),
 
     /// Request the current chain height.
     ///
@@ -128,6 +142,8 @@ pub enum BCResponse {
     ///
     /// Inner value is the hash of the requested block.
     BlockHash([u8; 32]),
+
+    FindBlock(Option<(Chain, u64)>),
 
     /// Response to [`BCReadRequest::FilterUnknownHashes`].
     ///

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -58,7 +58,7 @@
     clippy::nursery,
     clippy::cargo,
     unused_mut,
-    //missing_docs,
+    missing_docs,
     deprecated,
     unused_comparisons,
     nonstandard_style

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -88,7 +88,8 @@
 
 mod types;
 pub use types::{
-    ExtendedBlockHeader, OutputOnChain, VerifiedBlockInformation, VerifiedTransactionInformation,
+    AltBlockInformation, Chain, ChainID, ExtendedBlockHeader, OutputOnChain,
+    VerifiedBlockInformation, VerifiedTransactionInformation,
 };
 
 //---------------------------------------------------------------------------------------------------- Feature-gated

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -58,7 +58,7 @@
     clippy::nursery,
     clippy::cargo,
     unused_mut,
-    missing_docs,
+    //missing_docs,
     deprecated,
     unused_comparisons,
     nonstandard_style

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -88,7 +88,7 @@
 
 mod types;
 pub use types::{
-    AltBlockInformation, Chain, ChainID, ExtendedBlockHeader, OutputOnChain,
+    AltBlockInformation, Chain, ChainId, ExtendedBlockHeader, OutputOnChain,
     VerifiedBlockInformation, VerifiedTransactionInformation,
 };
 

--- a/types/src/types.rs
+++ b/types/src/types.rs
@@ -37,8 +37,8 @@ pub struct ExtendedBlockHeader {
 //---------------------------------------------------------------------------------------------------- VerifiedTransactionInformation
 /// Verified information of a transaction.
 ///
-/// If this is in a [`VerifiedBlockInformation`] this represents a  valid transaction, otherwise if this is in
-/// [`AltBlockInformation`] this represents a potentially valid transaction.
+/// - If this is in a [`VerifiedBlockInformation`] this represents a valid transaction
+/// - If this is in an [`AltBlockInformation`] this represents a potentially valid transaction
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct VerifiedTransactionInformation {
     /// The transaction itself.
@@ -90,12 +90,14 @@ pub struct VerifiedBlockInformation {
     /// The cumulative difficulty of all blocks up until and including this block.
     pub cumulative_difficulty: u128,
 }
+
 //---------------------------------------------------------------------------------------------------- ChainID
 /// A unique ID for an alt chain.
 ///
 /// The inner value is meaningless.
 #[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
 pub struct ChainID(pub u64);
+
 //---------------------------------------------------------------------------------------------------- Chain
 /// An identifier for a chain.
 #[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
@@ -105,8 +107,10 @@ pub enum Chain {
     /// An alt chain.
     Alt(ChainID),
 }
+
 //---------------------------------------------------------------------------------------------------- AltBlockInformation
 /// A block on an alternative chain.
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct AltBlockInformation {
     /// The block itself.
     pub block: Block,

--- a/types/src/types.rs
+++ b/types/src/types.rs
@@ -106,6 +106,7 @@ pub enum Chain {
     Alt(ChainID),
 }
 //---------------------------------------------------------------------------------------------------- AltBlockInformation
+/// A block on an alternative chain.
 pub struct AltBlockInformation {
     /// The block itself.
     pub block: Block,

--- a/types/src/types.rs
+++ b/types/src/types.rs
@@ -6,7 +6,6 @@ use monero_serai::{
     block::Block,
     transaction::{Timelock, Transaction},
 };
-
 //---------------------------------------------------------------------------------------------------- ExtendedBlockHeader
 /// Extended header data of a block.
 ///
@@ -38,7 +37,8 @@ pub struct ExtendedBlockHeader {
 //---------------------------------------------------------------------------------------------------- VerifiedTransactionInformation
 /// Verified information of a transaction.
 ///
-/// This represents a transaction in a valid block.
+/// If this is in a [`VerifiedBlockInformation`] this represents a  valid transaction, otherwise if this is in
+/// [`AltBlockInformation`] this represents a potentially valid transaction.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct VerifiedTransactionInformation {
     /// The transaction itself.
@@ -89,6 +89,42 @@ pub struct VerifiedBlockInformation {
     pub long_term_weight: usize,
     /// The cumulative difficulty of all blocks up until and including this block.
     pub cumulative_difficulty: u128,
+}
+//---------------------------------------------------------------------------------------------------- ChainID
+#[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
+pub struct ChainID(pub u64);
+//---------------------------------------------------------------------------------------------------- Chain
+#[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
+pub enum Chain {
+    Main,
+    Alt(ChainID),
+}
+//---------------------------------------------------------------------------------------------------- AltBlockInformation
+pub struct AltBlockInformation {
+    /// The block itself.
+    pub block: Block,
+    /// The serialized byte form of [`Self::block`].
+    ///
+    /// [`Block::serialize`].
+    pub block_blob: Vec<u8>,
+    /// All the transactions in the block, excluding the [`Block::miner_tx`].
+    pub txs: Vec<VerifiedTransactionInformation>,
+    /// The block's hash.
+    ///
+    /// [`Block::hash`].
+    pub block_hash: [u8; 32],
+    /// The block's proof-of-work hash.
+    pub pow_hash: [u8; 32],
+    /// The block's height.
+    pub height: u64,
+    /// The adjusted block size, in bytes.
+    pub weight: usize,
+    /// The long term block weight, which is the weight factored in with previous block weights.
+    pub long_term_weight: usize,
+    /// The cumulative difficulty of all blocks up until and including this block.
+    pub cumulative_difficulty: u128,
+
+    pub chain_id: ChainID,
 }
 
 //---------------------------------------------------------------------------------------------------- OutputOnChain

--- a/types/src/types.rs
+++ b/types/src/types.rs
@@ -6,6 +6,7 @@ use monero_serai::{
     block::Block,
     transaction::{Timelock, Transaction},
 };
+
 //---------------------------------------------------------------------------------------------------- ExtendedBlockHeader
 /// Extended header data of a block.
 ///
@@ -96,7 +97,7 @@ pub struct VerifiedBlockInformation {
 ///
 /// The inner value is meaningless.
 #[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
-pub struct ChainID(pub u64);
+pub struct ChainId(pub u64);
 
 //---------------------------------------------------------------------------------------------------- Chain
 /// An identifier for a chain.
@@ -105,7 +106,7 @@ pub enum Chain {
     /// The main chain.
     Main,
     /// An alt chain.
-    Alt(ChainID),
+    Alt(ChainId),
 }
 
 //---------------------------------------------------------------------------------------------------- AltBlockInformation
@@ -134,8 +135,8 @@ pub struct AltBlockInformation {
     pub long_term_weight: usize,
     /// The cumulative difficulty of all blocks up until and including this block.
     pub cumulative_difficulty: u128,
-    /// The [`ChainID`] of the chain this alt block is on.
-    pub chain_id: ChainID,
+    /// The [`ChainId`] of the chain this alt block is on.
+    pub chain_id: ChainId,
 }
 
 //---------------------------------------------------------------------------------------------------- OutputOnChain

--- a/types/src/types.rs
+++ b/types/src/types.rs
@@ -91,12 +91,18 @@ pub struct VerifiedBlockInformation {
     pub cumulative_difficulty: u128,
 }
 //---------------------------------------------------------------------------------------------------- ChainID
+/// A unique ID for an alt chain.
+///
+/// The inner value is meaningless.
 #[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
 pub struct ChainID(pub u64);
 //---------------------------------------------------------------------------------------------------- Chain
+/// An identifier for a chain.
 #[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
 pub enum Chain {
+    /// The main chain.
     Main,
+    /// An alt chain.
     Alt(ChainID),
 }
 //---------------------------------------------------------------------------------------------------- AltBlockInformation
@@ -123,7 +129,7 @@ pub struct AltBlockInformation {
     pub long_term_weight: usize,
     /// The cumulative difficulty of all blocks up until and including this block.
     pub cumulative_difficulty: u128,
-
+    /// The [`ChainID`] of the chain this alt block is on.
     pub chain_id: ChainID,
 }
 


### PR DESCRIPTION
### What

Adds alt-chain handling to our consensus code.

part of: #194

### How

Handling of alt blocks/chains is delicate balance, we need to check alt block weight however the amount of data needed to check block weight is too much to do for any alt block.

So handling of alt blocks is done in steps.

Going roughly, first we build the difficulty cache and check the blocks PoW. Then if that is valid we build the weight cache and check block weight. This means we need to add multiple new request to the context cache.

Also to prevent needing to build the caches multiple times we keep the alt caches cached in the context cache.

Some changes had to be made to the database requests/response types.