### PR TITLE
p2p/address-book: enable workspace lints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -504,7 +504,6 @@ dependencies = [
  "cuprate-p2p-core",
  "cuprate-pruning",
  "cuprate-test-utils",
- "cuprate-wire",
  "futures",
  "indexmap",
  "rand",

--- a/p2p/address-book/Cargo.toml
+++ b/p2p/address-book/Cargo.toml
@@ -8,7 +8,7 @@ authors = ["Boog900"]
 
 [dependencies]
 cuprate-pruning = { path = "../../pruning" }
-cuprate-wire = { path= "../../net/wire" }
+# cuprate-wire = { path= "../../net/wire" }
 cuprate-p2p-core = { path = "../p2p-core" }
 
 tower = { workspace = true, features = ["util"] }
@@ -29,3 +29,6 @@ borsh = { workspace = true, features = ["derive", "std"]}
 cuprate-test-utils = {path = "../../test-utils"}
 
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"]}
+
+[lints]
+workspace = true

--- a/p2p/address-book/Cargo.toml
+++ b/p2p/address-book/Cargo.toml
@@ -8,7 +8,6 @@ authors = ["Boog900"]
 
 [dependencies]
 cuprate-pruning = { path = "../../pruning" }
-# cuprate-wire = { path= "../../net/wire" }
 cuprate-p2p-core = { path = "../p2p-core" }
 
 tower = { workspace = true, features = ["util"] }

--- a/p2p/address-book/src/book.rs
+++ b/p2p/address-book/src/book.rs
@@ -109,7 +109,7 @@ impl<Z: BorshNetworkZone> AddressBook<Z> {
             match handle.poll_unpin(cx) {
                 Poll::Pending => return,
                 Poll::Ready(Ok(Err(e))) => {
-                    tracing::error!("Could not save peer list to disk, got error: {}", e);
+                    tracing::error!("Could not save peer list to disk, got error: {e}");
                 }
                 Poll::Ready(Err(e)) => {
                     if e.is_panic() {

--- a/p2p/address-book/src/book.rs
+++ b/p2p/address-book/src/book.rs
@@ -36,7 +36,7 @@ use crate::{
 mod tests;
 
 /// An entry in the connected list.
-pub struct ConnectionPeerEntry<Z: NetworkZone> {
+pub(crate) struct ConnectionPeerEntry<Z: NetworkZone> {
     addr: Option<Z::Addr>,
     id: u64,
     handle: ConnectionHandle,
@@ -109,14 +109,14 @@ impl<Z: BorshNetworkZone> AddressBook<Z> {
             match handle.poll_unpin(cx) {
                 Poll::Pending => return,
                 Poll::Ready(Ok(Err(e))) => {
-                    tracing::error!("Could not save peer list to disk, got error: {}", e)
+                    tracing::error!("Could not save peer list to disk, got error: {}", e);
                 }
                 Poll::Ready(Err(e)) => {
                     if e.is_panic() {
                         panic::resume_unwind(e.into_panic())
                     }
                 }
-                _ => (),
+                Poll::Ready(_) => (),
             }
         }
         // the task is finished.
@@ -144,6 +144,7 @@ impl<Z: BorshNetworkZone> AddressBook<Z> {
         let mut internal_addr_disconnected = Vec::new();
         let mut addrs_to_ban = Vec::new();
 
+        #[expect(clippy::iter_over_hash_type, reason = "ordering doesn't matter here")]
         for (internal_addr, peer) in &mut self.connected_peers {
             if let Some(time) = peer.handle.check_should_ban() {
                 match internal_addr {
@@ -158,7 +159,7 @@ impl<Z: BorshNetworkZone> AddressBook<Z> {
             }
         }
 
-        for (addr, time) in addrs_to_ban.into_iter() {
+        for (addr, time) in addrs_to_ban {
             self.ban_peer(addr, time);
         }
 
@@ -172,12 +173,7 @@ impl<Z: BorshNetworkZone> AddressBook<Z> {
                     .remove(&addr);
 
                 // If the amount of peers with this ban id is 0 remove the whole set.
-                if self
-                    .connected_peers_ban_id
-                    .get(&addr.ban_id())
-                    .unwrap()
-                    .is_empty()
-                {
+                if self.connected_peers_ban_id[&addr.ban_id()].is_empty() {
                     self.connected_peers_ban_id.remove(&addr.ban_id());
                 }
                 // remove the peer from the anchor list.
@@ -188,7 +184,7 @@ impl<Z: BorshNetworkZone> AddressBook<Z> {
 
     fn ban_peer(&mut self, addr: Z::Addr, time: Duration) {
         if self.banned_peers.contains_key(&addr.ban_id()) {
-            tracing::error!("Tried to ban peer twice, this shouldn't happen.")
+            tracing::error!("Tried to ban peer twice, this shouldn't happen.");
         }
 
         if let Some(connected_peers_with_ban_id) = self.connected_peers_ban_id.get(&addr.ban_id()) {
@@ -242,10 +238,10 @@ impl<Z: BorshNetworkZone> AddressBook<Z> {
         peer_list.retain_mut(|peer| {
             peer.adr.make_canonical();
 
-            if !peer.adr.should_add_to_peer_list() {
-                false
-            } else {
+            if peer.adr.should_add_to_peer_list() {
                 !self.is_peer_banned(&peer.adr)
+            } else {
+                false
             }
             // TODO: check rpc/ p2p ports not the same
         });
@@ -391,7 +387,7 @@ impl<Z: BorshNetworkZone> Service<AddressBookRequest<Z>> for AddressBook<Z> {
                         rpc_credits_per_hash,
                     },
                 )
-                .map(|_| AddressBookResponse::Ok),
+                .map(|()| AddressBookResponse::Ok),
             AddressBookRequest::IncomingPeerList(peer_list) => {
                 self.handle_incoming_peer_list(peer_list);
                 Ok(AddressBookResponse::Ok)

--- a/p2p/address-book/src/book/tests.rs
+++ b/p2p/address-book/src/book/tests.rs
@@ -109,7 +109,7 @@ async fn add_new_peer_already_connected() {
             },
         ),
         Err(AddressBookError::PeerAlreadyConnected)
-    )
+    );
 }
 
 #[tokio::test]
@@ -143,5 +143,5 @@ async fn banned_peer_removed_from_peer_lists() {
             .unwrap()
             .into_inner(),
         TestNetZoneAddr(1)
-    )
+    );
 }

--- a/p2p/address-book/src/peer_list.rs
+++ b/p2p/address-book/src/peer_list.rs
@@ -64,14 +64,13 @@ impl<Z: NetworkZone> PeerList<Z> {
     /// Adds a new peer to the peer list
     pub(crate) fn add_new_peer(&mut self, peer: ZoneSpecificPeerListEntryBase<Z::Addr>) {
         if self.peers.insert(peer.adr, peer).is_none() {
-            // It's more clear with this
-            #[allow(clippy::unwrap_or_default)]
+            #[expect(clippy::unwrap_or_default, reason = "It's more clear with this")]
             self.pruning_seeds
                 .entry(peer.pruning_seed)
                 .or_insert_with(Vec::new)
                 .push(peer.adr);
 
-            #[allow(clippy::unwrap_or_default)]
+            #[expect(clippy::unwrap_or_default)]
             self.ban_ids
                 .entry(peer.adr.ban_id())
                 .or_insert_with(Vec::new)

--- a/p2p/address-book/src/peer_list/tests.rs
+++ b/p2p/address-book/src/peer_list/tests.rs
@@ -14,7 +14,7 @@ fn make_fake_peer(
 ) -> ZoneSpecificPeerListEntryBase<TestNetZoneAddr> {
     ZoneSpecificPeerListEntryBase {
         adr: TestNetZoneAddr(id),
-        id: id as u64,
+        id: u64::from(id),
         last_seen: 0,
         pruning_seed: PruningSeed::decompress(pruning_seed.unwrap_or(0)).unwrap(),
         rpc_port: 0,
@@ -22,14 +22,14 @@ fn make_fake_peer(
     }
 }
 
-pub fn make_fake_peer_list(
+pub(crate) fn make_fake_peer_list(
     start_idx: u32,
     numb_o_peers: u32,
 ) -> PeerList<TestNetZone<true, true, true>> {
     let mut peer_list = Vec::with_capacity(numb_o_peers as usize);
 
     for idx in start_idx..(start_idx + numb_o_peers) {
-        peer_list.push(make_fake_peer(idx, None))
+        peer_list.push(make_fake_peer(idx, None));
     }
 
     PeerList::new(peer_list)
@@ -50,7 +50,7 @@ fn make_fake_peer_list_with_random_pruning_seeds(
             } else {
                 r.gen_range(384..=391)
             }),
-        ))
+        ));
     }
     PeerList::new(peer_list)
 }
@@ -70,7 +70,7 @@ fn peer_list_reduce_length() {
 #[test]
 fn peer_list_reduce_length_with_peers_we_need() {
     let mut peer_list = make_fake_peer_list(0, 500);
-    let must_keep_peers = HashSet::from_iter(peer_list.peers.keys().copied());
+    let must_keep_peers = peer_list.peers.keys().copied().collect::<HashSet<_>>();
 
     let target_len = 49;
 
@@ -92,7 +92,7 @@ fn peer_list_remove_specific_peer() {
     let peers = peer_list.peers;
 
     for (_, addrs) in pruning_idxs {
-        addrs.iter().for_each(|adr| assert_ne!(adr, &peer.adr))
+        addrs.iter().for_each(|adr| assert_ne!(adr, &peer.adr));
     }
 
     assert!(!peers.contains_key(&peer.adr));
@@ -104,13 +104,13 @@ fn peer_list_pruning_idxs_are_correct() {
     let mut total_len = 0;
 
     for (seed, list) in peer_list.pruning_seeds {
-        for peer in list.iter() {
+        for peer in &list {
             assert_eq!(peer_list.peers.get(peer).unwrap().pruning_seed, seed);
             total_len += 1;
         }
     }
 
-    assert_eq!(total_len, peer_list.peers.len())
+    assert_eq!(total_len, peer_list.peers.len());
 }
 
 #[test]
@@ -122,11 +122,7 @@ fn peer_list_add_new_peer() {
 
     assert_eq!(peer_list.len(), 11);
     assert_eq!(peer_list.peers.get(&new_peer.adr), Some(&new_peer));
-    assert!(peer_list
-        .pruning_seeds
-        .get(&new_peer.pruning_seed)
-        .unwrap()
-        .contains(&new_peer.adr));
+    assert!(peer_list.pruning_seeds[&new_peer.pruning_seed].contains(&new_peer.adr));
 }
 
 #[test]
@@ -164,7 +160,7 @@ fn peer_list_get_peer_with_block() {
     assert!(peer
         .pruning_seed
         .get_next_unpruned_block(1, 1_000_000)
-        .is_ok())
+        .is_ok());
 }
 
 #[test]

--- a/p2p/address-book/src/store.rs
+++ b/p2p/address-book/src/store.rs
@@ -1,3 +1,8 @@
+#![expect(
+    single_use_lifetimes,
+    reason = "false positive on generated derive code on `SerPeerDataV1`"
+)]
+
 use std::fs;
 
 use borsh::{from_slice, to_vec, BorshDeserialize, BorshSerialize};
@@ -21,7 +26,7 @@ struct DeserPeerDataV1<A: NetZoneAddress> {
     gray_list: Vec<ZoneSpecificPeerListEntryBase<A>>,
 }
 
-pub fn save_peers_to_disk<Z: BorshNetworkZone>(
+pub(crate) fn save_peers_to_disk<Z: BorshNetworkZone>(
     cfg: &AddressBookConfig,
     white_list: &PeerList<Z>,
     gray_list: &PeerList<Z>,
@@ -38,7 +43,7 @@ pub fn save_peers_to_disk<Z: BorshNetworkZone>(
     spawn_blocking(move || fs::write(&file, &data))
 }
 
-pub async fn read_peers_from_disk<Z: BorshNetworkZone>(
+pub(crate) async fn read_peers_from_disk<Z: BorshNetworkZone>(
     cfg: &AddressBookConfig,
 ) -> Result<
     (


### PR DESCRIPTION
### What
Enables and fixes workspace lints for `cuprate-address-book`.