### PR TITLE
P2P: Add hourly warning logging for no incoming P2P connections

### DIFF
--- a/p2p/p2p/src/inbound_server.rs
+++ b/p2p/p2p/src/inbound_server.rs
@@ -40,6 +40,7 @@ pub async fn inbound_server<Z, T, HS, A>(
     mut address_book: A,
     config: P2PConfig<Z>,
     transport_config: Option<T::ServerConfig>,
+    inbound_semaphore: Arc<Semaphore>,
 ) -> Result<(), tower::BoxError>
 where
     Z: NetworkZone,
@@ -67,8 +68,8 @@ where
 
     let mut listener = pin!(listener);
 
-    // Create semaphore for limiting to maximum inbound connections.
-    let semaphore = Arc::new(Semaphore::new(config.max_inbound_connections));
+    // Use the provided semaphore for limiting to maximum inbound connections.
+    let semaphore = inbound_semaphore;
     // Create ping request handling JoinSet
     let mut ping_join_set = JoinSet::new();
 

--- a/p2p/p2p/src/lib.rs
+++ b/p2p/p2p/src/lib.rs
@@ -5,7 +5,11 @@
 use std::sync::Arc;
 
 use futures::FutureExt;
-use tokio::{sync::mpsc, task::JoinSet};
+use tokio::{
+    sync::mpsc,
+    task::JoinSet,
+    time::{sleep, Duration},
+};
 use tower::{buffer::Buffer, util::BoxCloneService, Service, ServiceExt};
 use tracing::{instrument, Instrument, Span};
 
@@ -30,6 +34,42 @@ pub use config::{AddressBookConfig, P2PConfig, TransportConfig};
 use connection_maintainer::MakeConnectionRequest;
 use peer_set::PeerSet;
 pub use peer_set::{ClientDropGuard, PeerSetRequest, PeerSetResponse};
+
+/// Interval for checking inbound connection status (1 hour in seconds)
+const INBOUND_CONNECTION_MONITOR_INTERVAL_SECS: u64 = 3600;
+
+/// Monitors for inbound connections and logs a warning if none are detected.
+///
+/// This task runs every hour to check if there are inbound connections available.
+/// If `max_inbound_connections` is 0, the task will exit without logging.
+async fn inbound_connection_monitor<Z: NetworkZone>(
+    inbound_semaphore: Arc<tokio::sync::Semaphore>,
+    max_inbound_connections: usize,
+    p2p_port: u16,
+) {
+    // Skip monitoring if inbound connections are disabled
+    if max_inbound_connections == 0 {
+        return;
+    }
+
+    loop {
+        // Wait for the monitoring interval
+        sleep(Duration::from_secs(
+            INBOUND_CONNECTION_MONITOR_INTERVAL_SECS,
+        ))
+        .await;
+
+        // Check if we have any inbound connections
+        // If available permits equals max_inbound_connections, no peers are connected
+        let available_permits = inbound_semaphore.available_permits();
+        if available_permits == max_inbound_connections {
+            tracing::warn!(
+                "No incoming connections - check firewalls/routers allow port {}",
+                p2p_port
+            );
+        }
+    }
+}
 
 /// Initializes the P2P [`NetworkInterface`] for a specific [`NetworkZone`].
 ///
@@ -111,6 +151,9 @@ where
 
     let peer_set = PeerSet::new(new_connection_rx);
 
+    // Create semaphore for limiting inbound connections and monitoring
+    let inbound_semaphore = Arc::new(tokio::sync::Semaphore::new(config.max_inbound_connections));
+
     let mut background_tasks = JoinSet::new();
 
     background_tasks.spawn(
@@ -118,6 +161,17 @@ where
             .run()
             .instrument(Span::current()),
     );
+
+    // Spawn inbound connection monitor task
+    background_tasks.spawn(
+        inbound_connection_monitor::<Z>(
+            inbound_semaphore.clone(),
+            config.max_inbound_connections,
+            config.p2p_port,
+        )
+        .instrument(tracing::info_span!("inbound_connection_monitor")),
+    );
+
     background_tasks.spawn(
         inbound_server::inbound_server(
             new_connection_tx,
@@ -125,6 +179,7 @@ where
             address_book.clone(),
             config,
             transport_config.server_config,
+            inbound_semaphore,
         )
         .map(|res| {
             if let Err(e) = res {


### PR DESCRIPTION
### What
Closes #486 

Implements hourly logging to detect when no incoming P2P connections are established, helping users diagnose potential firewall or router configuration issues.

- Adds `inbound_connection_monitor` function that checks for active inbound connections every hour
- Logs warning message when no incoming connections are detected: `No incoming connections - check firewalls/routers allow port {p2p_port}`
- Refactors semaphore creation from `inbound_server` to `lib.rs` for shared access between monitoring and connection handling
- Skips monitoring when `max_inbound_connections = 0` (inbound connections disabled)

### Why

Users may not realize their node isn't receiving incoming connections due to firewall/NAT issues. This proactive monitoring helps identify connectivity problems that could impact network participation and sync performance.

### Where

- **P2P networking layer**: Adds monitoring functionality to the inbound connection system
- **Background task management**: New monitoring task runs alongside existing P2P background tasks
- **Logging/observability**: Introduces new warning logs for network diagnostics
- **Function signatures**: `inbound_server` function signature changed to accept shared semaphore
- **Resource sharing**: Semaphore ownership moved from `inbound_server` to parent scope for cross-task access

### How

1. **Shared semaphore creation**: Moves semaphore instantiation from `inbound_server` to `initialize_network` function, allowing multiple tasks to access the same connection tracking resource

2. **Monitoring task**: Spawns `inbound_connection_monitor` as a background task that:
  - Sleeps for 1 hour intervals using `INBOUND_CONNECTION_MONITOR_INTERVAL_SECS` constant
  - Checks `inbound_semaphore.available_permits()` to determine active connections
  - Logs warning when `available_permits == max_inbound_connections` (no connections active)

3. **Connection detection logic**: Uses semaphore permit counting as a proxy for active connections:
  - Each inbound connection acquires a semaphore permit
  - When all permits are available, no connections are established
  - This approach leverages existing connection limiting infrastructure

  6. **Task lifecycle**: Monitor runs continuously in background, automatically stopping when the P2P interface is dropped