### PR TITLE
clippy: add `doc-valid-idents`

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,2 +1,9 @@
 # <https://rust-lang.github.io/rust-clippy/master/index.html#upper_case_acronyms>
 upper-case-acronyms-aggressive = true
+
+# <https://rust-lang.github.io/rust-clippy/master/index.html#doc_markdown>
+doc-valid-idents = [
+    "RandomX",
+    # This adds the rest of the default exceptions.
+    ".."
+]

--- a/consensus/context/src/lib.rs
+++ b/consensus/context/src/lib.rs
@@ -192,7 +192,7 @@ pub struct NewBlockData {
 /// A request to the blockchain context cache.
 #[derive(Debug, Clone)]
 pub enum BlockChainContextRequest {
-    /// Gets all the current  `RandomX` VMs.
+    /// Gets all the current RandomX VMs.
     CurrentRxVms,
 
     /// Get the next difficulties for these blocks.
@@ -294,7 +294,7 @@ pub enum BlockChainContextRequest {
     /// This variant is private and is not callable from outside this crate, the block verifier service will
     /// handle getting the randomX VM of an alt chain.
     AltChainRxVM {
-        /// The height the `RandomX` VM is needed for.
+        /// The height the RandomX VM is needed for.
         height: usize,
         /// The chain to look in for the seed.
         chain: Chain,
@@ -329,7 +329,7 @@ pub enum BlockChainContextResponse {
 
     /// Response to [`BlockChainContextRequest::CurrentRxVms`]
     ///
-    /// A map of seed height to `RandomX` VMs.
+    /// A map of seed height to RandomX VMs.
     RxVms(HashMap<usize, Arc<RandomXVm>>),
 
     /// A list of difficulties.

--- a/consensus/context/src/rx_vms.rs
+++ b/consensus/context/src/rx_vms.rs
@@ -1,6 +1,6 @@
-//! `RandomX` VM Cache
+//! RandomX VM Cache
 //!
-//! This module keeps track of the `RandomX` VM to calculate the next blocks proof-of-work, if the block needs a randomX VM and potentially
+//! This module keeps track of the RandomX VM to calculate the next blocks proof-of-work, if the block needs a randomX VM and potentially
 //! more VMs around this height.
 //!
 use std::{
@@ -34,11 +34,11 @@ pub const RX_SEEDS_CACHED: usize = 2;
 /// A multithreaded randomX VM.
 #[derive(Debug)]
 pub struct RandomXVm {
-    /// These `RandomX` VMs all share the same cache.
+    /// These RandomX VMs all share the same cache.
     vms: ThreadLocal<VmInner>,
-    /// The `RandomX` cache.
+    /// The RandomX cache.
     cache: RandomXCache,
-    /// The flags used to start the `RandomX` VMs.
+    /// The flags used to start the RandomX VMs.
     flags: RandomXFlag,
 }
 
@@ -161,7 +161,7 @@ impl RandomXVmCache {
         Ok(alt_vm)
     }
 
-    /// Get the main-chain `RandomX` VMs.
+    /// Get the main-chain RandomX VMs.
     pub async fn get_vms(&mut self) -> HashMap<usize, Arc<RandomXVm>> {
         match self.seeds.len().checked_sub(self.vms.len()) {
             // No difference in the amount of seeds to VMs.
@@ -213,7 +213,7 @@ impl RandomXVmCache {
         self.vms.clone()
     }
 
-    /// Removes all the `RandomX` VMs above the `new_height`.
+    /// Removes all the RandomX VMs above the `new_height`.
     pub fn pop_blocks_main_chain(&mut self, new_height: usize) {
         self.seeds.retain(|(height, _)| *height < new_height);
         self.vms.retain(|height, _| *height < new_height);

--- a/consensus/rules/src/blocks.rs
+++ b/consensus/rules/src/blocks.rs
@@ -44,19 +44,19 @@ pub enum BlockError {
     MinerTxError(#[from] MinerTxError),
 }
 
-/// A trait to represent the `RandomX` VM.
+/// A trait to represent the RandomX VM.
 pub trait RandomX {
     type Error;
 
     fn calculate_hash(&self, buf: &[u8]) -> Result<[u8; 32], Self::Error>;
 }
 
-/// Returns if this height is a `RandomX` seed height.
+/// Returns if this height is a RandomX seed height.
 pub const fn is_randomx_seed_height(height: usize) -> bool {
     height % RX_SEEDHASH_EPOCH_BLOCKS == 0
 }
 
-/// Returns the `RandomX` seed height for this block.
+/// Returns the RandomX seed height for this block.
 ///
 /// ref: <https://monero-book.cuprate.org/consensus_rules/blocks.html#randomx-seed>
 pub const fn randomx_seed_height(height: usize) -> usize {

--- a/consensus/src/block.rs
+++ b/consensus/src/block.rs
@@ -154,7 +154,7 @@ impl PreparedBlock {
     ///
     /// # Panics
     /// This function will panic if `randomx_vm` is
-    /// [`None`] even though `RandomX` is needed.
+    /// [`None`] even though RandomX is needed.
     fn new_prepped<R: RandomX>(
         block: PreparedBlockExPow,
         randomx_vm: Option<&R>,


### PR DESCRIPTION
### What
Adds exceptions to `doc-valid-idents` for clippy.

See `Configuration` in https://rust-lang.github.io/rust-clippy/master/index.html#doc_markdown.

### Why
To fix false positives like `RandomX`.