### PR TITLE
cuprated: Removing panicking assert in  `address_book_config`

### DIFF
--- a/binaries/cuprated/src/config/p2p.rs
+++ b/binaries/cuprated/src/config/p2p.rs
@@ -274,11 +274,6 @@ impl AddressBookConfig {
         network: Network,
         our_own_address: Option<Z::Addr>,
     ) -> cuprate_address_book::AddressBookConfig<Z> {
-        assert!(
-            !Z::BROADCAST_OWN_ADDR && our_own_address.is_some(),
-            "This network DO NOT take an incoming address."
-        );
-
         cuprate_address_book::AddressBookConfig {
             max_white_list_length: self.max_white_list_length,
             max_gray_list_length: self.max_gray_list_length,


### PR DESCRIPTION
### What

The boolean condition at: 

https://github.com/Cuprate/cuprate/commit/392653c659335a07dfb47ae8959e0c7d66182244#diff-6d75e447e3327caf5ac1c2bf3e162690ac5df0c16338dc6b612ad0a6c96367e0R276-R279

is wrong and cause cuprated to panic at launch.

### How

Removing the assert as it provide little benefits at the end.