### PR TITLE
P2P: move seed nodes to config

### DIFF
--- a/p2p/address-book/src/book/tests.rs
+++ b/p2p/address-book/src/book/tests.rs
@@ -20,10 +20,7 @@ fn test_cfg() -> AddressBookConfig {
     }
 }
 
-fn make_fake_address_book(
-    numb_white: u32,
-    numb_gray: u32,
-) -> AddressBook<TestNetZone<true, true, true>> {
+fn make_fake_address_book(numb_white: u32, numb_gray: u32) -> AddressBook<TestNetZone<true>> {
     let white_list = make_fake_peer_list(0, numb_white);
     let gray_list = make_fake_peer_list(numb_white, numb_gray);
 

--- a/p2p/address-book/src/peer_list/tests.rs
+++ b/p2p/address-book/src/peer_list/tests.rs
@@ -25,7 +25,7 @@ fn make_fake_peer(
 pub(crate) fn make_fake_peer_list(
     start_idx: u32,
     numb_o_peers: u32,
-) -> PeerList<TestNetZone<true, true, true>> {
+) -> PeerList<TestNetZone<true>> {
     let mut peer_list = Vec::with_capacity(numb_o_peers as usize);
 
     for idx in start_idx..(start_idx + numb_o_peers) {
@@ -35,9 +35,7 @@ pub(crate) fn make_fake_peer_list(
     PeerList::new(peer_list)
 }
 
-fn make_fake_peer_list_with_random_pruning_seeds(
-    numb_o_peers: u32,
-) -> PeerList<TestNetZone<true, true, true>> {
+fn make_fake_peer_list_with_random_pruning_seeds(numb_o_peers: u32) -> PeerList<TestNetZone<true>> {
     let mut r = rand::thread_rng();
 
     let mut peer_list = Vec::with_capacity(numb_o_peers as usize);

--- a/p2p/address-book/src/store.rs
+++ b/p2p/address-book/src/store.rs
@@ -79,9 +79,8 @@ mod tests {
 
         let de_ser: DeserPeerDataV1<TestNetZoneAddr> = from_slice(&data).unwrap();
 
-        let white_list_2: PeerList<TestNetZone<true, true, true>> =
-            PeerList::new(de_ser.white_list);
-        let gray_list_2: PeerList<TestNetZone<true, true, true>> = PeerList::new(de_ser.gray_list);
+        let white_list_2: PeerList<TestNetZone<true>> = PeerList::new(de_ser.white_list);
+        let gray_list_2: PeerList<TestNetZone<true>> = PeerList::new(de_ser.gray_list);
 
         assert_eq!(white_list.peers.len(), white_list_2.peers.len());
         assert_eq!(gray_list.peers.len(), gray_list_2.peers.len());

--- a/p2p/p2p-core/src/lib.rs
+++ b/p2p/p2p-core/src/lib.rs
@@ -139,21 +139,11 @@ pub trait NetZoneAddress:
 pub trait NetworkZone: Clone + Copy + Send + 'static {
     /// The network name.
     const NAME: &'static str;
-    /// Allow syncing over this network.
-    ///
-    /// Not recommended for anonymity networks.
-    const ALLOW_SYNC: bool;
-    /// Enable dandelion++ for this network.
-    ///
-    /// This is unneeded on anonymity networks.
-    const DANDELION_PP: bool;
     /// Check if our node ID matches the incoming peers node ID for this network.
     ///
     /// This has privacy implications on an anonymity network if true so should be set
     /// to false.
     const CHECK_NODE_ID: bool;
-    /// Fixed seed nodes for this network.
-    const SEEDS: &'static [Self::Addr];
 
     /// The address type of this network.
     type Addr: NetZoneAddress;

--- a/p2p/p2p-core/src/network_zones/clear.rs
+++ b/p2p/p2p-core/src/network_zones/clear.rs
@@ -1,5 +1,5 @@
 use std::{
-    net::{IpAddr, Ipv4Addr, SocketAddr},
+    net::{IpAddr, SocketAddr},
     pin::Pin,
     task::{Context, Poll},
 };
@@ -45,26 +45,10 @@ pub struct ClearNetServerCfg {
 #[derive(Clone, Copy)]
 pub enum ClearNet {}
 
-const fn ip_v4(a: u8, b: u8, c: u8, d: u8, port: u16) -> SocketAddr {
-    SocketAddr::new(IpAddr::V4(Ipv4Addr::new(a, b, c, d)), port)
-}
-
 #[async_trait::async_trait]
 impl NetworkZone for ClearNet {
     const NAME: &'static str = "ClearNet";
 
-    const SEEDS: &'static [Self::Addr] = &[
-        ip_v4(176, 9, 0, 187, 18080),
-        ip_v4(88, 198, 163, 90, 18080),
-        ip_v4(66, 85, 74, 134, 18080),
-        ip_v4(51, 79, 173, 165, 18080),
-        ip_v4(192, 99, 8, 110, 18080),
-        ip_v4(37, 187, 74, 171, 18080),
-        ip_v4(77, 172, 183, 193, 18080),
-    ];
-
-    const ALLOW_SYNC: bool = true;
-    const DANDELION_PP: bool = true;
     const CHECK_NODE_ID: bool = true;
 
     type Addr = SocketAddr;

--- a/p2p/p2p-core/tests/fragmented_handshake.rs
+++ b/p2p/p2p-core/tests/fragmented_handshake.rs
@@ -47,9 +47,6 @@ pub enum FragNet {}
 #[async_trait::async_trait]
 impl NetworkZone for FragNet {
     const NAME: &'static str = "FragNet";
-    const SEEDS: &'static [Self::Addr] = &[];
-    const ALLOW_SYNC: bool = true;
-    const DANDELION_PP: bool = true;
     const CHECK_NODE_ID: bool = true;
 
     type Addr = SocketAddr;

--- a/p2p/p2p-core/tests/handshake.rs
+++ b/p2p/p2p-core/tests/handshake.rs
@@ -44,10 +44,10 @@ async fn handshake_cuprate_to_cuprate() {
     our_basic_node_data_2.peer_id = 2344;
 
     let mut handshaker_1 =
-        HandshakerBuilder::<TestNetZone<true, true, true>>::new(our_basic_node_data_1).build();
+        HandshakerBuilder::<TestNetZone<true>>::new(our_basic_node_data_1).build();
 
     let mut handshaker_2 =
-        HandshakerBuilder::<TestNetZone<true, true, true>>::new(our_basic_node_data_2).build();
+        HandshakerBuilder::<TestNetZone<true>>::new(our_basic_node_data_2).build();
 
     let (p1, p2) = duplex(50_000);
 

--- a/p2p/p2p/src/broadcast.rs
+++ b/p2p/p2p/src/broadcast.rs
@@ -414,7 +414,7 @@ mod tests {
     #[tokio::test]
     async fn tx_broadcast_direction_correct() {
         let (mut brcst, outbound_mkr, inbound_mkr) =
-            init_broadcast_channels::<TestNetZone<true, true, true>>(TEST_CONFIG);
+            init_broadcast_channels::<TestNetZone<true>>(TEST_CONFIG);
 
         let mut outbound_stream = pin!(outbound_mkr(InternalPeerID::Unknown(1)));
         let mut inbound_stream = pin!(inbound_mkr(InternalPeerID::Unknown(1)));
@@ -473,7 +473,7 @@ mod tests {
     #[tokio::test]
     async fn block_broadcast_sent_to_all() {
         let (mut brcst, outbound_mkr, inbound_mkr) =
-            init_broadcast_channels::<TestNetZone<true, true, true>>(TEST_CONFIG);
+            init_broadcast_channels::<TestNetZone<true>>(TEST_CONFIG);
 
         let mut outbound_stream = pin!(outbound_mkr(InternalPeerID::Unknown(1)));
         let mut inbound_stream = pin!(inbound_mkr(InternalPeerID::Unknown(1)));
@@ -499,7 +499,7 @@ mod tests {
     #[tokio::test]
     async fn tx_broadcast_skipped_for_received_from_peer() {
         let (mut brcst, outbound_mkr, inbound_mkr) =
-            init_broadcast_channels::<TestNetZone<true, true, true>>(TEST_CONFIG);
+            init_broadcast_channels::<TestNetZone<true>>(TEST_CONFIG);
 
         let mut outbound_stream = pin!(outbound_mkr(InternalPeerID::Unknown(1)));
         let mut outbound_stream_from = pin!(outbound_mkr(InternalPeerID::Unknown(0)));

--- a/p2p/p2p/src/config.rs
+++ b/p2p/p2p/src/config.rs
@@ -8,6 +8,8 @@ use cuprate_wire::{common::PeerSupportFlags, BasicNodeData};
 pub struct P2PConfig<N: NetworkZone> {
     /// The [`Network`] we should connect to.
     pub network: Network,
+    /// Seed nodes to connect to find peers if our address book is empty.
+    pub seeds: Vec<N::Addr>,
 
     /// The number of outbound connections to make and try keep.
     pub outbound_connections: usize,

--- a/p2p/p2p/src/connection_maintainer.rs
+++ b/p2p/p2p/src/connection_maintainer.rs
@@ -104,12 +104,12 @@ where
         clippy::significant_drop_tightening
     )]
     async fn connect_to_random_seeds(&mut self) -> Result<(), OutboundConnectorError> {
-        let seeds = N::SEEDS.choose_multiple(&mut thread_rng(), MAX_SEED_CONNECTIONS);
+        let seeds = self
+            .config
+            .seeds
+            .choose_multiple(&mut thread_rng(), MAX_SEED_CONNECTIONS);
 
-        assert!(
-            seeds.len() != 0,
-            "No seed nodes available to get peers from"
-        );
+        assert_ne!(seeds.len(), 0, "No seed nodes available to get peers from");
 
         let mut allowed_errors = seeds.len();
 

--- a/test-utils/src/test_netzone.rs
+++ b/test-utils/src/test_netzone.rs
@@ -69,16 +69,11 @@ impl TryFrom<NetworkAddress> for TestNetZoneAddr {
 
 /// TODO
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
-pub struct TestNetZone<const ALLOW_SYNC: bool, const DANDELION_PP: bool, const CHECK_NODE_ID: bool>;
+pub struct TestNetZone<const CHECK_NODE_ID: bool>;
 
 #[async_trait::async_trait]
-impl<const ALLOW_SYNC: bool, const DANDELION_PP: bool, const CHECK_NODE_ID: bool> NetworkZone
-    for TestNetZone<ALLOW_SYNC, DANDELION_PP, CHECK_NODE_ID>
-{
+impl<const CHECK_NODE_ID: bool> NetworkZone for TestNetZone<CHECK_NODE_ID> {
     const NAME: &'static str = "Testing";
-    const SEEDS: &'static [Self::Addr] = &[];
-    const ALLOW_SYNC: bool = ALLOW_SYNC;
-    const DANDELION_PP: bool = DANDELION_PP;
     const CHECK_NODE_ID: bool = CHECK_NODE_ID;
 
     type Addr = TestNetZoneAddr;


### PR DESCRIPTION

### What
Moves the seed nodes to the config + removes a few unused constants 

### Why
Seeds nodes depend on the network.

