### PR TITLE
workspace: add naming convention lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -250,6 +250,7 @@ empty_structs_with_brackets = "deny"
 empty_enum_variants_with_brackets = "deny"
 empty_drop = "deny"
 clone_on_ref_ptr = "deny"
+upper_case_acronyms  = "deny"
 
 # Hot
 # inline_always = "deny"
@@ -296,6 +297,7 @@ let_underscore_drop = "deny"
 unreachable_pub = "deny"
 unused_qualifications = "deny"
 variant_size_differences = "deny"
+non_camel_case_types = "deny"
 
 # Hot
 # unused_results = "deny"

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,1 @@
+upper-case-acronyms-aggressive = true

--- a/consensus/src/block/alt_block.rs
+++ b/consensus/src/block/alt_block.rs
@@ -24,7 +24,7 @@ use crate::{
     block::{free::pull_ordered_transactions, PreparedBlock},
     context::{
         difficulty::DifficultyCache,
-        rx_vms::RandomXVM,
+        rx_vms::RandomXVm,
         weight::{self, BlockWeightsCache},
         AltChainContextCache, AltChainRequestToken, BLOCKCHAIN_TIMESTAMP_CHECK_WINDOW,
     },
@@ -195,7 +195,7 @@ async fn alt_rx_vm<C>(
     parent_chain: Chain,
     alt_chain_context: &mut AltChainContextCache,
     context_svc: C,
-) -> Result<Option<Arc<RandomXVM>>, ExtendedConsensusError>
+) -> Result<Option<Arc<RandomXVm>>, ExtendedConsensusError>
 where
     C: Service<
             BlockChainContextRequest,

--- a/consensus/src/block/batch_prepare.rs
+++ b/consensus/src/block/batch_prepare.rs
@@ -15,7 +15,7 @@ use cuprate_helper::asynch::rayon_spawn_async;
 
 use crate::{
     block::{free::pull_ordered_transactions, PreparedBlock, PreparedBlockExPow},
-    context::rx_vms::RandomXVM,
+    context::rx_vms::RandomXVm,
     transactions::new_tx_verification_data,
     BlockChainContextRequest, BlockChainContextResponse, ExtendedConsensusError,
     VerifyBlockResponse,
@@ -148,7 +148,7 @@ where
         tracing::debug!("New randomX seed in batch, initialising VM");
 
         let new_vm = rayon_spawn_async(move || {
-            Arc::new(RandomXVM::new(&new_vm_seed).expect("RandomX VM gave an error on set up!"))
+            Arc::new(RandomXVm::new(&new_vm_seed).expect("RandomX VM gave an error on set up!"))
         })
         .await;
 

--- a/consensus/src/context.rs
+++ b/consensus/src/context.rs
@@ -33,7 +33,7 @@ mod tokens;
 
 use cuprate_types::Chain;
 use difficulty::DifficultyCache;
-use rx_vms::RandomXVM;
+use rx_vms::RandomXVm;
 use weight::BlockWeightsCache;
 
 pub(crate) use alt_chains::{sealed::AltChainRequestToken, AltChainContextCache};
@@ -236,7 +236,7 @@ pub enum BlockChainContextRequest {
     /// seed.
     ///
     /// This should include the seed used to init this VM and the VM.
-    NewRXVM(([u8; 32], Arc<RandomXVM>)),
+    NewRXVM(([u8; 32], Arc<RandomXVm>)),
     /// A request to add a new block to the cache.
     Update(NewBlockData),
     /// Pop blocks from the cache to the specified height.
@@ -313,7 +313,7 @@ pub enum BlockChainContextResponse {
     /// Blockchain context response.
     Context(BlockChainContext),
     /// A map of seed height to RandomX VMs.
-    RxVms(HashMap<usize, Arc<RandomXVM>>),
+    RxVms(HashMap<usize, Arc<RandomXVm>>),
     /// A list of difficulties.
     BatchDifficulties(Vec<u128>),
     /// An alt chain context cache.
@@ -321,7 +321,7 @@ pub enum BlockChainContextResponse {
     /// A difficulty cache for an alt chain.
     AltChainDifficultyCache(DifficultyCache),
     /// A randomX VM for an alt chain.
-    AltChainRxVM(Arc<RandomXVM>),
+    AltChainRxVM(Arc<RandomXVm>),
     /// A weight cache for an alt chain
     AltChainWeightCache(BlockWeightsCache),
     /// A generic Ok response.

--- a/consensus/src/context/alt_chains.rs
+++ b/consensus/src/context/alt_chains.rs
@@ -11,7 +11,7 @@ use cuprate_types::{
 use crate::{
     ExtendedConsensusError,
     __private::Database,
-    context::{difficulty::DifficultyCache, rx_vms::RandomXVM, weight::BlockWeightsCache},
+    context::{difficulty::DifficultyCache, rx_vms::RandomXVm, weight::BlockWeightsCache},
 };
 
 pub(crate) mod sealed {
@@ -32,7 +32,7 @@ pub struct AltChainContextCache {
     pub difficulty_cache: Option<DifficultyCache>,
 
     /// A cached RX VM.
-    pub cached_rx_vm: Option<(usize, Arc<RandomXVM>)>,
+    pub cached_rx_vm: Option<(usize, Arc<RandomXVm>)>,
 
     /// The chain height of the alt chain.
     pub chain_height: usize,

--- a/consensus/src/context/task.rs
+++ b/consensus/src/context/task.rs
@@ -45,7 +45,7 @@ pub struct ContextTask<D: Database> {
     /// The weight cache.
     weight_cache: weight::BlockWeightsCache,
     /// The RX VM cache.
-    rx_vm_cache: rx_vms::RandomXVMCache,
+    rx_vm_cache: rx_vms::RandomXVmCache,
     /// The hard-fork state cache.
     hardfork_state: hardforks::HardForkState,
 
@@ -127,7 +127,7 @@ impl<D: Database + Clone + Send + 'static> ContextTask<D> {
 
         let db = database.clone();
         let rx_seed_handle = tokio::spawn(async move {
-            rx_vms::RandomXVMCache::init_from_chain_height(chain_height, &current_hf, db).await
+            rx_vms::RandomXVmCache::init_from_chain_height(chain_height, &current_hf, db).await
         });
 
         let context_svc = ContextTask {

--- a/consensus/src/tests/context/rx_vms.rs
+++ b/consensus/src/tests/context/rx_vms.rs
@@ -9,7 +9,7 @@ use cuprate_consensus_rules::{
 };
 
 use crate::{
-    context::rx_vms::{get_last_rx_seed_heights, RandomXVMCache},
+    context::rx_vms::{get_last_rx_seed_heights, RandomXVmCache},
     tests::mock_db::*,
 };
 
@@ -42,7 +42,7 @@ fn rx_heights_consistent() {
 async fn rx_vm_created_on_hf_12() {
     let db = DummyDatabaseBuilder::default().finish(Some(10));
 
-    let mut cache = RandomXVMCache::init_from_chain_height(10, &HardFork::V11, db)
+    let mut cache = RandomXVmCache::init_from_chain_height(10, &HardFork::V11, db)
         .await
         .unwrap();
 
@@ -67,7 +67,7 @@ proptest! {
         let rt = Builder::new_multi_thread().enable_all().build().unwrap();
 
         rt.block_on(async move {
-            let cache = RandomXVMCache::init_from_chain_height(10, &hf, db).await.unwrap();
+            let cache = RandomXVmCache::init_from_chain_height(10, &hf, db).await.unwrap();
             assert!(cache.seeds.len() == cache.vms.len() || hf < HardFork::V12);
         });
     }

--- a/net/epee-encoding/tests/duplicate_key.rs
+++ b/net/epee-encoding/tests/duplicate_key.rs
@@ -9,12 +9,12 @@ epee_object!(
     a: u8,
 );
 
-struct TT {
+struct T2 {
     a: u8,
 }
 
 epee_object!(
-    TT,
+    T2,
     a: u8 = 0,
 );
 
@@ -35,5 +35,5 @@ fn duplicate_key_with_default() {
         b'a', 0x0B, 0x00,
     ];
 
-    assert!(from_bytes::<TT, _>(&mut &data[..]).is_err());
+    assert!(from_bytes::<T2, _>(&mut &data[..]).is_err());
 }


### PR DESCRIPTION
### What
Adds:

- https://rust-lang.github.io/rust-clippy/master/index.html#/upper_case_acronyms
- https://doc.rust-lang.org/rustc/lints/listing/warn-by-default.html#non-camel-case-types

to enforce the [Rust naming convention](https://rust-lang.github.io/api-guidelines/naming.html#casing-conforms-to-rfc-430-c-case).

---

Changes `RandomXVM` -> `RandomXVm` and some other things. To be fair `RandomX` is an uncommon case but here are some other VM examples:

- https://reth.rs/docs/reth/revm/struct.Evm.html
- https://reth.rs/docs/reth/core/rpc/types/trace/parity/struct.VmTrace.html
