### PR TITLE
rpc-types: fix `HardForkInfoRequest`

### DIFF
--- a/rpc/types/src/json.rs
+++ b/rpc/types/src/json.rs
@@ -820,7 +820,7 @@ define_request_and_response! {
     HardForkInfo,
 
     #[doc = serde_doc_test!(
-        HARD_FORK_INFO => HardForkInfo {
+        HARD_FORK_INFO_REQUEST => HardForkInfoRequest {
             version: 16,
         }
     )]

--- a/rpc/types/src/json.rs
+++ b/rpc/types/src/json.rs
@@ -817,8 +817,17 @@ define_request_and_response! {
     hard_fork_info,
     cc73fe71162d564ffda8e549b79a350bca53c454 =>
     core_rpc_server_commands_defs.h => 1958..=1995,
-    HardForkInfo (empty),
-    Request {},
+    HardForkInfo,
+
+    #[doc = serde_doc_test!(
+        HARD_FORK_INFO => HardForkInfo {
+            version: 16,
+        }
+    )]
+    #[derive(Copy)]
+    Request {
+        version: u8,
+    },
 
     #[doc = serde_doc_test!(
         HARD_FORK_INFO_RESPONSE => HardForkInfoResponse {

--- a/test-utils/src/rpc/data/json.rs
+++ b/test-utils/src/rpc/data/json.rs
@@ -608,7 +608,10 @@ define_request_and_response! {
 r#"{
   "jsonrpc": "2.0",
   "id": "0",
-  "method": "hard_fork_info"
+  "method": "hard_fork_info",
+  "params": {
+    "version": 16
+  }
 }"#;
     Response =
 r#"{


### PR DESCRIPTION
### What
Fixes the `HardForkInfoRequest` type, it was missing a field: https://github.com/monero-project/monero/blob/9866a0e9021e2422d8055731a586083eb5e2be67/src/rpc/core_rpc_server_commands_defs.h#L1962.