### PR TITLE
Storage: use `saturating_add` for `cumulative_generated_coins`

### DIFF
--- a/storage/blockchain/src/ops/block.rs
+++ b/storage/blockchain/src/ops/block.rs
@@ -89,9 +89,9 @@ pub fn add_block(
     // RCT output count needs account for _this_ block's outputs.
     let cumulative_rct_outs = get_rct_num_outputs(tables.rct_outputs())?;
 
+    // `saturating_add` is used here as cumulative generated coins overflows due to tail emission.
     let cumulative_generated_coins =
-        cumulative_generated_coins(&block.height.saturating_sub(1), tables.block_infos())?
-            + block.generated_coins;
+        cumulative_generated_coins(&block.height.saturating_sub(1), tables.block_infos())?.saturating_add(block.generated_coins);
 
     let (cumulative_difficulty_low, cumulative_difficulty_high) =
         split_u128_into_low_high_bits(block.cumulative_difficulty);

--- a/storage/blockchain/src/ops/block.rs
+++ b/storage/blockchain/src/ops/block.rs
@@ -91,7 +91,8 @@ pub fn add_block(
 
     // `saturating_add` is used here as cumulative generated coins overflows due to tail emission.
     let cumulative_generated_coins =
-        cumulative_generated_coins(&block.height.saturating_sub(1), tables.block_infos())?.saturating_add(block.generated_coins);
+        cumulative_generated_coins(&block.height.saturating_sub(1), tables.block_infos())?
+            .saturating_add(block.generated_coins);
 
     let (cumulative_difficulty_low, cumulative_difficulty_high) =
         split_u128_into_low_high_bits(block.cumulative_difficulty);


### PR DESCRIPTION
### Why

This amount overflows due to tail emission, the consensus cache already does this.
