### PR TITLE
consensus-context: enable workspace lints

### DIFF
--- a/consensus/context/Cargo.toml
+++ b/consensus/context/Cargo.toml
@@ -7,8 +7,8 @@ authors = ["SyntheticBird","Boog900"]
 
 [dependencies]
 cuprate-consensus-rules =  { path = "../rules", features = ["proptest"]}
-cuprate-helper = { path = "../../helper", default-features = false, features = ["std", "cast"] }
-cuprate-types = { path = "../../types", default-features = false }
+cuprate-helper = { path = "../../helper", default-features = false, features = ["std", "cast", "num", "asynch"] }
+cuprate-types = { path = "../../types", default-features = false, features = ["blockchain"] }
 
 futures = { workspace = true, features = ["std", "async-await"] }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"]}
@@ -22,3 +22,6 @@ randomx-rs = { workspace = true }
 rayon = { workspace = true }
 thread_local = { workspace = true }
 hex = { workspace = true }
+
+[lints]
+workspace = true

--- a/consensus/context/src/difficulty.rs
+++ b/consensus/context/src/difficulty.rs
@@ -329,7 +329,7 @@ fn next_difficulty(
     }
 
     // TODO: do checked operations here and unwrap so we don't silently overflow?
-    (windowed_work * hf.block_time().as_secs() as u128 + time_span - 1) / time_span
+    (windowed_work * u128::from(hf.block_time().as_secs()) + time_span - 1) / time_span
 }
 
 /// Get the start and end of the window to calculate difficulty.

--- a/consensus/context/src/lib.rs
+++ b/consensus/context/src/lib.rs
@@ -3,7 +3,11 @@
 //! This crate contains a service to get cached context from the blockchain: [`BlockChainContext`].
 //! This is used during contextual validation, this does not have all the data for contextual validation
 //! (outputs) for that you will need a [`Database`].
-//!
+
+// Used in documentation references for [`BlockChainContextRequest`]
+// FIXME: should we pull in a dependency just to link docs?
+use monero_serai as _;
+
 use std::{
     cmp::min,
     collections::HashMap,

--- a/consensus/rules/Cargo.toml
+++ b/consensus/rules/Cargo.toml
@@ -11,7 +11,7 @@ proptest = ["cuprate-types/proptest"]
 rayon = ["dep:rayon"]
 
 [dependencies]
-cuprate-constants = { path = "../../constants", default-features = false }
+cuprate-constants = { path = "../../constants", default-features = false, features = ["block"] }
 cuprate-helper = { path = "../../helper", default-features = false, features = ["std", "cast"] }
 cuprate-types = { path = "../../types", default-features = false }
 cuprate-cryptonight = {path = "../../cryptonight"}

--- a/consensus/rules/src/lib.rs
+++ b/consensus/rules/src/lib.rs
@@ -63,9 +63,9 @@ where
 /// An internal function that returns an iterator or a parallel iterator if the
 /// `rayon` feature is enabled.
 #[cfg(not(feature = "rayon"))]
-fn try_par_iter<T>(t: T) -> impl std::iter::Iterator<Item = T::Item>
+fn try_par_iter<T>(t: T) -> impl Iterator<Item = T::Item>
 where
-    T: std::iter::IntoIterator,
+    T: IntoIterator,
 {
     t.into_iter()
 }

--- a/consensus/rules/src/miner_tx.rs
+++ b/consensus/rules/src/miner_tx.rs
@@ -68,7 +68,7 @@ pub fn calculate_block_reward(
         .unwrap();
     let effective_median_bw: u128 = median_bw.try_into().unwrap();
 
-    (((base_reward as u128 * multiplicand) / effective_median_bw) / effective_median_bw)
+    (((u128::from(base_reward) * multiplicand) / effective_median_bw) / effective_median_bw)
         .try_into()
         .unwrap()
 }


### PR DESCRIPTION
### What
Enables and fixes workspace lints for `cuprate-consensus-context`.

Unrelated: also fixes clippy warnings from [Rust 1.82](https://blog.rust-lang.org/2024/10/17/Rust-1.82.0.html).