### PR TITLE
types: fix pruned `BlockCompleteEntry`

### DIFF
--- a/types/src/block_complete_entry.rs
+++ b/types/src/block_complete_entry.rs
@@ -136,7 +136,7 @@ impl TransactionBlobs {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct PrunedTxBlobEntry {
     /// The transaction.
-    pub tx: Bytes,
+    pub blob: Bytes,
     /// The prunable transaction hash.
     pub prunable_hash: ByteArray<32>,
 }
@@ -144,7 +144,7 @@ pub struct PrunedTxBlobEntry {
 #[cfg(feature = "epee")]
 epee_object!(
     PrunedTxBlobEntry,
-    tx: Bytes,
+    blob: Bytes,
     prunable_hash: ByteArray<32>,
 );
 


### PR DESCRIPTION
I misnamed this field: https://github.com/monero-project/monero/blob/893916ad091a92e765ce3241b94e706ad012b62a/src/cryptonote_protocol/cryptonote_protocol_defs.h#L123