### PR TITLE
ci: fix `deny`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -354,9 +354,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.4"
+version = "1.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9157bbaa6b165880c27a4293a474c91cdcf265cc68cc829bf10be0964a391caf"
+checksum = "1fcb57c740ae1daf453ae85f16e37396f672b039e00d9d866e07ddb24e328e3a"
 dependencies = [
  "shlex",
 ]
@@ -2588,15 +2588,14 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "ring"
-version = "0.17.8"
+version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
  "getrandom",
  "libc",
- "spin",
  "untrusted",
  "windows-sys 0.52.0",
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -83,7 +83,7 @@ ignore = [
     #{ crate = "a-crate-that-is-yanked@0.1.1", reason = "you can specify why you are ignoring the yanked crate" },
 
     # TODO: check this is sorted before a beta release.
-    { id = "RUSTSEC-2024-0370", reason = "unmaintained crate, not necessarily vulnerable yet." }
+    { id = "RUSTSEC-2024-0436", reason = "`paste` unmaintained, not necessarily vulnerable yet." }
 ]
 # If this is true, then cargo deny will use the git executable to fetch advisory database.
 # If this is false, then it uses a built-in git library.


### PR DESCRIPTION
### What
Fixes `cargo-deny`.

- Adds ignore for https://rustsec.org/advisories/RUSTSEC-2024-0436
- Removes https://rustsec.org/advisories/RUSTSEC-2024-0370.html (no longer in dep tree)
- Fixes https://rustsec.org/advisories/RUSTSEC-2025-0009.html by updating `ring`