### PR TITLE
cuprated --dry-run option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ monerod
 books/*/book
 fast_sync_hashes.bin
 /books/user/Cuprated.toml
+cuprate.toml

--- a/binaries/cuprated/src/config/args.rs
+++ b/binaries/cuprated/src/config/args.rs
@@ -46,6 +46,15 @@ pub struct Args {
     /// Print misc version information in JSON.
     #[arg(short, long)]
     pub version: bool,
+
+    /// Test the configuration file and exit.
+    /// `cuprated` will check the configuration for
+    /// correct syntax and valid values, then print
+    /// the configuration and exit successfully without
+    /// starting. If any errors occur, they will be
+    /// logged and `cuprated` and exit with an error code.
+    #[arg(long)]
+    pub dry_run: bool,
 }
 
 impl Args {
@@ -63,6 +72,10 @@ impl Args {
         if self.generate_config {
             println!("{}", Config::documented_config());
             exit(0);
+        }
+
+        if self.dry_run {
+            Config::dry_run_check(self);
         }
     }
 


### PR DESCRIPTION
### **Adding cuprated --dry-run option**

### What
adding of command line option --dry-run 



### Why
to verify config file parameters : 
   Config deserialization
   PATH permissions
   If ports can be binded to


### Where
the modifications are in **config.rs** where we create:
 a **check_port()** function which check if the port is available or not
 a **dry_run_check()** function which look for the config file .toml or take the default config and check the deserialization, path permissions and availability of ports by calling **check_port()** function

and in **arg.rs** where we add the **dry_run** argument and call the **dry_run_check()** function
