### PR TITLE
database: Test heed get_range

### DIFF
--- a/storage/database/src/backend/tests.rs
+++ b/storage/database/src/backend/tests.rs
@@ -360,7 +360,7 @@ fn tables_are_sorted() {
     // Insert range, assert each new
     // number inserted is the minimum `last()` value.
     for key in RANGE {
-        table.put(&key, &(key as u64)).unwrap();
+        table.put(&key, &u64::from(key)).unwrap();
         table.contains(&key).unwrap();
         let (first, _) = table.first().unwrap();
         let (last, _) = table.last().unwrap();

--- a/storage/database/src/backend/tests.rs
+++ b/storage/database/src/backend/tests.rs
@@ -360,7 +360,7 @@ fn tables_are_sorted() {
     // Insert range, assert each new
     // number inserted is the minimum `last()` value.
     for key in RANGE {
-        table.put(&key, &0).unwrap();
+        table.put(&key, &(key as u64)).unwrap();
         table.contains(&key).unwrap();
         let (first, _) = table.first().unwrap();
         let (last, _) = table.last().unwrap();
@@ -383,6 +383,9 @@ fn tables_are_sorted() {
             let key = key.unwrap();
             assert_eq!(i, iter);
             assert_eq!(iter, key);
+        }
+        for (v, vv) in table.get_range(100..249).unwrap().zip(100..249) {
+            assert_eq!(v.unwrap(), vv);
         }
     }
 


### PR DESCRIPTION
### What
Test the get_range function in `storage/database/src/backend/heed/database.rs`. 

### Why
This is meant to address issue #348 .

### Where
This is related to the heed database backend and related tests.

### How
This PR is meant to address a perceived misunderstanding in issue #348 . The table insertions in the test have incrementing keys but all have a value equal to `0u64`.

`get_range` is defined to return Values rather than Keys, as per the function signature, yet in the reproduction code all the Values must equal 0. 

```
impl<T: Table> DatabaseIter<T> for HeedTableRo<'_, T> {
    #[inline]
    fn get_range<'a, Range>(
        &'a self,
        range: Range,
    ) -> Result<impl Iterator<Item = Result<T::Value, RuntimeError>> + 'a, RuntimeError>
    where
        Range: RangeBounds<T::Key> + 'a
```

If we wish to test `get_range` we should be checking the Values within the new loop, as this is what get_range returns. I believe the functionality of `get_range` is correct.
