### PR TITLE
Use blank peer list if saved peer list cannot be read.

### DIFF
--- a/p2p/address-book/src/lib.rs
+++ b/p2p/address-book/src/lib.rs
@@ -67,8 +67,8 @@ pub async fn init_address_book<Z: BorshNetworkZone>(
         Ok(res) => res,
         Err(e) if e.kind() == ErrorKind::NotFound => (vec![], vec![]),
         Err(e) => {
-            tracing::error!("Failed to open peer list, {}", e);
-            panic!("{e}");
+            tracing::error!("Error: Failed to open peer list,\n{},\nstarting with an empty list", e);
+            (vec![], vec![])
         }
     };
 

--- a/p2p/address-book/src/lib.rs
+++ b/p2p/address-book/src/lib.rs
@@ -67,7 +67,10 @@ pub async fn init_address_book<Z: BorshNetworkZone>(
         Ok(res) => res,
         Err(e) if e.kind() == ErrorKind::NotFound => (vec![], vec![]),
         Err(e) => {
-            tracing::error!("Error: Failed to open peer list,\n{},\nstarting with an empty list", e);
+            tracing::error!(
+                "Error: Failed to open peer list,\n{},\nstarting with an empty list",
+                e
+            );
             (vec![], vec![])
         }
     };

--- a/p2p/address-book/src/store.rs
+++ b/p2p/address-book/src/store.rs
@@ -50,15 +50,15 @@ pub(crate) fn save_peers_to_disk<Z: BorshNetworkZone>(
             Ok(_) => {
                 let orig_file_path = file.clone();
                 match fs::remove_file(file) {
-                    Ok(_) => {},
+                    Ok(_) => {}
                     Err(x) => {
                         tracing::error!("{x}. Saved peer list to temp file instead.");
                         return Err(x);
                     }
                 }
                 fs::rename(tmp_file, orig_file_path)
-            },
-            Err(x) => Err(x)
+            }
+            Err(x) => Err(x),
         }
     })
 }

--- a/p2p/address-book/src/store.rs
+++ b/p2p/address-book/src/store.rs
@@ -47,17 +47,7 @@ pub(crate) fn save_peers_to_disk<Z: BorshNetworkZone>(
     spawn_blocking(move || {
         fs::create_dir_all(dir)?;
         match fs::write(&tmp_file, &data) {
-            Ok(_) => {
-                let orig_file_path = file.clone();
-                match fs::remove_file(file) {
-                    Ok(_) => {}
-                    Err(x) => {
-                        tracing::error!("{x}. Saved peer list to temp file instead.");
-                        return Err(x);
-                    }
-                }
-                fs::rename(tmp_file, orig_file_path)
-            }
+            Ok(_) => fs::rename(tmp_file, file),
             Err(x) => Err(x),
         }
     })


### PR DESCRIPTION
address-book: fix panic when the peer list on the file system cannot be read

### What
Writes a blank peer list to a temporary location, then attempts to clean the old location, and save the new file as the old file.

Fixes #399 
<!-- Describe the pull request in detail. -->
Cuprate can still panic if deleting the old file fails. That error will be logged, to allow manual cleanup and the latest peer list will already be saved to disk as a .tmp file. The user can remove the .tmp file extension if they wish to use it. 
