### PR TITLE
lints: add `#![forbid]` lints per crate

### DIFF
--- a/binaries/cuprated/src/main.rs
+++ b/binaries/cuprated/src/main.rs
@@ -1,5 +1,9 @@
 #![doc = include_str!("../README.md")]
 #![cfg_attr(docsrs, feature(doc_cfg))]
+#![forbid(
+    unsafe_code,
+    reason = "Crate-specific lints. There should be good reasoning when removing these."
+)]
 #![allow(
     unused_imports,
     unreachable_pub,

--- a/consensus/context/src/lib.rs
+++ b/consensus/context/src/lib.rs
@@ -4,6 +4,13 @@
 //! This is used during contextual validation, this does not have all the data for contextual validation
 //! (outputs) for that you will need a [`Database`].
 
+#![forbid(
+    clippy::should_panic_without_expect,
+    clippy::single_char_lifetime_names,
+    unsafe_code,
+    reason = "Crate-specific lints. There should be good reasoning when removing these."
+)]
+
 // Used in documentation references for [`BlockChainContextRequest`]
 // FIXME: should we pull in a dependency just to link docs?
 use monero_serai as _;

--- a/consensus/fast-sync/src/fast_sync.rs
+++ b/consensus/fast-sync/src/fast_sync.rs
@@ -41,13 +41,14 @@ fn max_height() -> u64 {
     (HASHES_OF_HASHES.len() * BATCH_SIZE) as u64
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
 pub struct ValidBlockId(BlockId);
 
 fn valid_block_ids(block_ids: &[BlockId]) -> Vec<ValidBlockId> {
     block_ids.iter().map(|b| ValidBlockId(*b)).collect()
 }
 
+#[derive(Debug)]
 #[expect(clippy::large_enum_variant)]
 pub enum FastSyncRequest {
     ValidateHashes {
@@ -110,6 +111,7 @@ impl From<tower::BoxError> for FastSyncError {
     }
 }
 
+#[derive(Debug)]
 pub struct FastSyncService<C> {
     context_svc: C,
 }

--- a/consensus/fast-sync/src/lib.rs
+++ b/consensus/fast-sync/src/lib.rs
@@ -1,3 +1,14 @@
+#![forbid(
+    clippy::missing_assert_message,
+    clippy::should_panic_without_expect,
+    clippy::single_char_lifetime_names,
+    unsafe_code,
+    unused_results,
+    missing_copy_implementations,
+    missing_debug_implementations,
+    reason = "Crate-specific lints. There should be good reasoning when removing these."
+)]
+
 // Used in `create.rs`
 use clap as _;
 use cuprate_blockchain as _;

--- a/consensus/rules/src/blocks.rs
+++ b/consensus/rules/src/blocks.rs
@@ -210,7 +210,7 @@ fn check_txs_unique(txs: &[[u8; 32]]) -> Result<(), BlockError> {
 
 /// This struct contains the data needed to verify a block, implementers MUST make sure
 /// the data in this struct is calculated correctly.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct ContextToVerifyBlock {
     /// ref: <https://monero-book.cuprate.org/consensus_rules/blocks/weights.html#median-weight-for-coinbase-checks>
     pub median_weight_for_block_reward: usize,

--- a/consensus/rules/src/lib.rs
+++ b/consensus/rules/src/lib.rs
@@ -1,3 +1,10 @@
+#![forbid(
+    unsafe_code,
+    missing_copy_implementations,
+    missing_debug_implementations,
+    reason = "Crate-specific lints. There should be good reasoning when removing these."
+)]
+
 cfg_if::cfg_if! {
     // Used in external `tests/`.
     if #[cfg(test)] {

--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -11,6 +11,12 @@
 //! with [`BlockchainResponse`].
 //!
 
+#![forbid(
+    unsafe_code,
+    missing_copy_implementations,
+    reason = "Crate-specific lints. There should be good reasoning when removing these."
+)]
+
 cfg_if::cfg_if! {
     // Used in external `tests/`.
     if #[cfg(test)] {

--- a/constants/src/lib.rs
+++ b/constants/src/lib.rs
@@ -1,5 +1,18 @@
 #![doc = include_str!("../README.md")]
-#![deny(missing_docs, reason = "all constants should document what they are")]
+#![forbid(
+    clippy::missing_assert_message,
+    clippy::missing_docs_in_private_items,
+    clippy::missing_errors_doc,
+    clippy::missing_panics_doc,
+    clippy::should_panic_without_expect,
+    clippy::single_char_lifetime_names,
+    missing_docs,
+    unsafe_code,
+    unused_results,
+    missing_copy_implementations,
+    missing_debug_implementations,
+    reason = "Crate-specific lints. There should be good reasoning when removing these."
+)]
 #![no_std] // This can be removed if we eventually need `std`.
 
 mod macros;

--- a/constants/src/macros.rs
+++ b/constants/src/macros.rs
@@ -1,3 +1,5 @@
+//! General macros.
+
 /// Output a string link to `monerod` source code.
 #[allow(
     clippy::allow_attributes,

--- a/cryptonight/src/lib.rs
+++ b/cryptonight/src/lib.rs
@@ -1,3 +1,14 @@
+#![forbid(
+    clippy::missing_errors_doc,
+    clippy::missing_panics_doc,
+    clippy::should_panic_without_expect,
+    clippy::single_char_lifetime_names,
+    unsafe_code,
+    missing_copy_implementations,
+    missing_debug_implementations,
+    reason = "Crate-specific lints. There should be good reasoning when removing these."
+)]
+
 mod blake256;
 mod cnaes;
 mod hash_v2;
@@ -18,6 +29,7 @@ pub struct DataCanNotBeHashed;
 
 /// Calculates the `CryptoNight` v1 hash of buf.
 ///
+/// # Errors
 /// This will return an error if buf is less than 43 bytes.
 pub fn cryptonight_hash_v1(buf: &[u8]) -> Result<[u8; 32], DataCanNotBeHashed> {
     if buf.len() < 43 {

--- a/helper/src/lib.rs
+++ b/helper/src/lib.rs
@@ -1,5 +1,10 @@
 #![doc = include_str!("../README.md")]
 #![cfg_attr(not(feature = "std"), no_std)]
+#![forbid(
+    clippy::should_panic_without_expect,
+    clippy::single_char_lifetime_names,
+    reason = "Crate-specific lints. There should be good reasoning when removing these."
+)]
 
 //---------------------------------------------------------------------------------------------------- Public API
 #[cfg(feature = "asynch")]

--- a/net/epee-encoding/src/lib.rs
+++ b/net/epee-encoding/src/lib.rs
@@ -59,6 +59,13 @@
 //!
 //! ```
 
+#![forbid(
+    clippy::missing_assert_message,
+    clippy::should_panic_without_expect,
+    unsafe_code,
+    reason = "Crate-specific lints. There should be good reasoning when removing these."
+)]
+
 #[cfg(test)]
 use hex as _;
 

--- a/net/fixed-bytes/src/lib.rs
+++ b/net/fixed-bytes/src/lib.rs
@@ -1,4 +1,14 @@
 #![doc = include_str!("../README.md")]
+#![forbid(
+    clippy::missing_assert_message,
+    clippy::missing_errors_doc,
+    clippy::missing_panics_doc,
+    clippy::should_panic_without_expect,
+    clippy::single_char_lifetime_names,
+    unsafe_code,
+    missing_debug_implementations,
+    reason = "Crate-specific lints. There should be good reasoning when removing these."
+)]
 
 use core::{
     fmt::{Debug, Formatter},

--- a/net/levin/src/lib.rs
+++ b/net/levin/src/lib.rs
@@ -27,7 +27,13 @@
 //! This project is licensed under the MIT License.
 
 // Coding conventions
-#![forbid(unsafe_code)]
+#![forbid(
+    clippy::missing_assert_message,
+    clippy::should_panic_without_expect,
+    unsafe_code,
+    unused_results,
+    reason = "Crate-specific lints. There should be good reasoning when removing these."
+)]
 #![deny(non_upper_case_globals)]
 #![deny(non_camel_case_types)]
 #![deny(unused_mut)]

--- a/net/wire/src/lib.rs
+++ b/net/wire/src/lib.rs
@@ -22,6 +22,14 @@
 //!
 //! This project is licensed under the MIT License.
 
+#![forbid(
+    clippy::missing_assert_message,
+    clippy::missing_panics_doc,
+    clippy::should_panic_without_expect,
+    unsafe_code,
+    reason = "Crate-specific lints. There should be good reasoning when removing these."
+)]
+
 pub mod network_address;
 pub mod p2p;
 

--- a/p2p/address-book/src/lib.rs
+++ b/p2p/address-book/src/lib.rs
@@ -10,6 +10,15 @@
 //! clear net peers getting linked to their dark counterparts
 //! and so peers will only get told about peers they can
 //! connect to.
+
+#![forbid(
+    clippy::missing_assert_message,
+    clippy::should_panic_without_expect,
+    missing_docs,
+    unsafe_code,
+    reason = "Crate-specific lints. There should be good reasoning when removing these."
+)]
+
 use std::{io::ErrorKind, path::PathBuf, time::Duration};
 
 use cuprate_p2p_core::{NetZoneAddress, NetworkZone};

--- a/p2p/async-buffer/src/lib.rs
+++ b/p2p/async-buffer/src/lib.rs
@@ -4,6 +4,15 @@
 //!
 //! Weight is used to bound the channel, on creation you specify a max weight and for each value you
 //! specify a weight.
+
+#![forbid(
+    clippy::missing_errors_doc,
+    clippy::should_panic_without_expect,
+    unsafe_code,
+    missing_copy_implementations,
+    reason = "Crate-specific lints. There should be good reasoning when removing these."
+)]
+
 use std::{
     cmp::min,
     future::Future,

--- a/p2p/bucket/src/lib.rs
+++ b/p2p/bucket/src/lib.rs
@@ -38,10 +38,22 @@
 //!
 //! ```
 
-use arrayvec::{ArrayVec, CapacityError};
-use rand::random;
+#![forbid(
+    clippy::missing_assert_message,
+    clippy::missing_docs_in_private_items,
+    clippy::missing_errors_doc,
+    clippy::should_panic_without_expect,
+    clippy::single_char_lifetime_names,
+    missing_docs,
+    unsafe_code,
+    missing_copy_implementations,
+    reason = "Crate-specific lints. There should be good reasoning when removing these."
+)]
 
 use std::{collections::BTreeMap, net::Ipv4Addr};
+
+use arrayvec::{ArrayVec, CapacityError};
+use rand::random;
 
 /// A discriminant that can be computed from the type.
 pub trait Bucketable: Sized + Eq + Clone {

--- a/p2p/dandelion-tower/src/lib.rs
+++ b/p2p/dandelion-tower/src/lib.rs
@@ -58,6 +58,17 @@
 //! When removing data, for example because of a new block, you can remove from both pools provided it doesn't leak
 //! any data about stem transactions. You will probably want to set up a task that monitors the tx pool for stuck transactions,
 //! transactions that slipped in just as one was removed etc, this crate does not handle that.
+
+#![forbid(
+    clippy::missing_assert_message,
+    clippy::missing_errors_doc,
+    clippy::should_panic_without_expect,
+    clippy::single_char_lifetime_names,
+    unsafe_code,
+    missing_copy_implementations,
+    reason = "Crate-specific lints. There should be good reasoning when removing these."
+)]
+
 mod config;
 #[cfg(feature = "txpool")]
 pub mod pool;

--- a/p2p/p2p-core/src/lib.rs
+++ b/p2p/p2p-core/src/lib.rs
@@ -57,6 +57,14 @@
 //! # });
 //! ```
 
+#![forbid(
+    clippy::missing_assert_message,
+    clippy::should_panic_without_expect,
+    clippy::single_char_lifetime_names,
+    unsafe_code,
+    reason = "Crate-specific lints. There should be good reasoning when removing these."
+)]
+
 cfg_if::cfg_if! {
     // Used in `tests/`
     if #[cfg(test)] {

--- a/p2p/p2p/src/lib.rs
+++ b/p2p/p2p/src/lib.rs
@@ -2,6 +2,16 @@
 //!
 //! This crate contains a [`NetworkInterface`] which allows interacting with the Monero P2P network on
 //! a certain [`NetworkZone`]
+
+#![forbid(
+    clippy::missing_assert_message,
+    clippy::missing_errors_doc,
+    clippy::should_panic_without_expect,
+    clippy::single_char_lifetime_names,
+    unsafe_code,
+    reason = "Crate-specific lints. There should be good reasoning when removing these."
+)]
+
 use std::sync::Arc;
 
 use futures::FutureExt;

--- a/pruning/src/lib.rs
+++ b/pruning/src/lib.rs
@@ -18,6 +18,16 @@
 //! ```
 //!
 
+#![forbid(
+    clippy::missing_assert_message,
+    clippy::should_panic_without_expect,
+    clippy::single_char_lifetime_names,
+    unsafe_code,
+    unused_results,
+    missing_debug_implementations,
+    reason = "Crate-specific lints. There should be good reasoning when removing these."
+)]
+
 use std::cmp::Ordering;
 
 use cuprate_constants::block::MAX_BLOCK_HEIGHT_USIZE;

--- a/rpc/interface/src/lib.rs
+++ b/rpc/interface/src/lib.rs
@@ -1,5 +1,19 @@
 #![doc = include_str!("../README.md")]
 #![cfg_attr(docsrs, feature(doc_cfg))]
+#![forbid(
+    clippy::missing_assert_message,
+    clippy::missing_docs_in_private_items,
+    clippy::missing_errors_doc,
+    clippy::missing_panics_doc,
+    clippy::should_panic_without_expect,
+    clippy::single_char_lifetime_names,
+    missing_docs,
+    unsafe_code,
+    unused_results,
+    missing_copy_implementations,
+    missing_debug_implementations,
+    reason = "Crate-specific lints. There should be good reasoning when removing these."
+)]
 
 mod route;
 mod router_builder;

--- a/rpc/interface/src/router_builder.rs
+++ b/rpc/interface/src/router_builder.rs
@@ -69,7 +69,7 @@ macro_rules! generate_router_builder {
         ///     .all()
         ///     .build();
         /// ```
-        #[derive(Clone)]
+        #[derive(Debug, Clone)]
         pub struct RouterBuilder<H: RpcHandler> {
             router: Router<H>,
         }

--- a/rpc/interface/src/rpc_handler_dummy.rs
+++ b/rpc/interface/src/rpc_handler_dummy.rs
@@ -28,7 +28,7 @@ use crate::rpc_handler::RpcHandler;
 ///
 /// This is mostly used for testing purposes and can
 /// be disabled by disable the `dummy` feature flag.
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct RpcHandlerDummy {
     /// Should this RPC server be [restricted](RpcHandler::restricted)?

--- a/rpc/json-rpc/src/lib.rs
+++ b/rpc/json-rpc/src/lib.rs
@@ -1,4 +1,16 @@
 #![doc = include_str!("../README.md")]
+#![forbid(
+    clippy::missing_assert_message,
+    clippy::missing_docs_in_private_items,
+    clippy::missing_errors_doc,
+    clippy::missing_panics_doc,
+    clippy::should_panic_without_expect,
+    missing_docs,
+    unsafe_code,
+    missing_copy_implementations,
+    missing_debug_implementations,
+    reason = "Crate-specific lints. There should be good reasoning when removing these."
+)]
 
 pub mod error;
 

--- a/rpc/types/src/lib.rs
+++ b/rpc/types/src/lib.rs
@@ -4,6 +4,17 @@
     clippy::allow_attributes,
     reason = "macros (internal + serde) make this lint hard to satisfy"
 )]
+#![forbid(
+    clippy::missing_assert_message,
+    clippy::missing_errors_doc,
+    clippy::missing_panics_doc,
+    clippy::should_panic_without_expect,
+    clippy::single_char_lifetime_names,
+    unsafe_code,
+    unused_results,
+    missing_debug_implementations,
+    reason = "Crate-specific lints. There should be good reasoning when removing these."
+)]
 
 mod constants;
 #[cfg(any(feature = "serde", feature = "epee"))]

--- a/storage/blockchain/src/lib.rs
+++ b/storage/blockchain/src/lib.rs
@@ -3,6 +3,13 @@
     // See `cuprate-database` for reasoning.
     clippy::significant_drop_tightening
 )]
+#![forbid(
+    clippy::should_panic_without_expect,
+    missing_docs,
+    missing_copy_implementations,
+    missing_debug_implementations,
+    reason = "Crate-specific lints. There should be good reasoning when removing these."
+)]
 
 // Only allow building 64-bit targets.
 //

--- a/storage/database/src/lib.rs
+++ b/storage/database/src/lib.rs
@@ -14,6 +14,16 @@
     // the database transaction + tables.
     clippy::significant_drop_tightening
 )]
+#![forbid(
+    clippy::missing_assert_message,
+    clippy::missing_docs_in_private_items,
+    clippy::missing_errors_doc,
+    clippy::missing_panics_doc,
+    clippy::should_panic_without_expect,
+    missing_docs,
+    missing_copy_implementations,
+    reason = "Crate-specific lints. There should be good reasoning when removing these."
+)]
 // Allow some lints in tests.
 #![cfg_attr(
     test,

--- a/storage/service/src/lib.rs
+++ b/storage/service/src/lib.rs
@@ -1,4 +1,14 @@
 #![doc = include_str!("../README.md")]
+#![forbid(
+    clippy::missing_assert_message,
+    clippy::missing_errors_doc,
+    clippy::should_panic_without_expect,
+    clippy::single_char_lifetime_names,
+    missing_docs,
+    unsafe_code,
+    missing_copy_implementations,
+    reason = "Crate-specific lints. There should be good reasoning when removing these."
+)]
 
 mod reader_threads;
 mod service;

--- a/storage/txpool/src/lib.rs
+++ b/storage/txpool/src/lib.rs
@@ -3,6 +3,13 @@
     // See `cuprate-database` for reasoning.
     clippy::significant_drop_tightening
 )]
+#![forbid(
+    clippy::missing_assert_message,
+    clippy::should_panic_without_expect,
+    clippy::single_char_lifetime_names,
+    unsafe_code,
+    reason = "Crate-specific lints. There should be good reasoning when removing these."
+)]
 
 // Used in docs: <https://github.com/Cuprate/cuprate/pull/170#discussion_r1823644357>.
 use tower as _;

--- a/types/src/json/output.rs
+++ b/types/src/json/output.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 use crate::hex::HexBytes;
 
 /// JSON representation of an output.
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Output {
     pub amount: u64,
@@ -18,7 +18,7 @@ pub struct Output {
 }
 
 /// [`Output::target`].
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(untagged))]
 pub enum Target {
@@ -35,7 +35,7 @@ impl Default for Target {
 }
 
 /// [`Target::TaggedKey::tagged_key`].
-#[derive(Clone, Default, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Copy, Clone, Default, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct TaggedKey {
     pub key: HexBytes<32>,

--- a/types/src/json/tx.rs
+++ b/types/src/json/tx.rs
@@ -343,7 +343,7 @@ pub struct Clsag {
 }
 
 /// [`RctSignatures::NonCoinbase::ecdhInfo`].
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(untagged))]
 #[expect(variant_size_differences)]

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -3,6 +3,19 @@
 #![cfg_attr(any(feature = "proptest"), allow(non_local_definitions))]
 // Allow some lints when running in debug mode.
 #![cfg_attr(debug_assertions, allow(clippy::todo, clippy::multiple_crate_versions))]
+#![forbid(
+    clippy::missing_assert_message,
+    clippy::missing_docs_in_private_items,
+    clippy::missing_errors_doc,
+    clippy::missing_panics_doc,
+    clippy::should_panic_without_expect,
+    clippy::single_char_lifetime_names,
+    unsafe_code,
+    unused_results,
+    missing_copy_implementations,
+    missing_debug_implementations,
+    reason = "Crate-specific lints. There should be good reasoning when removing these."
+)]
 
 //---------------------------------------------------------------------------------------------------- Public API
 // Import private modules, export public types.

--- a/types/src/types.rs
+++ b/types/src/types.rs
@@ -197,7 +197,7 @@ pub struct MinerData {
 /// A transaction in the txpool.
 ///
 /// Used in [`MinerData::tx_backlog`].
-#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct MinerDataTxBacklogEntry {
     pub id: [u8; 32],
     pub weight: u64,
@@ -243,7 +243,7 @@ pub struct ChainInfo {
 }
 
 /// Used in RPC's `add_aux_pow`.
-#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct AuxPow {
     pub id: [u8; 32],
     pub hash: [u8; 32],

--- a/zmq/types/src/json_message_types.rs
+++ b/zmq/types/src/json_message_types.rs
@@ -39,7 +39,7 @@ pub struct TxPoolAdd {
 /// ZMQ `json-minimal-txpool_add` subscriber messages contain an array of
 /// `TxPoolAddMin` JSON objects. See `TxPoolAdd` for information on which
 /// transactions are published to subscribers.
-#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[derive(Copy, Debug, Default, Clone, Serialize, Deserialize)]
 pub struct TxPoolAddMin {
     /// transaction ID
     pub id: HexBytes<32>,
@@ -128,7 +128,7 @@ pub struct ToKey {
 }
 
 /// Holds the block height of the coinbase transaction.
-#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[derive(Copy, Debug, Default, Clone, Serialize, Deserialize)]
 pub struct MinerInput {
     /// namespace layer around the block height
     pub r#gen: Gen,
@@ -136,7 +136,7 @@ pub struct MinerInput {
 
 /// Additional namespace layer around the block height in `ChainMain`; gen is
 /// another name for a coinbase transaction
-#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[derive(Copy, Debug, Default, Clone, Serialize, Deserialize)]
 pub struct Gen {
     /// block height when the coinbase transaction was created
     pub height: u64,
@@ -266,7 +266,7 @@ pub struct MinerTx {
 }
 
 /// Holds a transaction entry in the `MinerData` `tx_backlog` field.
-#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[derive(Copy, Debug, Default, Clone, Serialize, Deserialize)]
 pub struct TxBacklog {
     /// transaction ID
     pub id: HexBytes<32>,

--- a/zmq/types/src/lib.rs
+++ b/zmq/types/src/lib.rs
@@ -1,1 +1,14 @@
+#![forbid(
+    clippy::missing_assert_message,
+    clippy::missing_errors_doc,
+    clippy::missing_panics_doc,
+    clippy::should_panic_without_expect,
+    clippy::single_char_lifetime_names,
+    unsafe_code,
+    unused_results,
+    missing_copy_implementations,
+    missing_debug_implementations,
+    reason = "Crate-specific lints. There should be good reasoning when removing these."
+)]
+
 pub mod json_message_types;


### PR DESCRIPTION
### What
Adds more specific `#![forbid]` lints for all crates when applicable. 

### Why
Allows us to uphold certain static invariants within crates, the most useful one being `unsafe_code`.
