### PR TITLE
readme: `Documentation` -> `Books` & `Crates`

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Monero network.
 
 <!-- TODO: add some details about what Cuprate is and is not, goals, status -->
 
-## Documentation
+## Books
 
 _Cuprate is currently a work-in-progress; documentation will be changing/unfinished._
 
@@ -49,7 +49,10 @@ Cuprate maintains various documentation books:
 | [Monero's protocol book](https://monero-book.cuprate.org)       | Documents the Monero protocol                              |
 | [Cuprate's user book](https://user.cuprate.org)                 | Practical user-guide for using `cuprated`                  |
 
-For crate (library) documentation, see: https://doc.cuprate.org. This site holds documentation for Cuprate's crates and all dependencies. All Cuprate crates start with `cuprate_`, for example: [`cuprate_database`](https://doc.cuprate.org/cuprate_database).
+## Crates
+For a detailed list of all crates, see: <https://architecture.cuprate.org/appendix/crates.html>.
+
+For crate (library) documentation, see: <https://doc.cuprate.org>. This site holds documentation for Cuprate's crates and all dependencies. All Cuprate crates start with `cuprate_`, for example: [`cuprate_database`](https://doc.cuprate.org/cuprate_database).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ _(work-in-progress)_
 ## Contents
 
 - [About](#about)
-- [Documentation](#documentation)
+- [Books](#books)
+- [Crates](#crates)
 - [Contributing](#contributing)
 - [Security](#security)
 - [License](#license)


### PR DESCRIPTION
### What
Splits `Documentation` into a `Books` and `Crates` section (links to [`crates.md`](https://architecture.cuprate.org/appendix/crates.html)) in the readme.