### PR TITLE
books: fix typo

### DIFF
--- a/books/protocol/src/p2p_network/levin/admin.md
+++ b/books/protocol/src/p2p_network/levin/admin.md
@@ -67,7 +67,7 @@ ID: `1007`[^support-flags]
 
 #### Request [^sf-req] { #support-flags-request }
 
-No data is serialized for a ping request.
+No data is serialized for a support flags request.
 
 #### Response [^sf-res] { #support-flags-response }
 


### PR DESCRIPTION
I forgot to change this when copy pasting 
