### PR TITLE
fixed-bytes: add `serde`, document feature flags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -274,6 +274,9 @@ name = "bytes"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "cc"
@@ -641,6 +644,7 @@ name = "cuprate-fixed-bytes"
 version = "0.1.0"
 dependencies = [
  "bytes",
+ "serde",
  "thiserror",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -645,6 +645,7 @@ version = "0.1.0"
 dependencies = [
  "bytes",
  "serde",
+ "serde_json",
  "thiserror",
 ]
 

--- a/net/fixed-bytes/Cargo.toml
+++ b/net/fixed-bytes/Cargo.toml
@@ -6,9 +6,11 @@ license = "MIT"
 authors = ["Boog900"]
 
 [features]
-default = ["std"]
+default = ["std", "serde"]
 std = ["bytes/std", "dep:thiserror"]
+serde = ["bytes/serde", "dep:serde"]
 
 [dependencies]
 thiserror = { workspace = true, optional = true }
 bytes = { workspace = true }
+serde = { workspace = true, optional = true }

--- a/net/fixed-bytes/Cargo.toml
+++ b/net/fixed-bytes/Cargo.toml
@@ -13,4 +13,4 @@ serde = ["bytes/serde", "dep:serde"]
 [dependencies]
 thiserror = { workspace = true, optional = true }
 bytes = { workspace = true }
-serde = { workspace = true, optional = true }
+serde = { workspace = true, features = ["derive"], optional = true }

--- a/net/fixed-bytes/Cargo.toml
+++ b/net/fixed-bytes/Cargo.toml
@@ -14,3 +14,6 @@ serde = ["bytes/serde", "dep:serde"]
 thiserror = { workspace = true, optional = true }
 bytes = { workspace = true }
 serde = { workspace = true, features = ["derive"], optional = true }
+
+[dev-dependencies]
+serde_json = { workspace = true, features = ["std"] }

--- a/net/fixed-bytes/README.md
+++ b/net/fixed-bytes/README.md
@@ -1,0 +1,10 @@
+# `cuprate-fixed-bytes`
+TODO
+
+# Feature flags
+| Feature flag | Does what |
+|--------------|-----------|
+| `std`        | TODO
+| `serde`      | Enables `serde` on applicable types
+
+`serde` is enabled by default.

--- a/net/fixed-bytes/src/lib.rs
+++ b/net/fixed-bytes/src/lib.rs
@@ -1,3 +1,5 @@
+#![doc = include_str!("../README.md")]
+
 use core::{
     fmt::{Debug, Formatter},
     ops::{Deref, Index},
@@ -5,7 +7,11 @@ use core::{
 
 use bytes::{BufMut, Bytes, BytesMut};
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 #[cfg_attr(feature = "std", derive(thiserror::Error))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub enum FixedByteError {
     #[cfg_attr(
         feature = "std",
@@ -43,6 +49,7 @@ impl Debug for FixedByteError {
 /// Internally this is just a wrapper around [`Bytes`], with the constructors checking that the length is equal to `N`.
 /// This implements [`Deref`] with the target being `[u8; N]`.
 #[derive(Debug, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct ByteArray<const N: usize>(Bytes);
 
 impl<const N: usize> ByteArray<N> {
@@ -88,6 +95,7 @@ impl<const N: usize> TryFrom<Vec<u8>> for ByteArray<N> {
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct ByteArrayVec<const N: usize>(Bytes);
 
 impl<const N: usize> ByteArrayVec<N> {

--- a/net/fixed-bytes/src/lib.rs
+++ b/net/fixed-bytes/src/lib.rs
@@ -247,6 +247,8 @@ impl<const N: usize> Index<usize> for ByteArrayVec<N> {
 
 #[cfg(test)]
 mod tests {
+    use serde_json::{from_str, to_string};
+
     use super::*;
 
     #[test]
@@ -256,5 +258,47 @@ mod tests {
 
         assert_eq!(bytes.len(), 100);
         let _ = bytes[99];
+    }
+
+    /// Tests that `serde` works on [`ByteArray`].
+    #[test]
+    #[cfg(feature = "serde")]
+    fn byte_array_serde() {
+        let b = ByteArray::from([1, 0, 0, 0, 1]);
+        let string = to_string(&b).unwrap();
+        assert_eq!(string, "[1,0,0,0,1]");
+        let b2 = from_str::<ByteArray<5>>(&string).unwrap();
+        assert_eq!(b, b2);
+    }
+
+    /// Tests that `serde` works on [`ByteArrayVec`].
+    #[test]
+    #[cfg(feature = "serde")]
+    fn byte_array_vec_serde() {
+        let b = ByteArrayVec::from([1, 0, 0, 0, 1]);
+        let string = to_string(&b).unwrap();
+        assert_eq!(string, "[1,0,0,0,1]");
+        let b2 = from_str::<ByteArrayVec<5>>(&string).unwrap();
+        assert_eq!(b, b2);
+    }
+
+    /// Tests that bad input `serde` fails on [`ByteArray`].
+    #[test]
+    #[cfg(feature = "serde")]
+    #[should_panic(
+        expected = r#"called `Result::unwrap()` on an `Err` value: Error("invalid length 4, expected 5", line: 0, column: 0)"#
+    )]
+    fn byte_array_bad_deserialize() {
+        from_str::<ByteArray<5>>("[1,0,0,0]").unwrap();
+    }
+
+    /// Tests that bad input `serde` fails on [`ByteArrayVec`].
+    #[test]
+    #[cfg(feature = "serde")]
+    #[should_panic(
+        expected = r#"called `Result::unwrap()` on an `Err` value: Error("invalid length 4, expected 5", line: 0, column: 0)"#
+    )]
+    fn byte_array_vec_bad_deserialize() {
+        from_str::<ByteArrayVec<5>>("[1,0,0,0]").unwrap();
     }
 }


### PR DESCRIPTION
### What
Adds a `serde` feature flag (enabled by default) to `cuprate-fixed-bytes` and documents it.

### Why
For https://github.com/Cuprate/cuprate/pull/220#discussion_r1672904392.