### PR TITLE
`cuprated`: add startup delay if config is missing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1094,6 +1094,7 @@ dependencies = [
  "hex-literal",
  "indexmap",
  "monero-serai",
+ "nu-ansi-term",
  "paste",
  "pin-project",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,6 +122,7 @@ hex                   = { version = "0.4", default-features = false }
 hex-literal           = { version = "0.4", default-features = false }
 indexmap              = { version = "2", default-features = false }
 monero-serai          = { git = "https://github.com/Cuprate/serai.git", rev = "e6fdef6", default-features = false }
+nu-ansi-term          = { version = "0.46", default-features = false }
 paste                 = { version = "1", default-features = false }
 pin-project           = { version = "1", default-features = false }
 randomx-rs            = { git = "https://github.com/Cuprate/randomx-rs.git", rev = "e09955c", default-features = false }

--- a/binaries/cuprated/Cargo.toml
+++ b/binaries/cuprated/Cargo.toml
@@ -57,6 +57,7 @@ hex                   = { workspace = true }
 hex-literal           = { workspace = true }
 indexmap              = { workspace = true }
 monero-serai          = { workspace = true }
+nu-ansi-term          = { workspace = true }
 paste                 = { workspace = true }
 pin-project           = { workspace = true }
 randomx-rs            = { workspace = true }

--- a/binaries/cuprated/src/config.rs
+++ b/binaries/cuprated/src/config.rs
@@ -25,6 +25,7 @@ mod storage;
 mod tokio;
 mod tracing_config;
 
+use crate::constants::{DEFAULT_CONFIG_STARTUP_DELAY, DEFAULT_CONFIG_WARNING};
 use fs::FileSystemConfig;
 use p2p::P2PConfig;
 use rayon::RayonConfig;
@@ -60,7 +61,13 @@ pub fn read_config_and_args() -> Config {
             })
             .inspect_err(|e| {
                 tracing::debug!("Failed to read config from config dir: {e}");
-                eprintln!("Failed to find/read config file, using default config.");
+                eprintln!(
+                    "{}",
+                    nu_ansi_term::Color::Red
+                        .bold()
+                        .paint(DEFAULT_CONFIG_WARNING)
+                );
+                std::thread::sleep(DEFAULT_CONFIG_STARTUP_DELAY);
             })
             .unwrap_or_default()
     };

--- a/binaries/cuprated/src/constants.rs
+++ b/binaries/cuprated/src/constants.rs
@@ -1,4 +1,5 @@
 //! General constants used throughout `cuprated`.
+use std::time::Duration;
 
 use const_format::formatcp;
 
@@ -22,6 +23,12 @@ pub const VERSION_BUILD: &str = formatcp!("{VERSION}-{}", cuprate_constants::bui
 /// The panic message used when cuprated encounters a critical service error.
 pub const PANIC_CRITICAL_SERVICE_ERROR: &str =
     "A service critical to Cuprate's function returned an unexpected error.";
+
+pub const DEFAULT_CONFIG_WARNING: &str = formatcp!( "WARNING: no config file found, using default config.\nThe default config may not be optimal for your hardware, see the user book here: <TODO>.\nPausing startup for {} seconds.",
+    DEFAULT_CONFIG_STARTUP_DELAY.as_secs()
+);
+
+pub const DEFAULT_CONFIG_STARTUP_DELAY: Duration = Duration::from_secs(15);
 
 pub const EXAMPLE_CONFIG: &str = include_str!("../Cuprated.toml");
 

--- a/binaries/cuprated/src/killswitch.rs
+++ b/binaries/cuprated/src/killswitch.rs
@@ -28,7 +28,7 @@ const _: () = {
 /// The killswitch activates if the current timestamp is ahead of this timestamp.
 ///
 /// Sat Mar 01 2025 05:00:00 GMT+0000
-pub const KILLSWITCH_ACTIVATION_TIMESTAMP: u64 = 1740805200;
+pub const KILLSWITCH_ACTIVATION_TIMESTAMP: u64 = u64::MAX;
 
 /// Check if the system clock is past a certain timestamp,
 /// if so, exit the entire program.


### PR DESCRIPTION

### What
Adds a startup delay with warning if a user does not have a config.

### Why
Not customizing a config for the specific hardware can effect sync performance quite a bit/cause OOMs on weak hardware.
