### PR TITLE
ci: remove dependency installs, set OS versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,7 @@ jobs:
       uses: ./.github/actions/monerod-download
 
     - name: Install dependencies (Windows)
-      if: matrix.os == 'windows-2019'
+      if: matrix.os == 'windows-2022'
       uses: lukka/get-cmake@v3.31.6
 
     - name: Documentation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,14 @@ jobs:
     - name: Download monerod
       uses: ./.github/actions/monerod-download
 
+    - name: Install dependencies (Windows)
+      if: matrix.os == 'windows-latest'
+      uses: msys2/setup-msys2@v2
+      with:
+        path-type: inherit
+        update: true
+        install: mingw-w64-x86_64-toolchain msys2-runtime-devel git mingw-w64-x86_64-cmake mingw-w64-x86_64-ninja
+
     - name: Documentation
       run: cargo doc --workspace --all-features --no-deps
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,18 +85,6 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, macos-latest, ubuntu-latest]
-        include:
-          - os: windows-latest
-            shell: msys2 {0}
-            # GNU Windows is used as we need
-            # `unistd.h` and more in `cryptonight/`.
-            rust: stable-x86_64-pc-windows-gnu
-          - os: macos-latest
-            shell: bash
-            rust: stable
-          - os: ubuntu-latest
-            shell: bash
-            rust: stable
 
     defaults:
       run:
@@ -122,38 +110,6 @@ jobs:
 
     - name: Download monerod
       uses: ./.github/actions/monerod-download
-
-    # Packages other than `Boost` used by `Monero` are listed here.
-    # https://github.com/monero-project/monero/blob/c444a7e002036e834bfb4c68f04a121ce1af5825/.github/workflows/build.yml#L71
-
-    - name: Install dependencies (Linux)
-      if: matrix.os == 'ubuntu-latest'
-      run: sudo apt install -y libboost-dev
-
-    - name: Install dependencies (macOS)
-      if: matrix.os == 'macos-latest'
-      run: HOMEBREW_NO_AUTO_UPDATE=1 brew install boost
-
-    - name: Install dependencies (Windows)
-      if: matrix.os == 'windows-latest'
-      uses: msys2/setup-msys2@v2
-      with:
-        path-type: inherit
-        update: true
-        install: mingw-w64-x86_64-toolchain mingw-w64-x86_64-boost msys2-runtime-devel git mingw-w64-x86_64-cmake mingw-w64-x86_64-ninja
-
-    # HACK: 2024-05-14
-    # GCC 14+ fails to build `lmdb-master-sys` with no clear error message:
-    # <https://github.com/Cuprate/cuprate/pull/127>
-    #
-    # - MSYS2 repos carry older versions of packages
-    # - pacman lets us manually downgrade from package files
-    # - Note that `gcc` requires `gcc-libs`
-    - name: Downgrade to GCC 13.2 (Windows)
-      if: matrix.os == 'windows-latest'
-      run: |
-        wget https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-gcc-13.2.0-6-any.pkg.tar.zst https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-gcc-libs-13.2.0-6-any.pkg.tar.zst
-        pacman -U --noconfirm mingw-w64-x86_64-gcc-13.2.0-6-any.pkg.tar.zst mingw-w64-x86_64-gcc-libs-13.2.0-6-any.pkg.tar.zst
 
     - name: Documentation
       run: cargo doc --workspace --all-features --no-deps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,10 +86,6 @@ jobs:
       matrix:
         os: [windows-latest, macos-latest, ubuntu-latest]
 
-    defaults:
-      run:
-        shell: ${{ matrix.shell }}
-
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -99,7 +95,7 @@ jobs:
     - name: Install Rust
       uses: dtolnay/rust-toolchain@master
       with:
-        toolchain: ${{ matrix.rust }}
+        toolchain: stable
         components: clippy
 
     - name: Cache
@@ -123,11 +119,10 @@ jobs:
         cargo test --all-features --workspace
         cargo test --package cuprate-blockchain --no-default-features --features redb
 
+    - name: Build
+      run: cargo build --all-features --all-targets --workspace
+
     - name: Hack Check
       run: |
         cargo install cargo-hack --locked
         cargo hack --workspace check --feature-powerset --no-dev-deps
-
-    # TODO: upload binaries with `actions/upload-artifact@v3`
-    - name: Build
-      run: cargo build --all-features --all-targets --workspace

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [windows-latest, macos-latest, ubuntu-latest]
+        os: [windows-2019, macos-latest, ubuntu-latest]
 
     steps:
     - name: Checkout
@@ -108,12 +108,8 @@ jobs:
       uses: ./.github/actions/monerod-download
 
     - name: Install dependencies (Windows)
-      if: matrix.os == 'windows-latest'
-      uses: msys2/setup-msys2@v2
-      with:
-        path-type: inherit
-        update: true
-        install: mingw-w64-x86_64-toolchain msys2-runtime-devel git mingw-w64-x86_64-cmake mingw-w64-x86_64-ninja
+      if: matrix.os == 'windows-2019'
+      uses: lukka/get-cmake@v3.31.6
 
     - name: Documentation
       run: cargo doc --workspace --all-features --no-deps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
         os: [
             windows-2022, # EOL = 2026-10-13 | <https://endoflife.date/windows-server>
             macos-15,     # EOL = 2027-09-16 | <https://endoflife.date/macos>
-            ubuntu-24.04  # EOL = 2029-04-25 | <https://endoflife.date/ubuntu>
+            ubuntu-22.04  # EOL = 2027-04-01 | <https://endoflife.date/ubuntu>
         ]
 
     steps:
@@ -113,7 +113,7 @@ jobs:
 
     - name: Install dependencies (Windows)
       if: matrix.os == 'windows-2022'
-      uses: lukka/get-cmake@v3.31.6
+      uses: lukka/get-cmake@v3.31.6 # Needed for `randomx-rs`
 
     - name: Documentation
       run: cargo doc --workspace --all-features --no-deps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,11 @@ jobs:
 
     strategy:
       matrix:
-        os: [windows-2019, macos-latest, ubuntu-latest]
+        os: [
+            windows-2022, # EOL = 2026-10-13 | <https://endoflife.date/windows-server>
+            macos-15,     # EOL = 2027-09-16 | <https://endoflife.date/macos>
+            ubuntu-24.04  # EOL = 2029-04-25 | <https://endoflife.date/ubuntu>
+        ]
 
     steps:
     - name: Checkout

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2495,8 +2495,8 @@ dependencies = [
 
 [[package]]
 name = "randomx-rs"
-version = "1.3.0"
-source = "git+https://github.com/Cuprate/randomx-rs.git?rev=0028464#002846452ed79b0b9568235a1a4100dcf2a5f9ba"
+version = "1.3.2"
+source = "git+https://github.com/Cuprate/randomx-rs.git?rev=e09955c#e09955cde78482203f125fbe6bcb81098048df98"
 dependencies = [
  "bitflags 1.3.2",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,7 +124,7 @@ indexmap              = { version = "2", default-features = false }
 monero-serai          = { git = "https://github.com/Cuprate/serai.git", rev = "e6fdef6", default-features = false }
 paste                 = { version = "1", default-features = false }
 pin-project           = { version = "1", default-features = false }
-randomx-rs            = { git = "https://github.com/Cuprate/randomx-rs.git", rev = "0028464", default-features = false }
+randomx-rs            = { git = "https://github.com/Cuprate/randomx-rs.git", rev = "e09955c", default-features = false }
 rand                  = { version = "0.8", default-features = false }
 rand_distr            = { version = "0.4", default-features = false }
 rayon                 = { version = "1", default-features = false }


### PR DESCRIPTION
### What
Certain dependency installs can be removed thanks to https://github.com/Cuprate/cuprate/pull/271.

This also pins OSs to specific versions.