### PR TITLE
storage: fix `get_txid` for pre-RCT outputs

### DIFF
--- a/storage/blockchain/src/ops/output.rs
+++ b/storage/blockchain/src/ops/output.rs
@@ -174,16 +174,7 @@ pub fn output_to_output_on_chain(
     let key = CompressedEdwardsY(output.key);
 
     let txid = if get_txid {
-        let height = u32_to_usize(output.height);
-        let tx_idx = u64_to_usize(output.tx_idx);
-        let txid = if let Some(hash) = table_block_txs_hashes.get(&height)?.get(tx_idx) {
-            *hash
-        } else {
-            let miner_tx_id = table_block_infos.get(&height)?.mining_tx_index;
-            let tx_blob = table_tx_blobs.get(&miner_tx_id)?;
-            Transaction::read(&mut tx_blob.0.as_slice())?.hash()
-        };
-        Some(txid)
+        Some(crate::ops::tx::get_tx_from_id(&output.tx_idx, table_tx_blobs)?.hash())
     } else {
         None
     };

--- a/storage/blockchain/src/ops/output.rs
+++ b/storage/blockchain/src/ops/output.rs
@@ -2,13 +2,12 @@
 
 //---------------------------------------------------------------------------------------------------- Import
 use curve25519_dalek::edwards::CompressedEdwardsY;
-use monero_serai::transaction::{Timelock, Transaction};
+use monero_serai::transaction::Timelock;
 
 use cuprate_database::{
     DbResult, RuntimeError, {DatabaseRo, DatabaseRw},
 };
-use cuprate_helper::{cast::u32_to_usize, crypto::compute_zero_commitment};
-use cuprate_helper::{cast::u64_to_usize, map::u64_to_timelock};
+use cuprate_helper::{cast::u32_to_usize, crypto::compute_zero_commitment, map::u64_to_timelock};
 use cuprate_types::OutputOnChain;
 
 use crate::{
@@ -159,8 +158,6 @@ pub fn output_to_output_on_chain(
     amount: Amount,
     get_txid: bool,
     table_tx_unlock_time: &impl DatabaseRo<TxUnlockTime>,
-    table_block_txs_hashes: &impl DatabaseRo<BlockTxsHashes>,
-    table_block_infos: &impl DatabaseRo<BlockInfos>,
     table_tx_blobs: &impl DatabaseRo<TxBlobs>,
 ) -> DbResult<OutputOnChain> {
     let commitment = compute_zero_commitment(amount);
@@ -204,8 +201,6 @@ pub fn rct_output_to_output_on_chain(
     rct_output: &RctOutput,
     get_txid: bool,
     table_tx_unlock_time: &impl DatabaseRo<TxUnlockTime>,
-    table_block_txs_hashes: &impl DatabaseRo<BlockTxsHashes>,
-    table_block_infos: &impl DatabaseRo<BlockInfos>,
     table_tx_blobs: &impl DatabaseRo<TxBlobs>,
 ) -> DbResult<OutputOnChain> {
     // INVARIANT: Commitments stored are valid when stored by the database.
@@ -253,8 +248,6 @@ pub fn id_to_output_on_chain(
             &rct_output,
             get_txid,
             tables.tx_unlock_time(),
-            tables.block_txs_hashes(),
-            tables.block_infos(),
             tables.tx_blobs(),
         )?;
 
@@ -267,8 +260,6 @@ pub fn id_to_output_on_chain(
             id.amount,
             get_txid,
             tables.tx_unlock_time(),
-            tables.block_txs_hashes(),
-            tables.block_infos(),
             tables.tx_blobs(),
         )?;
 

--- a/storage/blockchain/src/ops/output.rs
+++ b/storage/blockchain/src/ops/output.rs
@@ -2,7 +2,7 @@
 
 //---------------------------------------------------------------------------------------------------- Import
 use curve25519_dalek::edwards::CompressedEdwardsY;
-use monero_serai::transaction::{Timelock, Transaction};
+use monero_serai::transaction::Timelock;
 
 use cuprate_database::{
     DbResult, RuntimeError, {DatabaseRo, DatabaseRw},

--- a/storage/blockchain/src/ops/output.rs
+++ b/storage/blockchain/src/ops/output.rs
@@ -7,11 +7,7 @@ use monero_serai::transaction::{Timelock, Transaction};
 use cuprate_database::{
     DbResult, RuntimeError, {DatabaseRo, DatabaseRw},
 };
-use cuprate_helper::{
-    cast::{u32_to_usize, u64_to_usize},
-    crypto::compute_zero_commitment,
-    map::u64_to_timelock,
-};
+use cuprate_helper::cast::u64_to_usize;
 use cuprate_types::OutputOnChain;
 
 use crate::{
@@ -159,9 +155,9 @@ pub fn output_to_output_on_chain(
     amount: Amount,
     get_txid: bool,
     table_tx_unlock_time: &impl DatabaseRo<TxUnlockTime>,
-    table_tx_blobs: &impl DatabaseRo<TxBlobs>,
     table_block_txs_hashes: &impl DatabaseRo<BlockTxsHashes>,
     table_block_infos: &impl DatabaseRo<BlockInfos>,
+    table_tx_blobs: &impl DatabaseRo<TxBlobs>,
 ) -> DbResult<OutputOnChain> {
     let commitment = compute_zero_commitment(amount);
 
@@ -216,9 +212,9 @@ pub fn rct_output_to_output_on_chain(
     rct_output: &RctOutput,
     get_txid: bool,
     table_tx_unlock_time: &impl DatabaseRo<TxUnlockTime>,
-    table_tx_blobs: &impl DatabaseRo<TxBlobs>,
     table_block_txs_hashes: &impl DatabaseRo<BlockTxsHashes>,
     table_block_infos: &impl DatabaseRo<BlockInfos>,
+    table_tx_blobs: &impl DatabaseRo<TxBlobs>,
 ) -> DbResult<OutputOnChain> {
     // INVARIANT: Commitments stored are valid when stored by the database.
     let commitment = CompressedEdwardsY(rct_output.commitment);
@@ -277,9 +273,9 @@ pub fn id_to_output_on_chain(
             &rct_output,
             get_txid,
             tables.tx_unlock_time(),
-            tables.tx_blobs(),
             tables.block_txs_hashes(),
             tables.block_infos(),
+            tables.tx_blobs(),
         )?;
 
         Ok(output_on_chain)
@@ -291,9 +287,9 @@ pub fn id_to_output_on_chain(
             id.amount,
             get_txid,
             tables.tx_unlock_time(),
-            tables.tx_blobs(),
             tables.block_txs_hashes(),
             tables.block_infos(),
+            tables.tx_blobs(),
         )?;
 
         Ok(output_on_chain)

--- a/storage/blockchain/src/ops/output.rs
+++ b/storage/blockchain/src/ops/output.rs
@@ -7,7 +7,12 @@ use monero_serai::transaction::{Timelock, Transaction};
 use cuprate_database::{
     DbResult, RuntimeError, {DatabaseRo, DatabaseRw},
 };
-use cuprate_helper::cast::u64_to_usize;
+
+use cuprate_helper::{
+    cast::{u32_to_usize, u64_to_usize},
+    crypto::compute_zero_commitment,
+    map::u64_to_timelock,
+};
 use cuprate_types::OutputOnChain;
 
 use crate::{

--- a/storage/blockchain/src/ops/output.rs
+++ b/storage/blockchain/src/ops/output.rs
@@ -15,9 +15,7 @@ use crate::{
         macros::{doc_add_block_inner_invariant, doc_error},
         tx::get_tx_from_id,
     },
-    tables::{
-        BlockInfos, BlockTxsHashes, Outputs, RctOutputs, Tables, TablesMut, TxBlobs, TxUnlockTime,
-    },
+    tables::{Outputs, RctOutputs, Tables, TablesMut, TxBlobs, TxUnlockTime},
     types::{Amount, AmountIndex, Output, OutputFlags, PreRctOutputId, RctOutput},
 };
 

--- a/storage/blockchain/src/ops/output.rs
+++ b/storage/blockchain/src/ops/output.rs
@@ -15,10 +15,7 @@ use cuprate_helper::{
 use cuprate_types::OutputOnChain;
 
 use crate::{
-    ops::{
-        macros::{doc_add_block_inner_invariant, doc_error},
-        tx::get_tx_from_id,
-    },
+    ops::macros::{doc_add_block_inner_invariant, doc_error},
     tables::{
         BlockInfos, BlockTxsHashes, Outputs, RctOutputs, Tables, TablesMut, TxBlobs, TxUnlockTime,
     },

--- a/storage/blockchain/src/ops/output.rs
+++ b/storage/blockchain/src/ops/output.rs
@@ -12,7 +12,10 @@ use cuprate_helper::{cast::u64_to_usize, map::u64_to_timelock};
 use cuprate_types::OutputOnChain;
 
 use crate::{
-    ops::macros::{doc_add_block_inner_invariant, doc_error},
+    ops::{
+        macros::{doc_add_block_inner_invariant, doc_error},
+        tx::get_tx_from_id,
+    },
     tables::{
         BlockInfos, BlockTxsHashes, Outputs, RctOutputs, Tables, TablesMut, TxBlobs, TxUnlockTime,
     },
@@ -174,7 +177,7 @@ pub fn output_to_output_on_chain(
     let key = CompressedEdwardsY(output.key);
 
     let txid = if get_txid {
-        Some(crate::ops::tx::get_tx_from_id(&output.tx_idx, table_tx_blobs)?.hash())
+        Some(get_tx_from_id(&output.tx_idx, table_tx_blobs)?.hash())
     } else {
         None
     };
@@ -220,19 +223,7 @@ pub fn rct_output_to_output_on_chain(
     let key = CompressedEdwardsY(rct_output.key);
 
     let txid = if get_txid {
-        let height = u32_to_usize(rct_output.height);
-
-        let miner_tx_id = table_block_infos.get(&height)?.mining_tx_index;
-
-        let txid = if miner_tx_id == rct_output.tx_idx {
-            let tx_blob = table_tx_blobs.get(&miner_tx_id)?;
-            Transaction::read(&mut tx_blob.0.as_slice())?.hash()
-        } else {
-            let idx = u64_to_usize(rct_output.tx_idx - miner_tx_id - 1);
-            table_block_txs_hashes.get(&height)?[idx]
-        };
-
-        Some(txid)
+        Some(get_tx_from_id(&rct_output.tx_idx, table_tx_blobs)?.hash())
     } else {
         None
     };


### PR DESCRIPTION
### What
`/get_outs` was returning the wrong hash, it is fixed by this, including when it needs to return a miner tx hash.