### PR TITLE
books/architecture: add `Monero oddities`

### DIFF
--- a/books/architecture/src/SUMMARY.md
+++ b/books/architecture/src/SUMMARY.md
@@ -157,6 +157,11 @@
 
 ---
 
+- [🟢 Monero oddities](oddities/intro.md)
+    - [🟡 Little-endian IPv4 addresses](oddities/le-ipv4.md)
+
+---
+
 - [⚪️ Appendix](appendix/intro.md)
     - [🟢 Crates](appendix/crates.md)
     - [🔴 Contributing](appendix/contributing.md)

--- a/books/architecture/src/oddities/intro.md
+++ b/books/architecture/src/oddities/intro.md
@@ -1,0 +1,37 @@
+# Monero oddities
+This section is a list of any peculiar, interesting,
+or non-standard behavior that Monero has that is not
+planned on being changed or deprecated.
+
+This section exists to hold all the small yet noteworthy knowledge in one place,
+instead of in any single contributor's mind.
+
+These are usually behaviors stemming from implementation rather than protocol/cryptography.
+
+## Formatting
+This is the markdown formatting for each entry in this section.
+
+If applicable, consider using this formatting when adding to this section.
+
+```md
+# <concise_title_of_the_behavior>
+
+## What
+A detailed description of the behavior.
+
+## Why
+The reasoning behind why this behavior exists and/or
+any links to more detailed discussion on the behavior.
+
+## Expected
+The norm or standard behavior that is usually expected.
+
+## Affects
+A (potentially non-exhaustive) list of places that this behavior can/does affect.
+
+## Example
+An example link or section of code where the behavior occurs.
+
+## Source
+A link to original `monerod` code that defines the behavior.
+```

--- a/books/architecture/src/oddities/le-ipv4.md
+++ b/books/architecture/src/oddities/le-ipv4.md
@@ -1,0 +1,24 @@
+# Little-endian IPv4 addresses
+
+## What
+Monero encodes IPv4 addresses in [little-endian](https://en.wikipedia.org/wiki/Endianness) byte order.
+
+## Why
+TODO
+
+- <https://github.com/monero-project/monero/issues/3826>
+- <https://github.com/monero-project/monero/pull/5544>
+
+## Expected
+In general, [networking-related protocols/code use _networking order_ (big-endian)](https://en.wikipedia.org/wiki/Endianness#Networking).
+
+## Affects
+Any representation and (de)serialization of IPv4 addresses must keep little
+endian in-mind, e.g. the P2P wire format or `int` encoded IPv4 addresses in RPC.
+
+For example, [the `ip` field in `set_bans`](https://www.getmonero.org/resources/developer-guides/daemon-rpc.html#set_bans).
+
+For Cuprate, this means Rust's [`Ipv4Addr::from_bits/from`](https://doc.rust-lang.org/1.82.0/src/core/net/ip_addr.rs.html#1182) cannot be used in these cases as [it assumes big-endian encoding](https://doc.rust-lang.org/1.82.0/src/core/net/ip_addr.rs.html#540).
+
+## Source
+- <https://github.com/monero-project/monero/blob/893916ad091a92e765ce3241b94e706ad012b62a/contrib/epee/include/net/net_utils_base.h#L97>


### PR DESCRIPTION
### What
Adds a `Monero oddities` section to the architecture book and adds an entry for https://github.com/Cuprate/cuprate/pull/342.

### Why
There's a bunch of small yet important stuff like this I have stashed away that needs to be written somewhere (will add the rest later). If this section gets too big maybe we can add nested categories or make some dedicated documented but for now this seems like the right place.