### PR TITLE
cuprated: `fn main() -> ExitCode`

### DIFF
--- a/binaries/cuprated/src/blockchain.rs
+++ b/binaries/cuprated/src/blockchain.rs
@@ -35,12 +35,12 @@ pub async fn check_add_genesis(
     blockchain_read_handle: &mut BlockchainReadHandle,
     blockchain_write_handle: &mut BlockchainWriteHandle,
     network: Network,
-) {
+) -> Result<(), anyhow::Error> {
     // Try to get the chain height, will fail if the genesis block is not in the DB.
     if blockchain_read_handle
         .ready()
         .await
-        .expect(PANIC_CRITICAL_SERVICE_ERROR)
+        .map_err(|_| PANIC_CRITICAL_SERVICE_ERROR.into())?
         .call(BlockchainReadRequest::ChainHeight)
         .await
         .is_ok()
@@ -56,7 +56,7 @@ pub async fn check_add_genesis(
     blockchain_write_handle
         .ready()
         .await
-        .expect(PANIC_CRITICAL_SERVICE_ERROR)
+        .map_err(|_| PANIC_CRITICAL_SERVICE_ERROR.into())?
         .call(BlockchainWriteRequest::WriteBlock(
             VerifiedBlockInformation {
                 block_blob: genesis.serialize(),
@@ -74,7 +74,9 @@ pub async fn check_add_genesis(
             },
         ))
         .await
-        .expect(PANIC_CRITICAL_SERVICE_ERROR);
+        .map_err(|_| PANIC_CRITICAL_SERVICE_ERROR.into())?;
+
+    Ok(())
 }
 
 /// Initializes the consensus services.

--- a/binaries/cuprated/src/commands.rs
+++ b/binaries/cuprated/src/commands.rs
@@ -63,7 +63,7 @@ pub enum OutputTarget {
 }
 
 /// The [`Command`] listener loop.
-pub fn command_listener(incoming_commands: mpsc::Sender<Command>) -> ! {
+pub fn command_listener(incoming_commands: mpsc::Sender<Command>) -> Result<(), anyhow::Error> {
     let mut stdin = io::stdin();
     let mut line = String::new();
 
@@ -82,9 +82,11 @@ pub fn command_listener(incoming_commands: mpsc::Sender<Command>) -> ! {
                     .blocking_send(command)
                     .inspect_err(|err| eprintln!("Failed to send command: {err}")),
             ),
-            Err(err) => err.print().unwrap(),
+            Err(err) => err.print()?,
         }
     }
+
+    Ok(())
 }
 
 /// The [`Command`] handler loop.

--- a/binaries/cuprated/src/p2p.rs
+++ b/binaries/cuprated/src/p2p.rs
@@ -72,7 +72,7 @@ pub async fn initialize_zones_p2p(
     mut blockchain_read_handle: BlockchainReadHandle,
     txpool_read_handle: TxpoolReadHandle,
     tor_ctx: TorContext,
-) -> (NetworkInterfaces, Vec<Sender<IncomingTxHandler>>) {
+) -> Result<(NetworkInterfaces, Vec<Sender<IncomingTxHandler>>), anyhow::Error> {
     // Start clearnet P2P.
     let (clearnet, incoming_tx_handler_tx) = {
         // If proxy is set

--- a/storage/service/src/reader_threads.rs
+++ b/storage/service/src/reader_threads.rs
@@ -14,17 +14,16 @@ use serde::{Deserialize, Serialize};
 
 //---------------------------------------------------------------------------------------------------- init_thread_pool
 /// Initialize the reader thread-pool backed by `rayon`.
-pub fn init_thread_pool(reader_threads: ReaderThreads) -> Arc<ThreadPool> {
+pub fn init_thread_pool(reader_threads: ReaderThreads) -> Result<Arc<ThreadPool>, anyhow::Error> {
     // How many reader threads to spawn?
     let reader_count = reader_threads.as_threads().get();
 
-    Arc::new(
+    Ok(Arc::new(
         rayon::ThreadPoolBuilder::new()
             .num_threads(reader_count)
             .thread_name(|i| format!("{}::DatabaseReader({i})", module_path!()))
-            .build()
-            .unwrap(),
-    )
+            .build()?,
+    ))
 }
 
 //---------------------------------------------------------------------------------------------------- ReaderThreads


### PR DESCRIPTION
### What
Modifies `main()` and init functions to return an error instead of panicking.

Closes https://github.com/Cuprate/cuprate/issues/522.