### PR TITLE
rpc/types: add missing defaults to fields

### DIFF
--- a/rpc/types/src/bin.rs
+++ b/rpc/types/src/bin.rs
@@ -132,8 +132,8 @@ define_request_and_response! {
         start_height: u64,
         current_height: u64,
         output_indices: Vec<BlockOutputIndices>,
-        daemon_time: u64,
-        pool_info: PoolInfo,
+        daemon_time: u64 = default_zero::<u64>(), "default_zero",
+        pool_info: PoolInfo = PoolInfo::None, "PoolInfo::default",
     }
 }
 

--- a/rpc/types/src/bin.rs
+++ b/rpc/types/src/bin.rs
@@ -133,6 +133,7 @@ define_request_and_response! {
         current_height: u64,
         output_indices: Vec<BlockOutputIndices>,
         daemon_time: u64 = default_zero::<u64>(), "default_zero",
+        // FIXME: use `default()` after <https://github.com/Cuprate/cuprate/pull/355>
         pool_info: PoolInfo = PoolInfo::None, "PoolInfo::default",
     }
 }


### PR DESCRIPTION
These fields were missing defaults: https://github.com/monero-project/monero/blob/893916ad091a92e765ce3241b94e706ad012b62a/src/rpc/core_rpc_server_commands_defs.h#L265-L266

reported by @spirobel