### PR TITLE
ci: stable Rust for `deny`, remove `boost` dep for docs

### DIFF
--- a/.github/workflows/deny.yml
+++ b/.github/workflows/deny.yml
@@ -25,9 +25,16 @@ jobs:
           ~/.cargo
           target
         key: deny
+
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: stable
+
     - uses: actions/checkout@v4
       with:
         submodules: recursive
+
     - name: Install dependencies
       run: cargo install cargo-deny --locked
     - name: Deny

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -40,12 +40,6 @@ jobs:
         path: target/debug
         key: doc
 
-    # Packages other than `Boost` used by `Monero` are listed here.
-    # https://github.com/monero-project/monero/blob/c444a7e002036e834bfb4c68f04a121ce1af5825/.github/workflows/build.yml#L71
-
-    - name: Install dependencies (Linux)
-      run: sudo apt install -y libboost-dev
-
     - name: Documentation
       run: cargo +nightly doc --workspace --all-features
 


### PR DESCRIPTION
### What
- Uses Rust stable for `cargo deny`
- Removes the boost install for `cargo doc` uploads

### Why
- `cargo deny` without explicit stable will fail when there is a new Rust stable but GitHub CI hasn't updated yet: https://github.com/Cuprate/cuprate/actions/runs/12812449148/job/35724121202
- `boost` is no longer needed