### PR TITLE
`as` -> `cuprate_helper::cast`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -712,6 +712,7 @@ dependencies = [
  "bytemuck",
  "bytes",
  "cfg-if",
+ "cuprate-helper",
  "heed",
  "page_size",
  "paste",
@@ -884,6 +885,7 @@ version = "0.1.0"
 dependencies = [
  "borsh",
  "cuprate-constants",
+ "cuprate-helper",
  "thiserror",
 ]
 

--- a/consensus/fast-sync/src/fast_sync.rs
+++ b/consensus/fast-sync/src/fast_sync.rs
@@ -15,7 +15,7 @@ use tower::{Service, ServiceExt};
 use cuprate_consensus::transactions::new_tx_verification_data;
 use cuprate_consensus_context::{BlockChainContextRequest, BlockChainContextResponse};
 use cuprate_consensus_rules::{miner_tx::MinerTxError, ConsensusError};
-use cuprate_helper::cast::u64_to_usize;
+use cuprate_helper::cast::{u64_to_usize, usize_to_u64};
 use cuprate_types::{VerifiedBlockInformation, VerifiedTransactionInformation};
 
 use crate::{hash_of_hashes, BlockId, HashOfHashes};
@@ -38,7 +38,7 @@ const BATCH_SIZE: usize = 4;
 
 #[inline]
 fn max_height() -> u64 {
-    (HASHES_OF_HASHES.len() * BATCH_SIZE) as u64
+    usize_to_u64(HASHES_OF_HASHES.len() * BATCH_SIZE)
 }
 
 #[derive(Debug, PartialEq, Eq)]

--- a/consensus/rules/src/blocks.rs
+++ b/consensus/rules/src/blocks.rs
@@ -4,6 +4,7 @@ use crypto_bigint::{CheckedMul, U256};
 use monero_serai::block::Block;
 
 use cuprate_cryptonight::*;
+use cuprate_helper::cast::usize_to_u64;
 
 use crate::{
     check_block_version_vote, current_unix_timestamp,
@@ -89,8 +90,7 @@ pub fn calculate_pow_hash<R: RandomX>(
     } else if hf < &HardFork::V10 {
         cryptonight_hash_v2(buf)
     } else if hf < &HardFork::V12 {
-        // FIXME: https://github.com/Cuprate/cuprate/issues/167.
-        cryptonight_hash_r(buf, height as u64)
+        cryptonight_hash_r(buf, usize_to_u64(height))
     } else {
         randomx_vm
             .expect("RandomX VM needed from hf 12")

--- a/pruning/Cargo.toml
+++ b/pruning/Cargo.toml
@@ -11,6 +11,7 @@ borsh = ["dep:borsh"]
 
 [dependencies]
 cuprate-constants = { workspace = true }
+cuprate-helper    = { workspace = true, features = ["cast"] }
 
 thiserror = { workspace = true }
 

--- a/storage/blockchain/Cargo.toml
+++ b/storage/blockchain/Cargo.toml
@@ -20,7 +20,7 @@ service     = ["dep:thread_local", "dep:rayon", "cuprate-helper/thread"]
 [dependencies]
 cuprate-database         = { workspace = true }
 cuprate-database-service = { workspace = true }
-cuprate-helper           = { workspace = true, features = ["fs", "map", "crypto"] }
+cuprate-helper           = { workspace = true, features = ["fs", "map", "crypto", "cast"] }
 cuprate-types            = { workspace = true, features = ["blockchain"] }
 cuprate-pruning          = { workspace = true }
 

--- a/storage/blockchain/src/lib.rs
+++ b/storage/blockchain/src/lib.rs
@@ -4,17 +4,6 @@
     clippy::significant_drop_tightening
 )]
 
-// Only allow building 64-bit targets.
-//
-// This allows us to assume 64-bit
-// invariants in code, e.g. `usize as u64`.
-//
-// # Safety
-// As of 0d67bfb1bcc431e90c82d577bf36dd1182c807e2 (2024-04-12)
-// there are invariants relying on 64-bit pointer sizes.
-#[cfg(not(target_pointer_width = "64"))]
-compile_error!("Cuprate is only compatible with 64-bit CPUs");
-
 //---------------------------------------------------------------------------------------------------- Public API
 // Import private modules, export public types.
 //

--- a/storage/blockchain/src/ops/blockchain.rs
+++ b/storage/blockchain/src/ops/blockchain.rs
@@ -2,6 +2,7 @@
 
 //---------------------------------------------------------------------------------------------------- Import
 use cuprate_database::{DatabaseRo, RuntimeError};
+use cuprate_helper::cast::u64_to_usize;
 
 use crate::{
     ops::macros::doc_error,
@@ -25,8 +26,7 @@ use crate::{
 pub fn chain_height(
     table_block_heights: &impl DatabaseRo<BlockHeights>,
 ) -> Result<BlockHeight, RuntimeError> {
-    #[expect(clippy::cast_possible_truncation, reason = "we enforce 64-bit")]
-    table_block_heights.len().map(|height| height as usize)
+    table_block_heights.len().map(u64_to_usize)
 }
 
 /// Retrieve the height of the top block.
@@ -48,8 +48,7 @@ pub fn top_block_height(
 ) -> Result<BlockHeight, RuntimeError> {
     match table_block_heights.len()? {
         0 => Err(RuntimeError::KeyNotFound),
-        #[expect(clippy::cast_possible_truncation, reason = "we enforce 64-bit")]
-        height => Ok(height as usize - 1),
+        height => Ok(u64_to_usize(height) - 1),
     }
 }
 

--- a/storage/blockchain/src/ops/output.rs
+++ b/storage/blockchain/src/ops/output.rs
@@ -7,8 +7,7 @@ use monero_serai::transaction::Timelock;
 use cuprate_database::{
     RuntimeError, {DatabaseRo, DatabaseRw},
 };
-use cuprate_helper::crypto::compute_zero_commitment;
-use cuprate_helper::map::u64_to_timelock;
+use cuprate_helper::{cast::u32_to_usize, crypto::compute_zero_commitment, map::u64_to_timelock};
 use cuprate_types::OutputOnChain;
 
 use crate::{
@@ -172,7 +171,7 @@ pub fn output_to_output_on_chain(
         .unwrap_or(None);
 
     Ok(OutputOnChain {
-        height: output.height as usize,
+        height: u32_to_usize(output.height),
         time_lock,
         key,
         commitment,
@@ -212,7 +211,7 @@ pub fn rct_output_to_output_on_chain(
         .unwrap_or(None);
 
     Ok(OutputOnChain {
-        height: rct_output.height as usize,
+        height: u32_to_usize(rct_output.height),
         time_lock,
         key,
         commitment,

--- a/storage/database/Cargo.toml
+++ b/storage/database/Cargo.toml
@@ -12,11 +12,14 @@ keywords    = ["cuprate", "database"]
 # default     = ["heed"]
 # default     = ["redb"]
 # default     = ["redb-memory"]
-heed        = ["dep:heed"]
+heed        = ["dep:heed", "dep:cuprate-helper"]
 redb        = ["dep:redb"]
 redb-memory = ["redb"]
 
 [dependencies]
+# `usize_to_u64` needed in `heed`
+cuprate-helper = { workspace = true, features = ["cast"], optional = true }
+
 bytemuck  = { version = "1.18.0", features = ["must_cast", "derive", "min_const_generics", "extern_crate_alloc"] }
 bytes     = { workspace = true }
 cfg-if    = { workspace = true }

--- a/storage/database/src/backend/heed/env.rs
+++ b/storage/database/src/backend/heed/env.rs
@@ -9,6 +9,8 @@ use std::{
 
 use heed::{DatabaseFlags, EnvFlags, EnvOpenOptions};
 
+use cuprate_helper::cast::u64_to_usize;
+
 use crate::{
     backend::heed::{
         database::{HeedTableRo, HeedTableRw},
@@ -144,9 +146,8 @@ impl Env for ConcreteEnv {
         // (current disk size) + (a bit of leeway)
         // to account for empty databases where we
         // need to write same tables.
-        #[expect(clippy::cast_possible_truncation, reason = "only 64-bit targets")]
         let disk_size_bytes = match std::fs::File::open(&config.db_file) {
-            Ok(file) => file.metadata()?.len() as usize,
+            Ok(file) => u64_to_usize(file.metadata()?.len()),
             // The database file doesn't exist, 0 bytes.
             Err(io_err) if io_err.kind() == std::io::ErrorKind::NotFound => 0,
             Err(io_err) => return Err(io_err.into()),


### PR DESCRIPTION
### What
Replaces some leftover `as` casts with `cuprate_helper::cast` functions throughout the codebase.

### Why
https://github.com/Cuprate/cuprate/issues/167