### PR TITLE
`std::mem::{size,align}_of` -> `{size,align}_of`

### DIFF
--- a/net/epee-encoding/src/container_as_blob.rs
+++ b/net/epee-encoding/src/container_as_blob.rs
@@ -70,7 +70,7 @@ pub trait Containerable {
 macro_rules! int_container_able {
     ($int:ty ) => {
         impl Containerable for $int {
-            const SIZE: usize = std::mem::size_of::<$int>();
+            const SIZE: usize = size_of::<$int>();
 
             fn from_bytes(bytes: &[u8]) -> Self {
                 <$int>::from_le_bytes(bytes.try_into().unwrap())

--- a/net/epee-encoding/src/io.rs
+++ b/net/epee-encoding/src/io.rs
@@ -7,7 +7,7 @@ pub fn checked_read_primitive<B: Buf, R: Sized>(
     b: &mut B,
     read: impl Fn(&mut B) -> R,
 ) -> Result<R> {
-    checked_read(b, read, core::mem::size_of::<R>())
+    checked_read(b, read, size_of::<R>())
 }
 
 #[inline]
@@ -25,7 +25,7 @@ pub fn checked_write_primitive<B: BufMut, T: Sized>(
     write: impl Fn(&mut B, T),
     t: T,
 ) -> Result<()> {
-    checked_write(b, write, t, core::mem::size_of::<T>())
+    checked_write(b, write, t, size_of::<T>())
 }
 
 #[inline]

--- a/storage/blockchain/src/types.rs
+++ b/storage/blockchain/src/types.rs
@@ -121,7 +121,6 @@ pub type UnlockTime = u64;
 /// # Size & Alignment
 /// ```rust
 /// # use cuprate_blockchain::types::*;
-/// # use std::mem::*;
 /// assert_eq!(size_of::<PreRctOutputId>(), 16);
 /// assert_eq!(align_of::<PreRctOutputId>(), 8);
 /// ```
@@ -174,7 +173,6 @@ impl Key for PreRctOutputId {}
 /// # Size & Alignment
 /// ```rust
 /// # use cuprate_blockchain::types::*;
-/// # use std::mem::*;
 /// assert_eq!(size_of::<BlockInfo>(), 88);
 /// assert_eq!(align_of::<BlockInfo>(), 8);
 /// ```
@@ -226,7 +224,6 @@ bitflags::bitflags! {
     /// # Size & Alignment
     /// ```rust
     /// # use cuprate_blockchain::types::*;
-    /// # use std::mem::*;
     /// assert_eq!(size_of::<OutputFlags>(), 4);
     /// assert_eq!(align_of::<OutputFlags>(), 4);
     /// ```
@@ -262,7 +259,6 @@ bitflags::bitflags! {
 /// # Size & Alignment
 /// ```rust
 /// # use cuprate_blockchain::types::*;
-/// # use std::mem::*;
 /// assert_eq!(size_of::<Output>(), 48);
 /// assert_eq!(align_of::<Output>(), 8);
 /// ```
@@ -306,7 +302,6 @@ pub struct Output {
 /// # Size & Alignment
 /// ```rust
 /// # use cuprate_blockchain::types::*;
-/// # use std::mem::*;
 /// assert_eq!(size_of::<RctOutput>(), 80);
 /// assert_eq!(align_of::<RctOutput>(), 8);
 /// ```

--- a/storage/database/README.md
+++ b/storage/database/README.md
@@ -66,8 +66,8 @@ As `ConcreteEnv` is just a re-exposed type which has varying inner types,
 it means some properties will change depending on the backend used.
 
 For example:
-- [`std::mem::size_of::<ConcreteEnv>`]
-- [`std::mem::align_of::<ConcreteEnv>`]
+- [`size_of::<ConcreteEnv>`]
+- [`align_of::<ConcreteEnv>`]
 
 Things like these functions are affected by the backend and inner data,
 and should not be relied upon. This extends to any `struct/enum` that contains `ConcreteEnv`.

--- a/storage/database/src/storable.rs
+++ b/storage/database/src/storable.rs
@@ -109,7 +109,7 @@ impl<T> Storable for T
 where
     Self: Pod + Debug,
 {
-    const BYTE_LENGTH: Option<usize> = Some(std::mem::size_of::<T>());
+    const BYTE_LENGTH: Option<usize> = Some(size_of::<T>());
 
     #[inline]
     fn as_bytes(&self) -> &[u8] {


### PR DESCRIPTION
### What
Replace `std::mem::{size,align}_of` with `{size,align}_of` throughout the codebase.

Added to the prelude and stabilized in https://github.com/rust-lang/rust/pull/123168 (1.80).