### PR TITLE
cuprated: fix deadlock

### DIFF
--- a/binaries/cuprated/src/rpc/handlers/json_rpc.rs
+++ b/binaries/cuprated/src/rpc/handlers/json_rpc.rs
@@ -1071,7 +1071,7 @@ fn add_aux_pow_inner(
     // Some of the code below requires that the
     // `.len()` of certain containers are the same.
     // Boxed slices are used over `Vec` to slightly
-    // safe-guard against accidently pushing to it.
+    // safe-guard against accidentally pushing to it.
     let aux_pow = request.aux_pow.into_boxed_slice();
 
     // TODO: why is this here? it does nothing:

--- a/binaries/cuprated/src/txpool/dandelion.rs
+++ b/binaries/cuprated/src/txpool/dandelion.rs
@@ -110,7 +110,7 @@ impl Service<DandelionRouteReq<DandelionTx, CrossNetworkInternalPeerId>> for Mai
 pub fn start_dandelion_pool_manager(
     router: MainDandelionRouter,
     txpool_read_handle: TxpoolReadHandle,
-    promote_tx: mpsc::Sender<[u8; 32]>,
+    promote_tx: mpsc::UnboundedSender<[u8; 32]>,
 ) -> DandelionPoolService<DandelionTx, TxId, CrossNetworkInternalPeerId> {
     cuprate_dandelion_tower::pool::start_dandelion_pool_manager(
         // TODO: make this constant configurable?
@@ -118,7 +118,7 @@ pub fn start_dandelion_pool_manager(
         router,
         tx_store::TxStoreService {
             txpool_read_handle,
-            promote_tx: PollSender::new(promote_tx),
+            promote_tx,
         },
         DANDELION_CONFIG,
     )

--- a/binaries/cuprated/src/txpool/incoming_tx.rs
+++ b/binaries/cuprated/src/txpool/incoming_tx.rs
@@ -126,7 +126,7 @@ impl IncomingTxHandler {
 
         let dandelion_router = MainDandelionRouter::new(clearnet_router, tor_router);
 
-        let (promote_tx, promote_rx) = mpsc::channel(25);
+        let (promote_tx, promote_rx) = mpsc::unbounded_channel();
 
         let dandelion_pool_manager = dandelion::start_dandelion_pool_manager(
             dandelion_router,

--- a/binaries/cuprated/src/txpool/manager.rs
+++ b/binaries/cuprated/src/txpool/manager.rs
@@ -45,7 +45,7 @@ const INCOMING_TX_QUEUE_SIZE: usize = 100;
 pub async fn start_txpool_manager(
     mut txpool_write_handle: TxpoolWriteHandle,
     mut txpool_read_handle: TxpoolReadHandle,
-    promote_tx_channel: mpsc::Receiver<[u8; 32]>,
+    promote_tx_channel: mpsc::UnboundedReceiver<[u8; 32]>,
     diffuse_service: DiffuseService<ClearNet>,
     dandelion_pool_manager: DandelionPoolService<DandelionTx, TxId, CrossNetworkInternalPeerId>,
     config: TxpoolConfig,
@@ -206,7 +206,7 @@ struct TxpoolManager {
     dandelion_pool_manager: DandelionPoolService<DandelionTx, TxId, CrossNetworkInternalPeerId>,
     /// The channel the dandelion manager will use to communicate that a tx should be promoted to the
     /// public pool.
-    promote_tx_channel: mpsc::Receiver<[u8; 32]>,
+    promote_tx_channel: mpsc::UnboundedReceiver<[u8; 32]>,
     /// The [`DiffuseService`] to diffuse txs to the p2p network.
     ///
     /// Used for re-relays.


### PR DESCRIPTION
Fixes a deadlock where the txpool manager can be waiting on the dandelion manager and vice-versa 