### PR TITLE
cuprated: update killswitch timestamp

### DIFF
--- a/binaries/cuprated/src/killswitch.rs
+++ b/binaries/cuprated/src/killswitch.rs
@@ -32,8 +32,8 @@ const _: () = {
 
 /// The killswitch activates if the current timestamp is ahead of this timestamp.
 ///
-/// Wed Apr  9 12:00:00 AM UTC 2025
-pub const KILLSWITCH_ACTIVATION_TIMESTAMP: u64 = 1744156800;
+/// Wed Apr 16 12:00:00 AM UTC 2025
+pub const KILLSWITCH_ACTIVATION_TIMESTAMP: u64 = 1744761600;
 
 /// Check if the system clock is past a certain timestamp,
 /// if so, exit the entire program.
@@ -44,8 +44,8 @@ fn killswitch() {
     /// sanity checking the system's clock to make
     /// sure it is not overly behind.
     ///
-    /// Tue Mar 11 08:21:40 PM UTC 2025
-    const SYSTEM_CLOCK_SANITY_TIMESTAMP: u64 = 1741724500;
+    /// Tue Mar 11 08:33:20 PM UTC 2025
+    const SYSTEM_CLOCK_SANITY_TIMESTAMP: u64 = 1741725200;
 
     let current_ts = current_unix_timestamp();
 

--- a/binaries/cuprated/src/killswitch.rs
+++ b/binaries/cuprated/src/killswitch.rs
@@ -44,8 +44,8 @@ fn killswitch() {
     /// sanity checking the system's clock to make
     /// sure it is not overly behind.
     ///
-    /// Wed Mar  5 12:03:20 AM UTC 2025
-    const SYSTEM_CLOCK_SANITY_TIMESTAMP: u64 = 1741133000;
+    /// Mon Mar 10 08:25:34 PM UTC 2025
+    const SYSTEM_CLOCK_SANITY_TIMESTAMP: u64 = 1741638334;
 
     let current_ts = current_unix_timestamp();
 

--- a/binaries/cuprated/src/killswitch.rs
+++ b/binaries/cuprated/src/killswitch.rs
@@ -32,8 +32,8 @@ const _: () = {
 
 /// The killswitch activates if the current timestamp is ahead of this timestamp.
 ///
-/// Fri Apr 11 12:00:00 AM UTC 2025
-pub const KILLSWITCH_ACTIVATION_TIMESTAMP: u64 = 1744329600;
+/// Wed Apr  9 12:00:00 AM UTC 2025
+pub const KILLSWITCH_ACTIVATION_TIMESTAMP: u64 = 1744156800;
 
 /// Check if the system clock is past a certain timestamp,
 /// if so, exit the entire program.
@@ -44,8 +44,8 @@ fn killswitch() {
     /// sanity checking the system's clock to make
     /// sure it is not overly behind.
     ///
-    /// Mon Mar 10 08:25:34 PM UTC 2025
-    const SYSTEM_CLOCK_SANITY_TIMESTAMP: u64 = 1741638334;
+    /// Tue Mar 11 08:21:40 PM UTC 2025
+    const SYSTEM_CLOCK_SANITY_TIMESTAMP: u64 = 1741724500;
 
     let current_ts = current_unix_timestamp();
 

--- a/binaries/cuprated/src/killswitch.rs
+++ b/binaries/cuprated/src/killswitch.rs
@@ -16,19 +16,24 @@ use std::{process::exit, time::Duration};
 
 use cuprate_helper::time::current_unix_timestamp;
 
-/// Assert that this is not a v1 release and an alpha release.
+/// Assert that this is an alpha release.
 const _: () = {
     const_format::assertcp_ne!(
         crate::constants::MAJOR_VERSION,
         "1",
         "`cuprated` major version is 1, killswitch module should be deleted."
     );
+    const_format::assertcp_ne!(
+        crate::constants::MINOR_VERSION,
+        "1",
+        "`cuprated` minor version is 1, killswitch module should be deleted."
+    );
 };
 
 /// The killswitch activates if the current timestamp is ahead of this timestamp.
 ///
-/// Sat Mar 01 2025 05:00:00 GMT+0000
-pub const KILLSWITCH_ACTIVATION_TIMESTAMP: u64 = 1740805200;
+/// Fri Apr 11 12:00:00 AM UTC 2025
+pub const KILLSWITCH_ACTIVATION_TIMESTAMP: u64 = 1744329600;
 
 /// Check if the system clock is past a certain timestamp,
 /// if so, exit the entire program.
@@ -39,8 +44,8 @@ fn killswitch() {
     /// sanity checking the system's clock to make
     /// sure it is not overly behind.
     ///
-    /// Fri Jan 17 2025 14:19:10 GMT+0000
-    const SYSTEM_CLOCK_SANITY_TIMESTAMP: u64 = 1737123550;
+    /// Wed Mar  5 12:03:20 AM UTC 2025
+    const SYSTEM_CLOCK_SANITY_TIMESTAMP: u64 = 1741133000;
 
     let current_ts = current_unix_timestamp();
 


### PR DESCRIPTION
### What
Updates the `cuprated` killswitch timestamp using the following values from #374.

| `cuprated` version | Release codename | Release date | Killswitch date | Killswitch timestamp |
|--------------------|------------------|--------------|-----------------|----------------------|
| 0.0.1              | Molybdenite      | 2025-03-12   | 2025-04-16      | 1744761600

4 weeks from `2025-03-12` is `2025-04-09` + the 1 week grace period = `2025-04-16`.