### PR TITLE
workspace: Rust 1.84

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,12 +29,15 @@ jobs:
   fmt:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-      with:
-        submodules: recursive
-    - name: Format
-      run: cargo fmt --all --check
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+          components: rustfmt
+      - name: Format
+        run: cargo fmt --all --check
 
   # Run typo checker separately.
   # This will fast-cancel other CI early if this fails.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-resolver = "2"
+resolver = "3"
 members = [
 	# Binaries
 	"binaries/cuprated",
@@ -284,6 +284,9 @@ zero_repeat_side_effects = "deny"
 non_zero_suggestions = "deny"
 manual_is_power_of_two = "deny"
 used_underscore_items = "deny"
+unnecessary_map_or = "deny"
+map_all_any_identity = "deny"
+unnecessary_literal_bound = "deny"
 
 # Warm
 cast_possible_truncation = "deny"

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,1 +1,2 @@
+# <https://rust-lang.github.io/rust-clippy/master/index.html#upper_case_acronyms>
 upper-case-acronyms-aggressive = true

--- a/constants/build.rs
+++ b/constants/build.rs
@@ -24,7 +24,7 @@ fn set_commit_env() {
         .to_lowercase();
 
     // Commit hash should always be 40 bytes long.
-    assert_eq!(commit.as_bytes().len(), 40);
+    assert_eq!(commit.len(), 40);
 
     println!("cargo:rustc-env=COMMIT={commit}");
 }

--- a/rpc/json-rpc/src/version.rs
+++ b/rpc/json-rpc/src/version.rs
@@ -82,13 +82,13 @@ impl Serialize for Version {
 
 impl std::fmt::Display for Version {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, r#"{}"#, Self::TWO)
+        write!(f, "{}", Self::TWO)
     }
 }
 
 impl std::fmt::Debug for Version {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, r#"{}"#, Self::TWO)
+        write!(f, "{}", Self::TWO)
     }
 }
 

--- a/storage/database/src/config/config.rs
+++ b/storage/database/src/config/config.rs
@@ -15,10 +15,7 @@ use crate::{config::SyncMode, constants::DATABASE_DATA_FILENAME, resize::ResizeA
 /// use cuprate_database::config::*;
 /// assert_eq!(READER_THREADS_DEFAULT.get(), 126);
 /// ```
-pub const READER_THREADS_DEFAULT: NonZeroUsize = match NonZeroUsize::new(126) {
-    Some(n) => n,
-    None => unreachable!(),
-};
+pub const READER_THREADS_DEFAULT: NonZeroUsize = NonZeroUsize::new(126).unwrap();
 
 //---------------------------------------------------------------------------------------------------- ConfigBuilder
 /// Builder for [`Config`].


### PR DESCRIPTION
### What
Adds/fixes lints from [Rust 1.84](https://blog.rust-lang.org/2025/01/09/Rust-1.84.0.html) and updates the Cargo resolver to [version 3](https://doc.rust-lang.org/cargo/reference/resolver.html#resolver-versions).

Added clippy lints:
- [unnecessary_map_or](https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_map_or)
- [map_all_any_identity](https://rust-lang.github.io/rust-clippy/master/index.html#map_all_any_identity)
- [unnecessary_literal_bound](https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_literal_bound)