### PR TITLE
rpc: replace binary string endpoints/types

### DIFF
--- a/binaries/cuprated/src/rpc/bin.rs
+++ b/binaries/cuprated/src/rpc/bin.rs
@@ -1,13 +1,12 @@
 use anyhow::Error;
 
-use cuprate_rpc_types::{
-    bin::{
-        BinRequest, BinResponse, GetBlocksByHeightRequest, GetBlocksByHeightResponse,
-        GetBlocksRequest, GetBlocksResponse, GetHashesRequest, GetHashesResponse,
-        GetOutputIndexesRequest, GetOutputIndexesResponse, GetOutsRequest, GetOutsResponse,
-        GetTransactionPoolHashesRequest, GetTransactionPoolHashesResponse,
-    },
-    json::{GetOutputDistributionRequest, GetOutputDistributionResponse},
+use cuprate_rpc_types::bin::{
+    BinRequest, BinResponse, GetBlocksByHeightRequest, GetBlocksByHeightResponse, GetBlocksRequest,
+    GetBlocksResponse, GetHashesRequest, GetHashesResponse, GetOutputDistributionRequest,
+    GetOutputDistributionResponse, GetOutputIndexesRequest, GetOutputIndexesResponse,
+    GetOutsRequest, GetOutsResponse, GetTransactionPoolBacklogRequest,
+    GetTransactionPoolBacklogResponse, GetTransactionPoolHashesRequest,
+    GetTransactionPoolHashesResponse,
 };
 
 use crate::rpc::CupratedRpcHandler;
@@ -28,6 +27,9 @@ pub(super) async fn map_request(
         Req::GetOuts(r) => Resp::GetOuts(get_outs(state, r).await?),
         Req::GetTransactionPoolHashes(r) => {
             Resp::GetTransactionPoolHashes(get_transaction_pool_hashes(state, r).await?)
+        }
+        Req::GetTransactionPoolBacklog(r) => {
+            Resp::GetTransactionPoolBacklog(get_transaction_pool_backlog(state, r).await?)
         }
         Req::GetOutputDistribution(r) => {
             Resp::GetOutputDistribution(get_output_distribution(state, r).await?)
@@ -74,6 +76,13 @@ async fn get_transaction_pool_hashes(
     state: CupratedRpcHandler,
     request: GetTransactionPoolHashesRequest,
 ) -> Result<GetTransactionPoolHashesResponse, Error> {
+    todo!()
+}
+
+async fn get_transaction_pool_backlog(
+    state: CupratedRpcHandler,
+    request: GetTransactionPoolBacklogRequest,
+) -> Result<GetTransactionPoolBacklogResponse, Error> {
     todo!()
 }
 

--- a/binaries/cuprated/src/rpc/json.rs
+++ b/binaries/cuprated/src/rpc/json.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{convert::Infallible, sync::Arc};
 
 use anyhow::Error;
 use tower::ServiceExt;
@@ -14,8 +14,8 @@ use cuprate_rpc_types::json::{
     GetCoinbaseTxSumRequest, GetCoinbaseTxSumResponse, GetConnectionsRequest,
     GetConnectionsResponse, GetFeeEstimateRequest, GetFeeEstimateResponse, GetInfoRequest,
     GetInfoResponse, GetLastBlockHeaderRequest, GetLastBlockHeaderResponse, GetMinerDataRequest,
-    GetMinerDataResponse, GetOutputHistogramRequest, GetOutputHistogramResponse,
-    GetTransactionPoolBacklogRequest, GetTransactionPoolBacklogResponse, GetTxIdsLooseRequest,
+    GetMinerDataResponse, GetOutputHistogramV2Request, GetOutputHistogramV2Response,
+    GetTransactionPoolBacklogV2Request, GetTransactionPoolBacklogV2Response, GetTxIdsLooseRequest,
     GetTxIdsLooseResponse, GetVersionRequest, GetVersionResponse, HardForkInfoRequest,
     HardForkInfoResponse, JsonRpcRequest, JsonRpcResponse, OnGetBlockHashRequest,
     OnGetBlockHashResponse, PruneBlockchainRequest, PruneBlockchainResponse, RelayTxRequest,
@@ -60,8 +60,8 @@ pub(super) async fn map_request(
         Req::FlushTransactionPool(r) => {
             Resp::FlushTransactionPool(flush_transaction_pool(state, r).await?)
         }
-        Req::GetOutputHistogram(r) => {
-            Resp::GetOutputHistogram(get_output_histogram(state, r).await?)
+        Req::GetOutputHistogramV2(r) => {
+            Resp::GetOutputHistogramV2(get_output_histogram_v2(state, r).await?)
         }
         Req::GetCoinbaseTxSum(r) => Resp::GetCoinbaseTxSum(get_coinbase_tx_sum(state, r).await?),
         Req::GetVersion(r) => Resp::GetVersion(get_version(state, r).await?),
@@ -71,8 +71,8 @@ pub(super) async fn map_request(
         }
         Req::RelayTx(r) => Resp::RelayTx(relay_tx(state, r).await?),
         Req::SyncInfo(r) => Resp::SyncInfo(sync_info(state, r).await?),
-        Req::GetTransactionPoolBacklog(r) => {
-            Resp::GetTransactionPoolBacklog(get_transaction_pool_backlog(state, r).await?)
+        Req::GetTransactionPoolBacklogV2(r) => {
+            Resp::GetTransactionPoolBacklogV2(get_transaction_pool_backlog_v2(state, r).await?)
         }
         Req::GetMinerData(r) => Resp::GetMinerData(get_miner_data(state, r).await?),
         Req::PruneBlockchain(r) => Resp::PruneBlockchain(prune_blockchain(state, r).await?),
@@ -195,10 +195,10 @@ async fn flush_transaction_pool(
     todo!()
 }
 
-async fn get_output_histogram(
+async fn get_output_histogram_v2(
     state: CupratedRpcHandler,
-    request: GetOutputHistogramRequest,
-) -> Result<GetOutputHistogramResponse, Error> {
+    request: GetOutputHistogramV2Request,
+) -> Result<GetOutputHistogramV2Response, Error> {
     todo!()
 }
 
@@ -244,10 +244,10 @@ async fn sync_info(
     todo!()
 }
 
-async fn get_transaction_pool_backlog(
+async fn get_transaction_pool_backlog_v2(
     state: CupratedRpcHandler,
-    request: GetTransactionPoolBacklogRequest,
-) -> Result<GetTransactionPoolBacklogResponse, Error> {
+    request: GetTransactionPoolBacklogV2Request,
+) -> Result<GetTransactionPoolBacklogV2Response, Error> {
     todo!()
 }
 

--- a/rpc/interface/src/route/bin.rs
+++ b/rpc/interface/src/route/bin.rs
@@ -8,9 +8,10 @@ use cuprate_epee_encoding::from_bytes;
 use cuprate_rpc_types::{
     bin::{
         BinRequest, BinResponse, GetBlocksByHeightRequest, GetBlocksRequest, GetHashesRequest,
-        GetOutputIndexesRequest, GetOutsRequest, GetTransactionPoolHashesRequest,
+        GetOutputDistributionRequest, GetOutputIndexesRequest, GetOutsRequest,
+        GetTransactionPoolBacklogRequest, GetTransactionPoolBacklogResponse,
+        GetTransactionPoolHashesRequest,
     },
-    json::GetOutputDistributionRequest,
     RpcCall,
 };
 
@@ -102,7 +103,8 @@ generate_endpoints_with_input! {
     get_hashes => GetHashes,
     get_o_indexes => GetOutputIndexes,
     get_outs => GetOuts,
-    get_output_distribution => GetOutputDistribution
+    get_output_distribution => GetOutputDistribution,
+    get_txpool_backlog => GetTransactionPoolBacklog
 }
 
 generate_endpoints_with_no_input! {

--- a/rpc/interface/src/rpc_handler_dummy.rs
+++ b/rpc/interface/src/rpc_handler_dummy.rs
@@ -75,15 +75,15 @@ impl Service<JsonRpcRequest> for RpcHandlerDummy {
             Req::GetBans(_) => Resp::GetBans(Default::default()),
             Req::Banned(_) => Resp::Banned(Default::default()),
             Req::FlushTransactionPool(_) => Resp::FlushTransactionPool(Default::default()),
-            Req::GetOutputHistogram(_) => Resp::GetOutputHistogram(Default::default()),
+            Req::GetOutputHistogramV2(_) => Resp::GetOutputHistogramV2(Default::default()),
             Req::GetCoinbaseTxSum(_) => Resp::GetCoinbaseTxSum(Default::default()),
             Req::GetVersion(_) => Resp::GetVersion(Default::default()),
             Req::GetFeeEstimate(_) => Resp::GetFeeEstimate(Default::default()),
             Req::GetAlternateChains(_) => Resp::GetAlternateChains(Default::default()),
             Req::RelayTx(_) => Resp::RelayTx(Default::default()),
             Req::SyncInfo(_) => Resp::SyncInfo(Default::default()),
-            Req::GetTransactionPoolBacklog(_) => {
-                Resp::GetTransactionPoolBacklog(Default::default())
+            Req::GetTransactionPoolBacklogV2(_) => {
+                Resp::GetTransactionPoolBacklogV2(Default::default())
             }
             Req::GetMinerData(_) => Resp::GetMinerData(Default::default()),
             Req::PruneBlockchain(_) => Resp::PruneBlockchain(Default::default()),
@@ -120,6 +120,9 @@ impl Service<BinRequest> for RpcHandlerDummy {
             Req::GetOutputIndexes(_) => Resp::GetOutputIndexes(Default::default()),
             Req::GetOuts(_) => Resp::GetOuts(Default::default()),
             Req::GetTransactionPoolHashes(_) => Resp::GetTransactionPoolHashes(Default::default()),
+            Req::GetTransactionPoolBacklog(_) => {
+                Resp::GetTransactionPoolBacklog(Default::default())
+            }
             Req::GetOutputDistribution(_) => Resp::GetOutputDistribution(Default::default()),
         };
 

--- a/rpc/types/README.md
+++ b/rpc/types/README.md
@@ -45,29 +45,16 @@ For example:
 | [`/get_blocks.bin`](https://www.getmonero.org/resources/developer-guides/daemon-rpc.html#get_blockbin) | [`bin::GetBlocksRequest`] & [`bin::GetBlocksResponse`]
 | [`/get_height`](https://www.getmonero.org/resources/developer-guides/daemon-rpc.html#get_height) | [`other::GetHeightRequest`] & [`other::GetHeightResponse`]
 
-# Mixed types
-Note that some types mix JSON & binary together, i.e., the message overall is JSON,
-however some fields contain binary values inside JSON strings, for example:
+# Deprecated types
+TODO: update after finalizing <https://github.com/monero-project/monero/issues/9422>.
 
-```json
-{
-  "string": "",
-  "float": 30.0,
-  "integer": 30,
-  "binary": "<serialized binary>"
-}
-```
+- [`crate::json::GetTransactionPoolBacklogV2Response`]
+- [`crate::json::GetOutputDistributionV2Response`]
 
-`binary` here is (de)serialized as a normal [`String`]. In order to be clear on which fields contain binary data, the struct fields that have them will use [`crate::misc::BinaryString`] instead of [`String`].
+# Optimized types
+TODO: updated after deciding compatability <-> optimization tradeoff.
 
-These mixed types are:
-- [`crate::json::GetTransactionPoolBacklogResponse`]
-- [`crate::json::GetOutputDistributionResponse`]
-
-TODO: we need to figure out a type that (de)serializes correctly, `String` errors with `serde_json`
-
-# Fixed byte containers
-TODO
+- Fixed byte containers
 
 <!--
 

--- a/rpc/types/src/bin.rs
+++ b/rpc/types/src/bin.rs
@@ -21,16 +21,52 @@ use cuprate_types::BlockCompleteEntry;
 use crate::{
     base::AccessResponseBase,
     macros::{define_request, define_request_and_response, define_request_and_response_doc},
-    misc::{BlockOutputIndices, GetOutputsOut, OutKeyBin, PoolTxInfo, Status},
+    misc::{
+        BlockOutputIndices, Distribution, GetOutputsOut, OutKeyBin, PoolTxInfo, Status,
+        TxBacklogEntry,
+    },
     rpc_call::RpcCallValue,
 };
 
 #[cfg(any(feature = "epee", feature = "serde"))]
-use crate::defaults::{default_false, default_zero};
+use crate::defaults::{default_false, default_true, default_zero};
 #[cfg(feature = "epee")]
 use crate::misc::PoolInfoExtent;
 
 //---------------------------------------------------------------------------------------------------- Definitions
+define_request_and_response! {
+    get_txpool_backlogbin,
+    cc73fe71162d564ffda8e549b79a350bca53c454 =>
+    core_rpc_server_commands_defs.h => 1637..=1664,
+    GetTransactionPoolBacklog (empty),
+    Request {},
+
+    AccessResponseBase {
+        backlog: Vec<TxBacklogEntry>,
+    }
+}
+
+define_request_and_response! {
+    get_output_distributionbin,
+    cc73fe71162d564ffda8e549b79a350bca53c454 =>
+    core_rpc_server_commands_defs.h => 2445..=2520,
+
+    GetOutputDistribution,
+
+    Request {
+        amounts: Vec<u64>,
+        binary: bool = default_true(), "default_true",
+        compress: bool = default_false(), "default_false",
+        cumulative: bool = default_false(), "default_false",
+        from_height: u64 = default_zero::<u64>(), "default_zero",
+        to_height: u64 = default_zero::<u64>(), "default_zero",
+    },
+
+    AccessResponseBase {
+        distributions: Vec<Distribution>,
+    }
+}
+
 define_request_and_response! {
     get_blocks_by_heightbin,
     cc73fe71162d564ffda8e549b79a350bca53c454 =>
@@ -403,7 +439,8 @@ pub enum BinRequest {
     GetOutputIndexes(GetOutputIndexesRequest),
     GetOuts(GetOutsRequest),
     GetTransactionPoolHashes(GetTransactionPoolHashesRequest),
-    GetOutputDistribution(crate::json::GetOutputDistributionRequest),
+    GetTransactionPoolBacklog(GetTransactionPoolBacklogRequest),
+    GetOutputDistribution(GetOutputDistributionRequest),
 }
 
 impl RpcCallValue for BinRequest {
@@ -415,6 +452,7 @@ impl RpcCallValue for BinRequest {
             Self::GetOutputIndexes(x) => x.is_restricted(),
             Self::GetOuts(x) => x.is_restricted(),
             Self::GetTransactionPoolHashes(x) => x.is_restricted(),
+            Self::GetTransactionPoolBacklog(x) => x.is_restricted(),
             Self::GetOutputDistribution(x) => x.is_restricted(),
         }
     }
@@ -427,6 +465,7 @@ impl RpcCallValue for BinRequest {
             Self::GetOutputIndexes(x) => x.is_empty(),
             Self::GetOuts(x) => x.is_empty(),
             Self::GetTransactionPoolHashes(x) => x.is_empty(),
+            Self::GetTransactionPoolBacklog(x) => x.is_empty(),
             Self::GetOutputDistribution(x) => x.is_empty(),
         }
     }
@@ -448,7 +487,8 @@ pub enum BinResponse {
     GetOutputIndexes(GetOutputIndexesResponse),
     GetOuts(GetOutsResponse),
     GetTransactionPoolHashes(GetTransactionPoolHashesResponse),
-    GetOutputDistribution(crate::json::GetOutputDistributionResponse),
+    GetTransactionPoolBacklog(GetTransactionPoolBacklogResponse),
+    GetOutputDistribution(GetOutputDistributionResponse),
 }
 
 //---------------------------------------------------------------------------------------------------- Tests

--- a/rpc/types/src/json.rs
+++ b/rpc/types/src/json.rs
@@ -971,14 +971,15 @@ define_request_and_response! {
     }
 }
 
+// TODO: update after finalizing <https://github.com/monero-project/monero/issues/9422>.
 define_request_and_response! {
-    get_output_histogram,
+    get_output_histogram_v2,
     cc73fe71162d564ffda8e549b79a350bca53c454 =>
     core_rpc_server_commands_defs.h => 2118..=2168,
-    GetOutputHistogram,
+    GetOutputHistogramV2,
 
     #[doc = serde_doc_test!(
-        GET_OUTPUT_HISTOGRAM_REQUEST => GetOutputHistogramRequest {
+        GET_OUTPUT_HISTOGRAM_V2_REQUEST => GetOutputHistogramV2Request {
             amounts: vec![20000000000],
             min_count: 0,
             max_count: 0,
@@ -995,7 +996,7 @@ define_request_and_response! {
     },
 
     #[doc = serde_doc_test!(
-        GET_OUTPUT_HISTOGRAM_RESPONSE => GetOutputHistogramResponse {
+        GET_OUTPUT_HISTOGRAM_V2_RESPONSE => GetOutputHistogramV2Response {
             base: AccessResponseBase::OK,
             histogram: vec![HistogramEntry {
                 amount: 20000000000,
@@ -1324,38 +1325,41 @@ define_request_and_response! {
     }
 }
 
+// TODO: update after finalizing <https://github.com/monero-project/monero/issues/9422>.
 define_request_and_response! {
-    get_txpool_backlog,
+    get_txpool_backlog_v2,
     cc73fe71162d564ffda8e549b79a350bca53c454 =>
     core_rpc_server_commands_defs.h => 1637..=1664,
-    GetTransactionPoolBacklog (empty),
+    GetTransactionPoolBacklogV2 (empty),
     Request {},
 
-    // TODO: enable test after binary string impl.
-    // #[doc = serde_doc_test!(
-    //     GET_TRANSACTION_POOL_BACKLOG_RESPONSE => GetTransactionPoolBacklogResponse {
-    //         base: ResponseBase::OK,
-    //         backlog: "...Binary...".into(),
-    //     }
-    // )]
+    #[doc = serde_doc_test!(
+        GET_TRANSACTION_POOL_BACKLOG_V2_RESPONSE => GetTransactionPoolBacklogV2Response {
+            base: ResponseBase::OK,
+            backlog: vec![
+                TxBacklogEntry {
+                    weight: 0,
+                    fee: 0,
+                    time_in_pool: 0,
+                }
+            ],
+        }
+    )]
     ResponseBase {
-        // TODO: this is a [`BinaryString`].
         backlog: Vec<TxBacklogEntry>,
     }
 }
 
+// TODO: update after finalizing <https://github.com/monero-project/monero/issues/9422>.
 define_request_and_response! {
-    get_output_distribution,
+    get_output_distribution_v2,
     cc73fe71162d564ffda8e549b79a350bca53c454 =>
     core_rpc_server_commands_defs.h => 2445..=2520,
 
-    /// This type is also used in the (undocumented)
-    /// [`/get_output_distribution.bin`](https://github.com/monero-project/monero/blob/cc73fe71162d564ffda8e549b79a350bca53c454/src/rpc/core_rpc_server.h#L138)
-    /// binary endpoint.
-    GetOutputDistribution,
+    GetOutputDistributionV2,
 
     #[doc = serde_doc_test!(
-        GET_OUTPUT_DISTRIBUTION_REQUEST => GetOutputDistributionRequest {
+        GET_OUTPUT_DISTRIBUTION_V2_REQUEST => GetOutputDistributionV2Request {
             amounts: vec![628780000],
             from_height: 1462078,
             binary: true,
@@ -1373,19 +1377,18 @@ define_request_and_response! {
         to_height: u64 = default_zero::<u64>(), "default_zero",
     },
 
-    // TODO: enable test after binary string impl.
-    // #[doc = serde_doc_test!(
-    //     GET_OUTPUT_DISTRIBUTION_RESPONSE => GetOutputDistributionResponse {
-    //         base: AccessResponseBase::OK,
-    //         distributions: vec![Distribution::Uncompressed(DistributionUncompressed {
-    //             start_height: 1462078,
-    //             base: 0,
-    //             distribution: vec![],
-    //             amount: 2628780000,
-    //             binary: true,
-    //         })],
-    //     }
-    // )]
+    #[doc = serde_doc_test!(
+        GET_OUTPUT_DISTRIBUTION_RESPONSE => GetOutputDistributionResponse {
+            base: AccessResponseBase::OK,
+            distributions: vec![Distribution::Uncompressed(DistributionUncompressed {
+                start_height: 1462078,
+                base: 0,
+                distribution: vec![],
+                amount: 2628780000,
+                binary: true,
+            })],
+        }
+    )]
     AccessResponseBase {
         distributions: Vec<Distribution>,
     }
@@ -1615,14 +1618,14 @@ pub enum JsonRpcRequest {
     GetBans(GetBansRequest),
     Banned(BannedRequest),
     FlushTransactionPool(FlushTransactionPoolRequest),
-    GetOutputHistogram(GetOutputHistogramRequest),
+    GetOutputHistogramV2(GetOutputHistogramV2Request),
     GetCoinbaseTxSum(GetCoinbaseTxSumRequest),
     GetVersion(GetVersionRequest),
     GetFeeEstimate(GetFeeEstimateRequest),
     GetAlternateChains(GetAlternateChainsRequest),
     RelayTx(RelayTxRequest),
     SyncInfo(SyncInfoRequest),
-    GetTransactionPoolBacklog(GetTransactionPoolBacklogRequest),
+    GetTransactionPoolBacklogV2(GetTransactionPoolBacklogV2Request),
     GetMinerData(GetMinerDataRequest),
     PruneBlockchain(PruneBlockchainRequest),
     CalcPow(CalcPowRequest),
@@ -1644,10 +1647,10 @@ impl RpcCallValue for JsonRpcRequest {
             Self::GetBlock(x) => x.is_restricted(),
             Self::GetInfo(x) => x.is_restricted(),
             Self::HardForkInfo(x) => x.is_restricted(),
-            Self::GetOutputHistogram(x) => x.is_restricted(),
+            Self::GetOutputHistogramV2(x) => x.is_restricted(),
             Self::GetVersion(x) => x.is_restricted(),
             Self::GetFeeEstimate(x) => x.is_restricted(),
-            Self::GetTransactionPoolBacklog(x) => x.is_restricted(),
+            Self::GetTransactionPoolBacklogV2(x) => x.is_restricted(),
             Self::GetMinerData(x) => x.is_restricted(),
             Self::AddAuxPow(x) => x.is_restricted(),
             Self::GetTxIdsLoose(x) => x.is_restricted(),
@@ -1679,10 +1682,10 @@ impl RpcCallValue for JsonRpcRequest {
             Self::GetBlock(x) => x.is_empty(),
             Self::GetInfo(x) => x.is_empty(),
             Self::HardForkInfo(x) => x.is_empty(),
-            Self::GetOutputHistogram(x) => x.is_empty(),
+            Self::GetOutputHistogramV2(x) => x.is_empty(),
             Self::GetVersion(x) => x.is_empty(),
             Self::GetFeeEstimate(x) => x.is_empty(),
-            Self::GetTransactionPoolBacklog(x) => x.is_empty(),
+            Self::GetTransactionPoolBacklogV2(x) => x.is_empty(),
             Self::GetMinerData(x) => x.is_empty(),
             Self::AddAuxPow(x) => x.is_empty(),
             Self::GetTxIdsLoose(x) => x.is_empty(),
@@ -1747,14 +1750,14 @@ pub enum JsonRpcResponse {
     GetBans(GetBansResponse),
     Banned(BannedResponse),
     FlushTransactionPool(FlushTransactionPoolResponse),
-    GetOutputHistogram(GetOutputHistogramResponse),
+    GetOutputHistogramV2(GetOutputHistogramV2Response),
     GetCoinbaseTxSum(GetCoinbaseTxSumResponse),
     GetVersion(GetVersionResponse),
     GetFeeEstimate(GetFeeEstimateResponse),
     GetAlternateChains(GetAlternateChainsResponse),
     RelayTx(RelayTxResponse),
     SyncInfo(SyncInfoResponse),
-    GetTransactionPoolBacklog(GetTransactionPoolBacklogResponse),
+    GetTransactionPoolBacklogV2(GetTransactionPoolBacklogV2Response),
     GetMinerData(GetMinerDataResponse),
     PruneBlockchain(PruneBlockchainResponse),
     CalcPow(CalcPowResponse),

--- a/test-utils/src/rpc/data/json.rs
+++ b/test-utils/src/rpc/data/json.rs
@@ -1069,31 +1069,36 @@ r#"{
 }"#;
 }
 
-// TODO: binary string.
-// define_request_and_response! {
-//     get_txpool_backlog (json_rpc),
-//     GET_TRANSACTION_POOL_BACKLOG: &str,
-//     Request =
-// r#"{
-//   "jsonrpc": "2.0",
-//   "id": "0",
-//   "method": "get_txpool_backlog"
-// }"#;
-//     Response =
-// r#"{
-//   "id": "0",
-//   "jsonrpc": "2.0",
-//   "result": {
-//     "backlog": "...Binary...",
-//     "status": "OK",
-//     "untrusted": false
-//   }
-// }"#;
-// }
+define_request_and_response! {
+    get_txpool_backlog_v2 (json_rpc),
+    GET_TRANSACTION_POOL_BACKLOG_V2: &str,
+    Request =
+r#"{
+   "jsonrpc": "2.0",
+   "id": "0",
+   "method": "get_txpool_backlog_v2"
+ }"#;
+    Response =
+r#"{
+   "id": "0",
+   "jsonrpc": "2.0",
+   "result": {
+     "backlog": [
+        {
+          weight: 0,
+          fee: 0,
+          time_in_pool: 0,
+        }
+     ],
+     "status": "OK",
+     "untrusted": false
+   }
+ }"#;
+}
 
 define_request_and_response! {
-    get_output_distribution (json_rpc),
-    GET_OUTPUT_DISTRIBUTION: &str,
+    get_output_distribution_v2 (json_rpc),
+    GET_OUTPUT_DISTRIBUTION_V2: &str,
     Request =
 r#"{
   "jsonrpc": "2.0",


### PR DESCRIPTION
## What
Replaces RPC binary string endpoints/types by implementing https://github.com/monero-project/monero/issues/9422#issuecomment-2274036892.

This removes the planned deprecated endpoints/types i.e. `get_tx_backlog_v2` will work but `get_tx_backlog` will return error.

## RPC API changes
#### Removed
- /json_rpc (get_txpool_backlog)
- /json_rpc (get_output_distribution)

#### Added
- /json_rpc (get_txpool_backlog_v2)
- /json_rpc (get_output_distribution_v2)
- /get_txpool_backlog.bin

#### Same as before
- /get_output_distribution.bin

## JSON representation examples
```json
// get_txpool_backlog_v2
{
  "id": "0",
  "jsonrpc": "2.0",
  "result": {
    "backlog": [
      {
        "weight": 0,
        "fee": 0,
        "time_in_pool": 0
      }
    ],
    "status": "OK",
    "untrusted": false
  }
}
```
```json
// get_output_distribution_v2
{
  "id": "0",
  "jsonrpc": "2.0",
  "result": {
    "credits": 0,
    "distributions": [
      {
        "start_height": 0,
        "base": 0,
        "distribution": [1000, 2000, 3000],
        // If `compress` is passed the above field instead be something like:
        // "compressed_data": [0, 1, 2],
        "amount": 0,
        "binary": false
      }
    ],
    "status": "OK",
    "top_hash": "",
    "untrusted": false
  }
}
```