### PR TITLE
storage: add `RuntimeError::ResizedByAnotherProcess`

### DIFF
--- a/storage/blockchain/src/free.rs
+++ b/storage/blockchain/src/free.rs
@@ -41,6 +41,7 @@ pub fn open(config: Config) -> Result<ConcreteEnv, InitError> {
             RuntimeError::KeyExists
             | RuntimeError::KeyNotFound
             | RuntimeError::ResizeNeeded
+            | RuntimeError::ResizedByAnotherProcess
             | RuntimeError::TableNotFound => unreachable!(),
         }
     }

--- a/storage/database/src/backend/heed/error.rs
+++ b/storage/database/src/backend/heed/error.rs
@@ -76,6 +76,7 @@ impl From<heed::Error> for crate::RuntimeError {
                 E2::KeyExist => Self::KeyExists,
                 E2::NotFound => Self::KeyNotFound,
                 E2::MapFull => Self::ResizeNeeded,
+                E2::MapResized => Self::ResizedByAnotherProcess,
 
                 // Corruption errors, these have special panic messages.
                 //
@@ -104,18 +105,6 @@ impl From<heed::Error> for crate::RuntimeError {
                 // of being errors we can't control, these are errors
                 // that only happen if we write incorrect code.
 
-                // "Database contents grew beyond environment mapsize."
-                // We should be resizing the map when needed, this error
-                // occurring indicates we did _not_ do that, which is a bug
-                // and we should panic.
-                //
-                // FIXME: This can also mean _another_ process wrote to our
-                // LMDB file and increased the size. I don't think we need to accommodate for this.
-                // <http://www.lmdb.tech/doc/group__mdb.html#gaa2506ec8dab3d969b0e609cd82e619e5>
-                // Although `monerod` reacts to that instead of `MDB_MAP_FULL`
-                // which is what `mdb_put()` returns so... idk?
-                // <https://github.com/monero-project/monero/blob/059028a30a8ae9752338a7897329fe8012a310d5/src/blockchain_db/lmdb/db_lmdb.cpp#L526>
-                | E2::MapResized
                 // We should be setting `heed::EnvOpenOptions::max_readers()`
                 // with our reader thread value in [`crate::config::Config`],
                 // thus this error should never occur.

--- a/storage/database/src/backend/tests.rs
+++ b/storage/database/src/backend/tests.rs
@@ -128,7 +128,7 @@ fn resize() {
     // Resize by the OS page size.
     let page_size = *crate::resize::PAGE_SIZE;
     let old_size = env.current_map_size();
-    env.resize_map(Some(ResizeAlgorithm::FixedBytes(page_size)));
+    env.resize_map(Some(ResizeAlgorithm::FixedBytes(page_size)), false);
 
     // Assert it resized exactly by the OS page size.
     let new_size = env.current_map_size();
@@ -143,7 +143,7 @@ fn non_manual_resize_1() {
         unreachable!();
     }
     let (env, _tempdir) = tmp_concrete_env();
-    env.resize_map(None);
+    env.resize_map(None, false);
 }
 
 #[test]

--- a/storage/database/src/env.rs
+++ b/storage/database/src/env.rs
@@ -114,16 +114,22 @@ pub trait Env: Sized {
     ///
     /// By default, this function will use the `ResizeAlgorithm` in [`Env::config`].
     ///
-    /// If `resize_algorithm` is `Some`, that will be used instead.
-    ///
-    /// This function returns the _new_ memory map size in bytes.
+    /// - If `resized_by_another_process` is `true`, `0` will
+    ///   be passed to the internal resize function, see:
+    //    <http://www.lmdb.tech/doc/group__mdb.html#gad7ea55da06b77513609efebd44b26920>
+    /// - If `resize_algorithm` is `Some`, that will be used instead
+    /// - This function returns the _new_ memory map size in bytes
     ///
     /// # Invariant
     /// This function _must_ be re-implemented if [`Env::MANUAL_RESIZE`] is `true`.
     ///
     /// Otherwise, this function will panic with `unreachable!()`.
     #[expect(unused_variables)]
-    fn resize_map(&self, resize_algorithm: Option<ResizeAlgorithm>) -> NonZeroUsize {
+    fn resize_map(
+        &self,
+        resize_algorithm: Option<ResizeAlgorithm>,
+        resized_by_another_process: bool,
+    ) -> NonZeroUsize {
         unreachable!()
     }
 

--- a/storage/database/src/error.rs
+++ b/storage/database/src/error.rs
@@ -92,6 +92,16 @@ pub enum RuntimeError {
     #[error("database memory map must be resized")]
     ResizeNeeded,
 
+    /// Another process resized the database.
+    ///
+    /// This error will continue to surface if the `heed`
+    /// backend is used and another process resized the database.
+    ///
+    /// To fix this, [`Env::resize_map`] must be called
+    /// with `resized_by_another_process: true`.
+    #[error("database memory map resized by another process")]
+    ResizedByAnotherProcess,
+
     /// The given table did not exist in the database.
     #[error("database table did not exist")]
     TableNotFound,

--- a/storage/txpool/src/free.rs
+++ b/storage/txpool/src/free.rs
@@ -41,6 +41,7 @@ pub fn open(config: Config) -> Result<ConcreteEnv, InitError> {
             RuntimeError::KeyExists
             | RuntimeError::KeyNotFound
             | RuntimeError::ResizeNeeded
+            | RuntimeError::ResizedByAnotherProcess
             | RuntimeError::TableNotFound => unreachable!(),
         }
     }


### PR DESCRIPTION
### What
Adds `RuntimeError::ResizedByAnotherProcess` and related handling code to `storage/` crates.

### Why
If another process resizes the database file, the storage code will currently panic.

Discussed here: https://github.com/monero-project/meta/issues/1212.