### PR TITLE
ci: fix `release.yml`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,11 @@ jobs:
 
           # All archives have these files.
           cp LICENSE-AGPL target/release/LICENSE
-          cp binaries/cuprated/config/Cuprated.toml target/release/
+          if [ "$RUNNER_OS" == "Windows" ]; then
+              target/release/cuprated.exe --generate-config > target/release/Cuprated.toml
+          else
+              target/release/cuprated --generate-config > target/release/Cuprated.toml
+          fi
 
           OS=${{ matrix.os }}
 


### PR DESCRIPTION
### What
`Cuprated.toml` no longer exists which `release.yml` needed, this PR makes it `--generate-config` instead.