### PR TITLE
cuprated: update killswitch timestamp for `v0.0.2`

### DIFF
--- a/binaries/cuprated/src/killswitch.rs
+++ b/binaries/cuprated/src/killswitch.rs
@@ -32,8 +32,8 @@ const _: () = {
 
 /// The killswitch activates if the current timestamp is ahead of this timestamp.
 ///
-/// Wed Apr 16 12:00:00 AM UTC 2025
-pub const KILLSWITCH_ACTIVATION_TIMESTAMP: u64 = 1744761600;
+/// Wed May 14 12:00:00 AM UTC 2025
+pub const KILLSWITCH_ACTIVATION_TIMESTAMP: u64 = 1747180800;
 
 /// Check if the system clock is past a certain timestamp,
 /// if so, exit the entire program.
@@ -44,8 +44,8 @@ fn killswitch() {
     /// sanity checking the system's clock to make
     /// sure it is not overly behind.
     ///
-    /// Tue Mar 11 08:33:20 PM UTC 2025
-    const SYSTEM_CLOCK_SANITY_TIMESTAMP: u64 = 1741725200;
+    /// Mon May 12 12:00:00 AM UTC 2025
+    const SYSTEM_CLOCK_SANITY_TIMESTAMP: u64 = 1747008000;
 
     let current_ts = current_unix_timestamp();
 

--- a/binaries/cuprated/src/killswitch.rs
+++ b/binaries/cuprated/src/killswitch.rs
@@ -44,8 +44,8 @@ fn killswitch() {
     /// sanity checking the system's clock to make
     /// sure it is not overly behind.
     ///
-    /// Mon May 12 12:00:00 AM UTC 2025
-    const SYSTEM_CLOCK_SANITY_TIMESTAMP: u64 = 1747008000;
+    /// Tue April 8 12:00:00 AM UTC 2025
+    const SYSTEM_CLOCK_SANITY_TIMESTAMP: u64 = 1744070400;
 
     let current_ts = current_unix_timestamp();
 


### PR DESCRIPTION
### What
Updates the `cuprated` killswitch timestamp using the following values from #374.

| `cuprated` version | Release codename | Release date | Killswitch date | Killswitch timestamp |
|--------------------|------------------|--------------|-----------------|----------------------|
| 0.0.2              | Molybdenite      | 2025-04-09   | 2025-05-14      | 1747180800

Previous: https://github.com/Cuprate/cuprate/pull/391.