### PR TITLE
lints: replace `allow` with `expect`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -264,6 +264,7 @@ empty_enum_variants_with_brackets = "deny"
 empty_drop = "deny"
 clone_on_ref_ptr = "deny"
 upper_case_acronyms  = "deny"
+allow_attributes = "deny"
 
 # Hot
 # inline_always = "deny"

--- a/helper/src/atomic.rs
+++ b/helper/src/atomic.rs
@@ -28,9 +28,9 @@ const _: () = {
 /// This is an alias for
 /// [`crossbeam::atomic::AtomicCell<f32>`](https://docs.rs/crossbeam/latest/crossbeam/atomic/struct.AtomicCell.html).
 ///
-/// Note that there are no [`Ordering`] parameters,
-/// atomic loads use [`Acquire`](a),
-/// and atomic stores use [`Release`](r).
+/// Note that there are no [Ordering] parameters,
+/// atomic loads use [Acquire],
+/// and atomic stores use [Release].
 ///
 /// [Ordering]: std::sync::atomic::Ordering
 /// [Acquire]: std::sync::atomic::Ordering::Acquire
@@ -42,9 +42,9 @@ pub type AtomicF32 = AtomicCell<f32>;
 /// This is an alias for
 /// [`crossbeam::atomic::AtomicCell<f64>`](https://docs.rs/crossbeam/latest/crossbeam/atomic/struct.AtomicCell.html).
 ///
-/// Note that there are no [`Ordering`] parameters,
-/// atomic loads use [`Acquire`],
-/// and atomic stores use [`Release`].
+/// Note that there are no [Ordering] parameters,
+/// atomic loads use [Acquire],
+/// and atomic stores use [Release].
 ///
 /// [Ordering]: std::sync::atomic::Ordering
 /// [Acquire]: std::sync::atomic::Ordering::Acquire

--- a/helper/src/atomic.rs
+++ b/helper/src/atomic.rs
@@ -5,9 +5,6 @@
 //---------------------------------------------------------------------------------------------------- Use
 use crossbeam::atomic::AtomicCell;
 
-#[allow(unused_imports)] // docs
-use std::sync::atomic::{Ordering, Ordering::Acquire, Ordering::Release};
-
 //---------------------------------------------------------------------------------------------------- Atomic Float
 /// Compile-time assertion that our floats are
 /// lock-free for the target we're building for.
@@ -31,9 +28,13 @@ const _: () = {
 /// This is an alias for
 /// [`crossbeam::atomic::AtomicCell<f32>`](https://docs.rs/crossbeam/latest/crossbeam/atomic/struct.AtomicCell.html).
 ///
-/// Note that there are no [`Ordering`] parameters,
-/// atomic loads use [`Acquire`],
-/// and atomic stores use [`Release`].
+/// Note that there are no [`Ordering`](o) parameters,
+/// atomic loads use [`Acquire`](a),
+/// and atomic stores use [`Release`](r).
+///
+/// [o]: std::sync::atomic::Ordering
+/// [a]: std::sync::atomic::Ordering
+/// [r]: std::sync::atomic::Ordering
 pub type AtomicF32 = AtomicCell<f32>;
 
 /// An atomic [`f64`].
@@ -41,9 +42,13 @@ pub type AtomicF32 = AtomicCell<f32>;
 /// This is an alias for
 /// [`crossbeam::atomic::AtomicCell<f64>`](https://docs.rs/crossbeam/latest/crossbeam/atomic/struct.AtomicCell.html).
 ///
-/// Note that there are no [`Ordering`] parameters,
-/// atomic loads use [`Acquire`],
-/// and atomic stores use [`Release`].
+/// Note that there are no [`Ordering`](o) parameters,
+/// atomic loads use [`Acquire`](a),
+/// and atomic stores use [`Release`](r).
+///
+/// [o]: std::sync::atomic::Ordering
+/// [a]: std::sync::atomic::Ordering
+/// [r]: std::sync::atomic::Ordering
 pub type AtomicF64 = AtomicCell<f64>;
 
 //---------------------------------------------------------------------------------------------------- TESTS

--- a/helper/src/atomic.rs
+++ b/helper/src/atomic.rs
@@ -28,13 +28,13 @@ const _: () = {
 /// This is an alias for
 /// [`crossbeam::atomic::AtomicCell<f32>`](https://docs.rs/crossbeam/latest/crossbeam/atomic/struct.AtomicCell.html).
 ///
-/// Note that there are no [`Ordering`](o) parameters,
+/// Note that there are no [`Ordering`] parameters,
 /// atomic loads use [`Acquire`](a),
 /// and atomic stores use [`Release`](r).
 ///
-/// [o]: std::sync::atomic::Ordering
-/// [a]: std::sync::atomic::Ordering
-/// [r]: std::sync::atomic::Ordering
+/// [Ordering]: std::sync::atomic::Ordering
+/// [Acquire]: std::sync::atomic::Ordering::Acquire
+/// [Release]: std::sync::atomic::Ordering::Release
 pub type AtomicF32 = AtomicCell<f32>;
 
 /// An atomic [`f64`].
@@ -42,13 +42,13 @@ pub type AtomicF32 = AtomicCell<f32>;
 /// This is an alias for
 /// [`crossbeam::atomic::AtomicCell<f64>`](https://docs.rs/crossbeam/latest/crossbeam/atomic/struct.AtomicCell.html).
 ///
-/// Note that there are no [`Ordering`](o) parameters,
-/// atomic loads use [`Acquire`](a),
-/// and atomic stores use [`Release`](r).
+/// Note that there are no [`Ordering`] parameters,
+/// atomic loads use [`Acquire`],
+/// and atomic stores use [`Release`].
 ///
-/// [o]: std::sync::atomic::Ordering
-/// [a]: std::sync::atomic::Ordering
-/// [r]: std::sync::atomic::Ordering
+/// [Ordering]: std::sync::atomic::Ordering
+/// [Acquire]: std::sync::atomic::Ordering::Acquire
+/// [Release]: std::sync::atomic::Ordering::Release
 pub type AtomicF64 = AtomicCell<f64>;
 
 //---------------------------------------------------------------------------------------------------- TESTS

--- a/helper/src/map.rs
+++ b/helper/src/map.rs
@@ -29,7 +29,7 @@ use crate::cast::{u64_to_usize, usize_to_u64};
 /// ```
 #[inline]
 pub const fn split_u128_into_low_high_bits(value: u128) -> (u64, u64) {
-    #[allow(clippy::cast_possible_truncation)]
+    #[expect(clippy::cast_possible_truncation)]
     (value as u64, (value >> 64) as u64)
 }
 

--- a/helper/src/num.rs
+++ b/helper/src/num.rs
@@ -91,7 +91,7 @@ where
 ///
 /// # Invariant
 /// If not sorted the output will be invalid.
-#[allow(clippy::debug_assert_with_mut_call)]
+#[expect(clippy::debug_assert_with_mut_call)]
 pub fn median<T>(array: impl AsRef<[T]>) -> T
 where
     T: Add<Output = T>

--- a/helper/src/thread.rs
+++ b/helper/src/thread.rs
@@ -6,7 +6,6 @@
 use std::{cmp::max, num::NonZeroUsize};
 
 //---------------------------------------------------------------------------------------------------- Thread Count & Percent
-#[allow(non_snake_case)]
 /// Get the total amount of system threads.
 ///
 /// ```rust
@@ -28,10 +27,12 @@ macro_rules! impl_thread_percent {
 		$(
 			$(#[$doc])*
 			pub fn $fn_name() -> NonZeroUsize {
-		        // unwrap here is okay because:
-		        // - THREADS().get() is always non-zero
-		        // - max() guards against 0
-                #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss, clippy::cast_precision_loss)]
+                #[expect(
+                    clippy::cast_possible_truncation,
+                    clippy::cast_sign_loss,
+                    clippy::cast_precision_loss,
+                    reason = "unwrap here is okay because THREADS().get() is always non-zero and max() guards against 0"
+                )]
 		        NonZeroUsize::new(max(1, (threads().get() as f64 * $percent).floor() as usize)).unwrap()
 		    }
 		)*

--- a/helper/src/thread.rs
+++ b/helper/src/thread.rs
@@ -27,11 +27,14 @@ macro_rules! impl_thread_percent {
 		$(
 			$(#[$doc])*
 			pub fn $fn_name() -> NonZeroUsize {
+                // unwrap here is okay because:
+                // - THREADS().get() is always non-zero
+                // - max() guards against 0
                 #[expect(
                     clippy::cast_possible_truncation,
                     clippy::cast_sign_loss,
                     clippy::cast_precision_loss,
-                    reason = "unwrap here is okay because THREADS().get() is always non-zero and max() guards against 0"
+                    reason = "we need to round integers"
                 )]
 		        NonZeroUsize::new(max(1, (threads().get() as f64 * $percent).floor() as usize)).unwrap()
 		    }

--- a/helper/src/time.rs
+++ b/helper/src/time.rs
@@ -129,7 +129,7 @@ pub const fn secs_to_clock(seconds: u32) -> (u8, u8, u8) {
     debug_assert!(m < 60);
     debug_assert!(s < 60);
 
-    #[allow(clippy::cast_possible_truncation)] // checked above
+    #[expect(clippy::cast_possible_truncation, reason = "checked above")]
     (h as u8, m, s)
 }
 
@@ -154,7 +154,7 @@ pub fn time() -> u32 {
 ///
 /// This is guaranteed to return a value between `0..=86399`
 pub fn time_utc() -> u32 {
-    #[allow(clippy::cast_sign_loss)] // checked in function calls
+    #[expect(clippy::cast_sign_loss, reason = "checked in function calls")]
     unix_clock(chrono::offset::Local::now().timestamp() as u64)
 }
 

--- a/rpc/interface/src/route/bin.rs
+++ b/rpc/interface/src/route/bin.rs
@@ -28,7 +28,6 @@ macro_rules! generate_endpoints_with_input {
     ),*) => { paste::paste! {
         $(
             /// TODO
-            #[allow(unused_mut)]
             pub(crate) async fn $endpoint<H: RpcHandler>(
                 State(handler): State<H>,
                 mut request: Bytes,
@@ -55,7 +54,6 @@ macro_rules! generate_endpoints_with_no_input {
     ),*) => { paste::paste! {
         $(
             /// TODO
-            #[allow(unused_mut)]
             pub(crate) async fn $endpoint<H: RpcHandler>(
                 State(handler): State<H>,
             ) -> Result<Bytes, StatusCode> {

--- a/rpc/interface/src/router_builder.rs
+++ b/rpc/interface/src/router_builder.rs
@@ -69,7 +69,6 @@ macro_rules! generate_router_builder {
         ///     .all()
         ///     .build();
         /// ```
-        #[allow(clippy::struct_excessive_bools)]
         #[derive(Clone)]
         pub struct RouterBuilder<H: RpcHandler> {
             router: Router<H>,

--- a/rpc/interface/src/rpc_handler_dummy.rs
+++ b/rpc/interface/src/rpc_handler_dummy.rs
@@ -57,7 +57,7 @@ impl Service<JsonRpcRequest> for RpcHandlerDummy {
         use cuprate_rpc_types::json::JsonRpcRequest as Req;
         use cuprate_rpc_types::json::JsonRpcResponse as Resp;
 
-        #[allow(clippy::default_trait_access)]
+        #[expect(clippy::default_trait_access)]
         let resp = match req {
             Req::GetBlockCount(_) => Resp::GetBlockCount(Default::default()),
             Req::OnGetBlockHash(_) => Resp::OnGetBlockHash(Default::default()),
@@ -112,7 +112,7 @@ impl Service<BinRequest> for RpcHandlerDummy {
         use cuprate_rpc_types::bin::BinRequest as Req;
         use cuprate_rpc_types::bin::BinResponse as Resp;
 
-        #[allow(clippy::default_trait_access)]
+        #[expect(clippy::default_trait_access)]
         let resp = match req {
             Req::GetBlocks(_) => Resp::GetBlocks(Default::default()),
             Req::GetBlocksByHeight(_) => Resp::GetBlocksByHeight(Default::default()),
@@ -142,7 +142,7 @@ impl Service<OtherRequest> for RpcHandlerDummy {
         use cuprate_rpc_types::other::OtherRequest as Req;
         use cuprate_rpc_types::other::OtherResponse as Resp;
 
-        #[allow(clippy::default_trait_access)]
+        #[expect(clippy::default_trait_access)]
         let resp = match req {
             Req::GetHeight(_) => Resp::GetHeight(Default::default()),
             Req::GetTransactions(_) => Resp::GetTransactions(Default::default()),

--- a/rpc/json-rpc/src/tests.rs
+++ b/rpc/json-rpc/src/tests.rs
@@ -52,7 +52,7 @@ where
 }
 
 /// Tests an input JSON string matches an expected type `T`.
-#[expect(clippy::needless_pass_by_value)] // serde signature
+#[expect(clippy::needless_pass_by_value, reason = "serde signature")]
 fn assert_de<T>(json: &'static str, expected: T)
 where
     T: DeserializeOwned + std::fmt::Debug + Clone + PartialEq,

--- a/rpc/json-rpc/src/tests.rs
+++ b/rpc/json-rpc/src/tests.rs
@@ -52,7 +52,7 @@ where
 }
 
 /// Tests an input JSON string matches an expected type `T`.
-#[allow(clippy::needless_pass_by_value)] // serde signature
+#[expect(clippy::needless_pass_by_value)] // serde signature
 fn assert_de<T>(json: &'static str, expected: T)
 where
     T: DeserializeOwned + std::fmt::Debug + Clone + PartialEq,

--- a/rpc/types/src/bin.rs
+++ b/rpc/types/src/bin.rs
@@ -138,7 +138,6 @@ define_request! {
 )]
 ///
 /// This response's variant depends upon [`PoolInfoExtent`].
-#[allow(dead_code, missing_docs)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum GetBlocksResponse {
@@ -157,7 +156,6 @@ impl Default for GetBlocksResponse {
 }
 
 /// Data within [`GetBlocksResponse::PoolInfoNone`].
-#[allow(dead_code, missing_docs)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Default, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetBlocksResponsePoolInfoNone {
@@ -183,7 +181,6 @@ epee_object! {
 }
 
 /// Data within [`GetBlocksResponse::PoolInfoIncremental`].
-#[allow(dead_code, missing_docs)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Default, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetBlocksResponsePoolInfoIncremental {
@@ -215,7 +212,6 @@ epee_object! {
 }
 
 /// Data within [`GetBlocksResponse::PoolInfoFull`].
-#[allow(dead_code, missing_docs)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Default, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetBlocksResponsePoolInfoFull {
@@ -248,7 +244,6 @@ epee_object! {
 /// [`EpeeObjectBuilder`] for [`GetBlocksResponse`].
 ///
 /// Not for public usage.
-#[allow(dead_code, missing_docs)]
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct __GetBlocksResponseEpeeBuilder {
@@ -354,7 +349,6 @@ impl EpeeObjectBuilder<GetBlocksResponse> for __GetBlocksResponseEpeeBuilder {
 }
 
 #[cfg(feature = "epee")]
-#[allow(clippy::cognitive_complexity)]
 impl EpeeObject for GetBlocksResponse {
     type Builder = __GetBlocksResponseEpeeBuilder;
 
@@ -397,7 +391,6 @@ impl EpeeObject for GetBlocksResponse {
 /// See also: [`BinResponse`].
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[cfg_attr(feature = "serde", serde(untagged))]
-#[allow(missing_docs)]
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum BinRequest {
     GetBlocks(GetBlocksRequest),
@@ -444,7 +437,6 @@ impl RpcCallValue for BinRequest {
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[cfg_attr(feature = "serde", serde(untagged))]
-#[allow(missing_docs)]
 pub enum BinResponse {
     GetBlocks(GetBlocksResponse),
     GetBlocksByHeight(GetBlocksByHeightResponse),

--- a/rpc/types/src/free.rs
+++ b/rpc/types/src/free.rs
@@ -5,16 +5,16 @@
 
 /// Returns `true` if the input `u` is equal to `0`.
 #[inline]
-#[allow(clippy::trivially_copy_pass_by_ref)] // serde needs `&`
-#[allow(dead_code)] // TODO: see if needed after handlers.
+#[expect(clippy::trivially_copy_pass_by_ref, reason = "serde signature")]
+#[expect(dead_code, reason = "TODO: see if needed after handlers.")]
 pub(crate) const fn is_zero(u: &u64) -> bool {
     *u == 0
 }
 
 /// Returns `true` the input `u` is equal to `1`.
 #[inline]
-#[allow(clippy::trivially_copy_pass_by_ref)] // serde needs `&`
-#[allow(dead_code)] // TODO: see if needed after handlers.
+#[expect(clippy::trivially_copy_pass_by_ref, reason = "serde signature")]
+#[expect(dead_code, reason = "TODO: see if needed after handlers.")]
 pub(crate) const fn is_one(u: &u64) -> bool {
     *u == 1
 }

--- a/rpc/types/src/json.rs
+++ b/rpc/types/src/json.rs
@@ -1581,7 +1581,6 @@ define_request_and_response! {
     feature = "serde",
     serde(rename_all = "snake_case", tag = "method", content = "params")
 )]
-#[allow(missing_docs)]
 pub enum JsonRpcRequest {
     GetBlockCount(GetBlockCountRequest),
     OnGetBlockHash(OnGetBlockHashRequest),
@@ -1714,7 +1713,6 @@ impl RpcCallValue for JsonRpcRequest {
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[cfg_attr(feature = "serde", serde(untagged, rename_all = "snake_case"))]
-#[allow(missing_docs)]
 pub enum JsonRpcResponse {
     GetBlockCount(GetBlockCountResponse),
     OnGetBlockHash(OnGetBlockHashResponse),

--- a/rpc/types/src/lib.rs
+++ b/rpc/types/src/lib.rs
@@ -1,5 +1,9 @@
 #![doc = include_str!("../README.md")]
 #![cfg_attr(docsrs, feature(doc_cfg))]
+#![allow(
+    clippy::allow_attributes,
+    reason = "macros (internal + serde) make this lint hard to satisfy"
+)]
 
 mod constants;
 mod defaults;

--- a/rpc/types/src/macros.rs
+++ b/rpc/types/src/macros.rs
@@ -94,7 +94,7 @@ macro_rules! define_request_and_response {
         }
     ) => { paste::paste! {
         $crate::macros::define_request! {
-            #[allow(clippy::allow_attributes, dead_code, missing_docs, reason = "inside a macro")]
+            #[allow(dead_code, missing_docs, reason = "inside a macro")]
             #[doc = $crate::macros::define_request_and_response_doc!(
                 "response" => [<$type_name Response>],
                 $monero_daemon_rpc_doc_link,
@@ -119,7 +119,7 @@ macro_rules! define_request_and_response {
         }
 
         $crate::macros::define_response! {
-            #[allow(clippy::allow_attributes, dead_code, missing_docs, reason = "inside a macro")]
+            #[allow(dead_code, missing_docs, reason = "inside a macro")]
             #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
             #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
             #[doc = $crate::macros::define_request_and_response_doc!(
@@ -236,7 +236,7 @@ macro_rules! define_request {
             )*
         }
     ) => {
-        #[allow(clippy::allow_attributes, dead_code, missing_docs, reason = "inside a macro")]
+        #[allow(dead_code, missing_docs, reason = "inside a macro")]
         #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
         #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
         $( #[$attr] )*

--- a/rpc/types/src/macros.rs
+++ b/rpc/types/src/macros.rs
@@ -94,6 +94,7 @@ macro_rules! define_request_and_response {
         }
     ) => { paste::paste! {
         $crate::macros::define_request! {
+            #[allow(clippy::allow_attributes, dead_code, missing_docs, reason = "inside a macro")]
             #[doc = $crate::macros::define_request_and_response_doc!(
                 "response" => [<$type_name Response>],
                 $monero_daemon_rpc_doc_link,
@@ -118,8 +119,7 @@ macro_rules! define_request_and_response {
         }
 
         $crate::macros::define_response! {
-            #[allow(dead_code)]
-            #[allow(missing_docs)]
+            #[allow(clippy::allow_attributes, dead_code, missing_docs, reason = "inside a macro")]
             #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
             #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
             #[doc = $crate::macros::define_request_and_response_doc!(
@@ -236,7 +236,7 @@ macro_rules! define_request {
             )*
         }
     ) => {
-        #[allow(dead_code, missing_docs)]
+        #[allow(clippy::allow_attributes, dead_code, missing_docs, reason = "inside a macro")]
         #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
         #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
         $( #[$attr] )*

--- a/rpc/types/src/misc/distribution.rs
+++ b/rpc/types/src/misc/distribution.rs
@@ -76,7 +76,6 @@ impl Default for Distribution {
 }
 
 /// Data within [`Distribution::Uncompressed`].
-#[allow(dead_code, missing_docs)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Default, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DistributionUncompressed {
@@ -99,7 +98,6 @@ epee_object! {
 }
 
 /// Data within [`Distribution::CompressedBinary`].
-#[allow(dead_code, missing_docs)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Default, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DistributionCompressedBinary {
@@ -132,7 +130,7 @@ epee_object! {
 /// 1. Compresses the distribution array
 /// 2. Serializes the compressed data
 #[cfg(feature = "serde")]
-#[allow(clippy::ptr_arg)]
+#[expect(clippy::ptr_arg)]
 fn serialize_distribution_as_compressed_data<S>(v: &Vec<u64>, s: S) -> Result<S::Ok, S::Error>
 where
     S: serde::Serializer,
@@ -162,7 +160,6 @@ where
 /// [`EpeeObjectBuilder`] for [`Distribution`].
 ///
 /// Not for public usage.
-#[allow(dead_code, missing_docs)]
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct __DistributionEpeeBuilder {

--- a/rpc/types/src/misc/mod.rs
+++ b/rpc/types/src/misc/mod.rs
@@ -15,7 +15,7 @@
 mod binary_string;
 mod distribution;
 mod key_image_spent_status;
-#[allow(clippy::module_inception)]
+#[expect(clippy::module_inception)]
 mod misc;
 mod pool_info_extent;
 mod status;

--- a/rpc/types/src/other.rs
+++ b/rpc/types/src/other.rs
@@ -973,7 +973,6 @@ define_request_and_response! {
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[cfg_attr(feature = "serde", serde(untagged))]
-#[allow(missing_docs)]
 pub enum OtherRequest {
     GetHeight(GetHeightRequest),
     GetTransactions(GetTransactionsRequest),
@@ -1092,7 +1091,6 @@ impl RpcCallValue for OtherRequest {
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[cfg_attr(feature = "serde", serde(untagged))]
-#[allow(missing_docs)]
 pub enum OtherResponse {
     GetHeight(GetHeightResponse),
     GetTransactions(GetTransactionsResponse),

--- a/storage/blockchain/src/ops/block.rs
+++ b/storage/blockchain/src/ops/block.rs
@@ -183,7 +183,10 @@ pub fn get_block_extended_header(
 
 /// Same as [`get_block_extended_header`] but with a [`BlockHeight`].
 #[doc = doc_error!()]
-#[allow(clippy::missing_panics_doc)] // The panic is only possible with a corrupt DB
+#[expect(
+    clippy::missing_panics_doc,
+    reason = "The panic is only possible with a corrupt DB"
+)]
 #[inline]
 pub fn get_block_extended_header_from_height(
     block_height: &BlockHeight,
@@ -198,8 +201,10 @@ pub fn get_block_extended_header_from_height(
         block_info.cumulative_difficulty_high,
     );
 
-    // INVARIANT: #[cfg] @ lib.rs asserts `usize == u64`
-    #[allow(clippy::cast_possible_truncation)]
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "INVARIANT: #[cfg] @ lib.rs asserts `usize == u64`"
+    )]
     Ok(ExtendedBlockHeader {
         cumulative_difficulty,
         version: HardFork::from_version(block.header.hardfork_version)
@@ -260,11 +265,7 @@ pub fn block_exists(
 
 //---------------------------------------------------------------------------------------------------- Tests
 #[cfg(test)]
-#[allow(
-    clippy::significant_drop_tightening,
-    clippy::cognitive_complexity,
-    clippy::too_many_lines
-)]
+#[expect(clippy::significant_drop_tightening, clippy::too_many_lines)]
 mod test {
     use pretty_assertions::assert_eq;
 

--- a/storage/blockchain/src/ops/blockchain.rs
+++ b/storage/blockchain/src/ops/blockchain.rs
@@ -25,7 +25,7 @@ use crate::{
 pub fn chain_height(
     table_block_heights: &impl DatabaseRo<BlockHeights>,
 ) -> Result<BlockHeight, RuntimeError> {
-    #[allow(clippy::cast_possible_truncation)] // we enforce 64-bit
+    #[expect(clippy::cast_possible_truncation, reason = "we enforce 64-bit")]
     table_block_heights.len().map(|height| height as usize)
 }
 
@@ -48,7 +48,7 @@ pub fn top_block_height(
 ) -> Result<BlockHeight, RuntimeError> {
     match table_block_heights.len()? {
         0 => Err(RuntimeError::KeyNotFound),
-        #[allow(clippy::cast_possible_truncation)] // we enforce 64-bit
+        #[expect(clippy::cast_possible_truncation, reason = "we enforce 64-bit")]
         height => Ok(height as usize - 1),
     }
 }

--- a/storage/blockchain/src/service/read.rs
+++ b/storage/blockchain/src/service/read.rs
@@ -142,7 +142,6 @@ fn thread_local<T: Send>(env: &impl Env) -> ThreadLocal<T> {
 macro_rules! get_tables {
     ($env_inner:ident, $tx_ro:ident, $tables:ident) => {{
         $tables.get_or_try(|| {
-            #[allow(clippy::significant_drop_in_scrutinee)]
             match $env_inner.open_tables($tx_ro) {
                 // SAFETY: see above macro doc comment.
                 Ok(tables) => Ok(unsafe { crate::unsafe_sendable::UnsafeSendable::new(tables) }),
@@ -339,8 +338,10 @@ fn number_outputs_with_amount(env: &ConcreteEnv, amounts: Vec<Amount>) -> Respon
     let tables = thread_local(env);
 
     // Cache the amount of RCT outputs once.
-    // INVARIANT: #[cfg] @ lib.rs asserts `usize == u64`
-    #[allow(clippy::cast_possible_truncation)]
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "INVARIANT: #[cfg] @ lib.rs asserts `usize == u64`"
+    )]
     let num_rct_outputs = {
         let tx_ro = env_inner.tx_ro()?;
         let tables = env_inner.open_tables(&tx_ro)?;
@@ -360,8 +361,10 @@ fn number_outputs_with_amount(env: &ConcreteEnv, amounts: Vec<Amount>) -> Respon
             } else {
                 // v1 transactions.
                 match tables.num_outputs().get(&amount) {
-                    // INVARIANT: #[cfg] @ lib.rs asserts `usize == u64`
-                    #[allow(clippy::cast_possible_truncation)]
+                    #[expect(
+                        clippy::cast_possible_truncation,
+                        reason = "INVARIANT: #[cfg] @ lib.rs asserts `usize == u64`"
+                    )]
                     Ok(count) => Ok((amount, count as usize)),
                     // If we get a request for an `amount` that doesn't exist,
                     // we return `0` instead of an error.

--- a/storage/blockchain/src/service/tests.rs
+++ b/storage/blockchain/src/service/tests.rs
@@ -58,7 +58,10 @@ fn init_service() -> (
 /// - Receive response(s)
 /// - Assert proper tables were mutated
 /// - Assert read requests lead to expected responses
-#[allow(clippy::future_not_send)] // INVARIANT: tests are using a single threaded runtime
+#[expect(
+    clippy::future_not_send,
+    reason = "INVARIANT: tests are using a single threaded runtime"
+)]
 async fn test_template(
     // Which block(s) to add?
     blocks: &[&VerifiedBlockInformation],
@@ -164,8 +167,10 @@ async fn test_template(
         num_req
             .iter()
             .map(|amount| match tables.num_outputs().get(amount) {
-                // INVARIANT: #[cfg] @ lib.rs asserts `usize == u64`
-                #[allow(clippy::cast_possible_truncation)]
+                #[expect(
+                    clippy::cast_possible_truncation,
+                    reason = "INVARIANT: #[cfg] @ lib.rs asserts `usize == u64`"
+                )]
                 Ok(count) => (*amount, count as usize),
                 Err(RuntimeError::KeyNotFound) => (*amount, 0),
                 Err(e) => panic!("{e:?}"),
@@ -304,7 +309,10 @@ async fn test_template(
     // Assert we get back the same map of
     // `Amount`'s and `AmountIndex`'s.
     let mut response_output_count = 0;
-    #[allow(clippy::iter_over_hash_type)] // order doesn't matter in this test
+    #[expect(
+        clippy::iter_over_hash_type,
+        reason = "order doesn't matter in this test"
+    )]
     for (amount, output_map) in response {
         let amount_index_set = &map[&amount];
 

--- a/storage/blockchain/src/unsafe_sendable.rs
+++ b/storage/blockchain/src/unsafe_sendable.rs
@@ -26,7 +26,7 @@ use bytemuck::TransparentWrapper;
 /// Notably, `heed`'s table type uses this inside `service`.
 pub(crate) struct UnsafeSendable<T>(T);
 
-#[allow(clippy::non_send_fields_in_send_ty)]
+#[expect(clippy::non_send_fields_in_send_ty)]
 // SAFETY: Users ensure that their usage of this type is safe.
 unsafe impl<T> Send for UnsafeSendable<T> {}
 
@@ -41,7 +41,7 @@ impl<T> UnsafeSendable<T> {
     }
 
     /// Extract the inner `T`.
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub(crate) fn into_inner(self) -> T {
         self.0
     }

--- a/storage/database/src/backend/heed/env.rs
+++ b/storage/database/src/backend/heed/env.rs
@@ -144,7 +144,7 @@ impl Env for ConcreteEnv {
         // (current disk size) + (a bit of leeway)
         // to account for empty databases where we
         // need to write same tables.
-        #[allow(clippy::cast_possible_truncation)] // only 64-bit targets
+        #[expect(clippy::cast_possible_truncation)] // only 64-bit targets
         let disk_size_bytes = match std::fs::File::open(&config.db_file) {
             Ok(file) => file.metadata()?.len() as usize,
             // The database file doesn't exist, 0 bytes.

--- a/storage/database/src/backend/heed/env.rs
+++ b/storage/database/src/backend/heed/env.rs
@@ -144,7 +144,7 @@ impl Env for ConcreteEnv {
         // (current disk size) + (a bit of leeway)
         // to account for empty databases where we
         // need to write same tables.
-        #[expect(clippy::cast_possible_truncation)] // only 64-bit targets
+        #[expect(clippy::cast_possible_truncation, reason = "only 64-bit targets")]
         let disk_size_bytes = match std::fs::File::open(&config.db_file) {
             Ok(file) => file.metadata()?.len() as usize,
             // The database file doesn't exist, 0 bytes.

--- a/storage/database/src/backend/heed/error.rs
+++ b/storage/database/src/backend/heed/error.rs
@@ -57,7 +57,10 @@ impl From<heed::Error> for crate::InitError {
 }
 
 //---------------------------------------------------------------------------------------------------- RuntimeError
-#[expect(clippy::fallible_impl_from, reason = "We need to panic sometimes for safety")]
+#[expect(
+    clippy::fallible_impl_from,
+    reason = "We need to panic sometimes for safety"
+)]
 impl From<heed::Error> for crate::RuntimeError {
     /// # Panics
     /// This will panic on unrecoverable errors for safety.

--- a/storage/database/src/backend/heed/error.rs
+++ b/storage/database/src/backend/heed/error.rs
@@ -57,7 +57,7 @@ impl From<heed::Error> for crate::InitError {
 }
 
 //---------------------------------------------------------------------------------------------------- RuntimeError
-#[expect(clippy::fallible_impl_from)] // We need to panic sometimes.
+#[expect(clippy::fallible_impl_from, reason = "We need to panic sometimes for safety")]
 impl From<heed::Error> for crate::RuntimeError {
     /// # Panics
     /// This will panic on unrecoverable errors for safety.

--- a/storage/database/src/backend/heed/error.rs
+++ b/storage/database/src/backend/heed/error.rs
@@ -57,7 +57,7 @@ impl From<heed::Error> for crate::InitError {
 }
 
 //---------------------------------------------------------------------------------------------------- RuntimeError
-#[allow(clippy::fallible_impl_from)] // We need to panic sometimes.
+#[expect(clippy::fallible_impl_from)] // We need to panic sometimes.
 impl From<heed::Error> for crate::RuntimeError {
     /// # Panics
     /// This will panic on unrecoverable errors for safety.

--- a/storage/database/src/backend/tests.rs
+++ b/storage/database/src/backend/tests.rs
@@ -194,7 +194,7 @@ fn db_read_write() {
 
     // Insert keys.
     let mut key = KEY;
-    #[expect(clippy::explicit_counter_loop)] // we need the +1 side effect
+    #[expect(clippy::explicit_counter_loop, reason = "we need the +1 side effect")]
     for _ in 0..N {
         table.put(&key, &VALUE).unwrap();
         key += 1;

--- a/storage/database/src/backend/tests.rs
+++ b/storage/database/src/backend/tests.rs
@@ -194,7 +194,7 @@ fn db_read_write() {
 
     // Insert keys.
     let mut key = KEY;
-    #[allow(clippy::explicit_counter_loop)] // we need the +1 side effect
+    #[expect(clippy::explicit_counter_loop)] // we need the +1 side effect
     for _ in 0..N {
         table.put(&key, &VALUE).unwrap();
         key += 1;
@@ -269,7 +269,7 @@ fn db_read_write() {
 
         assert_ne!(table.get(&KEY).unwrap(), NEW_VALUE);
 
-        #[allow(unused_assignments)]
+        #[expect(unused_assignments)]
         table
             .update(&KEY, |mut value| {
                 value = NEW_VALUE;

--- a/storage/database/src/config/mod.rs
+++ b/storage/database/src/config/mod.rs
@@ -33,7 +33,7 @@
 //! # Ok(()) }
 //! ```
 
-#[allow(clippy::module_inception)]
+#[expect(clippy::module_inception)]
 mod config;
 pub use config::{Config, ConfigBuilder, READER_THREADS_DEFAULT};
 

--- a/storage/database/src/database.rs
+++ b/storage/database/src/database.rs
@@ -54,7 +54,7 @@ pub trait DatabaseIter<T: Table> {
 
     /// Get an [`Iterator`] that returns the `(key, value)` types for this database.
     #[doc = doc_iter!()]
-    #[allow(clippy::iter_not_returning_iterator)]
+    #[expect(clippy::iter_not_returning_iterator)]
     fn iter(
         &self,
     ) -> Result<impl Iterator<Item = Result<(T::Key, T::Value), RuntimeError>> + '_, RuntimeError>;

--- a/storage/database/src/env.rs
+++ b/storage/database/src/env.rs
@@ -122,7 +122,7 @@ pub trait Env: Sized {
     /// This function _must_ be re-implemented if [`Env::MANUAL_RESIZE`] is `true`.
     ///
     /// Otherwise, this function will panic with `unreachable!()`.
-    #[allow(unused_variables)]
+    #[expect(unused_variables)]
     fn resize_map(&self, resize_algorithm: Option<ResizeAlgorithm>) -> NonZeroUsize {
         unreachable!()
     }

--- a/storage/database/src/resize.rs
+++ b/storage/database/src/resize.rs
@@ -261,7 +261,7 @@ pub fn percent(current_size_bytes: usize, percent: f32) -> NonZeroUsize {
     let page_size = *PAGE_SIZE;
 
     // INVARIANT: Allow `f32` <-> `usize` casting, we handle all cases.
-    #[allow(
+    #[expect(
         clippy::cast_possible_truncation,
         clippy::cast_sign_loss,
         clippy::cast_precision_loss

--- a/storage/service/src/reader_threads.rs
+++ b/storage/service/src/reader_threads.rs
@@ -153,7 +153,7 @@ impl ReaderThreads {
             },
 
             // We handle the casting loss.
-            #[allow(
+            #[expect(
                 clippy::cast_precision_loss,
                 clippy::cast_possible_truncation,
                 clippy::cast_sign_loss

--- a/storage/txpool/src/service/interface.rs
+++ b/storage/txpool/src/service/interface.rs
@@ -18,7 +18,7 @@ pub enum TxpoolReadRequest {
 
 //---------------------------------------------------------------------------------------------------- TxpoolReadResponse
 /// The transaction pool [`tower::Service`] read response type.
-#[allow(clippy::large_enum_variant)]
+#[expect(clippy::large_enum_variant)]
 pub enum TxpoolReadResponse {
     /// A response containing the raw bytes of a transaction.
     // TODO: use bytes::Bytes.

--- a/storage/txpool/src/service/read.rs
+++ b/storage/txpool/src/service/read.rs
@@ -50,7 +50,7 @@ fn init_read_service_with_pool(env: Arc<ConcreteEnv>, pool: Arc<ThreadPool>) -> 
 /// 1. `Request` is mapped to a handler function
 /// 2. Handler function is called
 /// 3. [`TxpoolReadResponse`] is returned
-#[allow(clippy::needless_pass_by_value)]
+#[expect(clippy::needless_pass_by_value)]
 fn map_request(
     env: &ConcreteEnv,          // Access to the database
     request: TxpoolReadRequest, // The request we must fulfill

--- a/storage/txpool/src/types.rs
+++ b/storage/txpool/src/types.rs
@@ -39,7 +39,7 @@ pub struct TransactionInfo {
     pub weight: usize,
     /// [`TxStateFlags`] of this transaction.
     pub flags: TxStateFlags,
-    #[allow(clippy::pub_underscore_fields)]
+    #[expect(clippy::pub_underscore_fields)]
     /// Explicit padding so that we have no implicit padding bytes in `repr(C)`.
     ///
     /// Allows potential future expansion of this type.
@@ -92,7 +92,7 @@ impl From<RawCachedVerificationState> for CachedVerificationState {
     }
 }
 
-#[allow(clippy::fallible_impl_from)] // only panics in invalid states
+#[expect(clippy::fallible_impl_from, reason = "only panics in invalid states")]
 impl From<CachedVerificationState> for RawCachedVerificationState {
     fn from(value: CachedVerificationState) -> Self {
         match value {

--- a/types/src/hard_fork.rs
+++ b/types/src/hard_fork.rs
@@ -27,7 +27,6 @@ pub enum HardForkError {
 }
 
 /// An identifier for every hard-fork Monero has had.
-#[allow(missing_docs)]
 #[derive(Default, Debug, PartialEq, Eq, PartialOrd, Ord, Copy, Clone, Hash)]
 #[cfg_attr(any(feature = "proptest"), derive(proptest_derive::Arbitrary))]
 #[repr(u8)]


### PR DESCRIPTION
### What
Enables/fixes the [`allow_attributes`](https://rust-lang.github.io/rust-clippy/master/index.html#/allow_attributes) lint in the workspace lints.

Closes https://github.com/Cuprate/cuprate/issues/270.