### PR TITLE
 books/architecture: more `Monero oddities`

### DIFF
--- a/books/architecture/src/SUMMARY.md
+++ b/books/architecture/src/SUMMARY.md
@@ -165,7 +165,10 @@
 ---
 
 - [🟢 Monero oddities](oddities/intro.md)
+    - [🟡 Epee empty containers](oddities/epee-empty-containers.md)
+    - [🟡 Invalid blocks](oddities/invalid-blocks.md)
     - [🟡 Little-endian IPv4 addresses](oddities/le-ipv4.md)
+    - [🟡 2 variable integer formats](oddities/varint.md)
 
 ---
 

--- a/books/architecture/src/oddities/epee-empty-containers.md
+++ b/books/architecture/src/oddities/epee-empty-containers.md
@@ -1,0 +1,35 @@
+# Epee empty containers
+
+## What
+Monero's serialization in the `epee` library, responsible for both JSON and binary encoding, will not serialize containers that are empty.
+
+This causes some issues for the binary format:
+- <https://github.com/monero-rs/monero-epee-bin-serde/issues/49>
+- <https://github.com/monero-project/monero/pull/8940>
+
+For JSON, fields with empty containers will cause the field itself to not be present in the JSON output.
+
+## Expected
+Serialization of the key and an empty field, for example, this is expected:
+```json
+{
+  "empty": [],
+  "non_empty": [1]
+}
+```
+
+However `monerod` will write:
+```json
+{
+  "non_empty": [1]
+}
+```
+
+## Why
+TODO
+
+## Affects
+TODO
+
+## Source
+- TODO

--- a/books/architecture/src/oddities/invalid-blocks.md
+++ b/books/architecture/src/oddities/invalid-blocks.md
@@ -1,0 +1,21 @@
+# Invalid blocks
+
+## What
+TODO
+
+- Block 202612
+- Block 685498
+
+## Expected
+TODO
+
+## Why
+TODO
+
+## Affects
+TODO
+
+## Source
+- <https://github.com/monero-project/monero/pull/121>
+- <https://github.com/monero-project/monero/blob/893916ad091a92e765ce3241b94e706ad012b62a/src/crypto/tree-hash.c#L63-L74>
+- <https://github.com/monero-project/monero/blob/893916ad091a92e765ce3241b94e706ad012b62a/src/blockchain_db/blockchain_db.cpp#L450-L456>

--- a/books/architecture/src/oddities/varint.md
+++ b/books/architecture/src/oddities/varint.md
@@ -1,0 +1,19 @@
+# 2 variable integer formats
+
+## What
+Monero has 2 variant integer formats that are used in different contexts.
+
+## Expected
+TODO
+
+## Why
+TODO
+
+- <https://github.com/monero-project/monero/issues/3826>
+- <https://github.com/monero-project/monero/pull/5544>
+
+## Affects
+TODO
+
+## Source
+- TODO


### PR DESCRIPTION
### What
Continues https://github.com/Cuprate/cuprate/pull/343, adds a few entries to `Monero oddities` in the architecture book.