### PR TITLE
database: `SyncMode` changes

### DIFF
--- a/binaries/cuprated/Cuprated.toml
+++ b/binaries/cuprated/Cuprated.toml
@@ -54,11 +54,11 @@ check_client_pool_interval = { secs = 30, nanos = 0 }
 ## Txpool storage config.
 [storage.txpool]
 ## The database sync mode for the txpool.
-sync_mode = "Async"
+sync_mode = "Fast"
 ## The maximum size of all the txs in the pool (bytes).
 max_txpool_byte_size = 100_000_000
 
 ## Blockchain storage config.
 [storage.blockchain]
 ## The database sync mode for the blockchain.
-sync_mode = "Async"
+sync_mode = "Fast"

--- a/binaries/cuprated/src/config/storage.rs
+++ b/binaries/cuprated/src/config/storage.rs
@@ -29,21 +29,11 @@ impl Default for StorageConfig {
 }
 
 /// The blockchain config.
-#[derive(Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Default, Debug, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields, default)]
 pub struct BlockchainConfig {
     #[serde(flatten)]
     pub shared: SharedStorageConfig,
-}
-
-impl Default for BlockchainConfig {
-    fn default() -> Self {
-        Self {
-            shared: SharedStorageConfig {
-                sync_mode: SyncMode::Async,
-            },
-        }
-    }
 }
 
 /// The tx-pool config.
@@ -60,9 +50,7 @@ pub struct TxpoolConfig {
 impl Default for TxpoolConfig {
     fn default() -> Self {
         Self {
-            shared: SharedStorageConfig {
-                sync_mode: SyncMode::Async,
-            },
+            shared: SharedStorageConfig::default(),
             max_txpool_byte_size: 100_000_000,
         }
     }

--- a/storage/database/src/backend/heed/env.rs
+++ b/storage/database/src/backend/heed/env.rs
@@ -122,10 +122,10 @@ impl Env for ConcreteEnv {
         // <https://github.com/monero-project/monero/blob/059028a30a8ae9752338a7897329fe8012a310d5/src/blockchain_db/lmdb/db_lmdb.cpp#L1324>
         let flags = match config.sync_mode {
             SyncMode::Safe => EnvFlags::empty(),
-            SyncMode::Async => EnvFlags::MAP_ASYNC,
-            SyncMode::Fast => EnvFlags::NO_SYNC | EnvFlags::WRITE_MAP | EnvFlags::MAP_ASYNC,
-            // SOMEDAY: dynamic syncs are not implemented.
-            SyncMode::FastThenSafe | SyncMode::Threshold(_) => unimplemented!(),
+            // TODO: impl `FastThenSafe`
+            SyncMode::FastThenSafe | SyncMode::Fast => {
+                EnvFlags::NO_SYNC | EnvFlags::WRITE_MAP | EnvFlags::MAP_ASYNC
+            }
         };
 
         // SAFETY: the flags we're setting are 'unsafe'

--- a/storage/database/src/backend/redb/env.rs
+++ b/storage/database/src/backend/redb/env.rs
@@ -52,15 +52,9 @@ impl Env for ConcreteEnv {
     fn open(config: Config) -> Result<Self, InitError> {
         // SOMEDAY: dynamic syncs are not implemented.
         let durability = match config.sync_mode {
-            // FIXME: There's also `redb::Durability::Paranoid`:
-            // <https://docs.rs/redb/1.5.0/redb/enum.Durability.html#variant.Paranoid>
-            // should we use that instead of Immediate?
             SyncMode::Safe => redb::Durability::Immediate,
-            // FIXME: `Fast` maps to `Eventual` instead of `None` because of:
-            // <https://github.com/Cuprate/cuprate/issues/149>
-            SyncMode::Async | SyncMode::Fast => redb::Durability::Eventual,
-            // SOMEDAY: dynamic syncs are not implemented.
-            SyncMode::FastThenSafe | SyncMode::Threshold(_) => unimplemented!(),
+            // TODO: impl `FastThenSafe`
+            SyncMode::FastThenSafe | SyncMode::Fast => redb::Durability::Eventual,
         };
 
         let env_builder = redb::Builder::new();


### PR DESCRIPTION
### What
- Removes `SyncMode::{Async, Threshold}`
- Sets `SyncMode::default()` to `SyncMode::Fast`
- Sets `SyncMode::FastThenSafe` to behave the same as `SyncMode::Fast` (for now, will be implemented in another PR)

### Why
Reasoning is in this meeting: https://github.com/monero-project/meta/issues/1144.