### PR TITLE
`cuprated`: Generic SOCKS5 proxy support + ClearNet over Daemon

### DIFF
--- a/binaries/cuprated/src/config/p2p.rs
+++ b/binaries/cuprated/src/config/p2p.rs
@@ -18,7 +18,7 @@ use cuprate_p2p_core::{
     transports::{Tcp, TcpServerConfig},
     ClearNet, NetworkZone, Tor, Transport,
 };
-use cuprate_p2p_transport::{Arti, ArtiClientConfig, ArtiServerConfig};
+use cuprate_p2p_transport::{Arti, ArtiClientConfig, ArtiServerConfig, Socks, SocksClientConfig};
 use cuprate_wire::OnionAddr;
 
 use crate::{p2p::ProxySettings, tor::TorMode};
@@ -287,6 +287,14 @@ impl ClearNetConfig {
         TransportConfig {
             client_config: (),
             server_config,
+        }
+    }
+
+    /// Gets the transport config for [`ClearNet`] over [`Socks`].
+    pub fn socks_transport_config(&self, network: Network) -> TransportConfig<ClearNet, Socks> {
+        TransportConfig {
+            client_config: self.proxy.clone().try_into().unwrap(),
+            server_config: None,
         }
     }
 }

--- a/binaries/cuprated/src/config/p2p.rs
+++ b/binaries/cuprated/src/config/p2p.rs
@@ -291,7 +291,7 @@ impl ClearNetConfig {
     }
 
     /// Gets the transport config for [`ClearNet`] over [`Socks`].
-    pub fn socks_transport_config(&self, network: Network) -> TransportConfig<ClearNet, Socks> {
+    pub fn socks_transport_config(&self) -> TransportConfig<ClearNet, Socks> {
         TransportConfig {
             client_config: self.proxy.clone().try_into().unwrap(),
             server_config: None,

--- a/binaries/cuprated/src/config/p2p.rs
+++ b/binaries/cuprated/src/config/p2p.rs
@@ -289,14 +289,6 @@ impl ClearNetConfig {
             server_config,
         }
     }
-
-    /// Gets the transport config for [`ClearNet`] over [`Socks`].
-    pub fn socks_transport_config(&self) -> TransportConfig<ClearNet, Socks> {
-        TransportConfig {
-            client_config: self.proxy.clone().try_into().unwrap(),
-            server_config: None,
-        }
-    }
 }
 
 impl Default for ClearNetConfig {

--- a/binaries/cuprated/src/p2p.rs
+++ b/binaries/cuprated/src/p2p.rs
@@ -27,7 +27,8 @@ use crate::{
     config::Config,
     constants::PANIC_CRITICAL_SERVICE_ERROR,
     tor::{
-        transport_arti_config, transport_clearnet_arti_config, transport_clearnet_daemon_config, transport_daemon_config, TorContext, TorMode
+        transport_arti_config, transport_clearnet_arti_config, transport_clearnet_daemon_config,
+        transport_daemon_config, TorContext, TorMode,
     },
     txpool::{self, IncomingTxHandler},
 };
@@ -120,17 +121,15 @@ pub async fn initialize_zones_p2p(
                     .await
                     .unwrap()
                 }
-                TorMode::Daemon => {
-                    start_zone_p2p::<ClearNet, Socks>(
-                        blockchain_read_handle.clone(),
-                        context_svc.clone(),
-                        txpool_read_handle.clone(),
-                        config.clearnet_p2p_config(),
-                        transport_clearnet_daemon_config(config),
-                    )
-                    .await
-                    .unwrap()
-                }
+                TorMode::Daemon => start_zone_p2p::<ClearNet, Socks>(
+                    blockchain_read_handle.clone(),
+                    context_svc.clone(),
+                    txpool_read_handle.clone(),
+                    config.clearnet_p2p_config(),
+                    transport_clearnet_daemon_config(config),
+                )
+                .await
+                .unwrap(),
                 TorMode::Off => {
                     tracing::error!("Clearnet proxy set to \"tor\" but Tor is actually off. Please be sure to set a mode in the configuration or command line");
                     std::process::exit(0);

--- a/binaries/cuprated/src/tor.rs
+++ b/binaries/cuprated/src/tor.rs
@@ -21,7 +21,8 @@ use cuprate_helper::fs::CUPRATE_DATA_DIR;
 use cuprate_p2p::TransportConfig;
 use cuprate_p2p_core::{ClearNet, Tor};
 use cuprate_p2p_transport::{
-    Arti, ArtiClientConfig, ArtiServerConfig, Daemon, DaemonClientConfig, DaemonServerConfig, Socks, SocksClientConfig,
+    Arti, ArtiClientConfig, ArtiServerConfig, Daemon, DaemonClientConfig, DaemonServerConfig,
+    Socks, SocksClientConfig,
 };
 use cuprate_wire::OnionAddr;
 
@@ -203,7 +204,7 @@ pub const fn transport_clearnet_daemon_config(config: &Config) -> TransportConfi
     TransportConfig {
         client_config: SocksClientConfig {
             proxy: config.tor.daemon.address,
-            authentication: None
+            authentication: None,
         },
         server_config: None,
     }

--- a/binaries/cuprated/src/tor.rs
+++ b/binaries/cuprated/src/tor.rs
@@ -21,7 +21,7 @@ use cuprate_helper::fs::CUPRATE_DATA_DIR;
 use cuprate_p2p::TransportConfig;
 use cuprate_p2p_core::{ClearNet, Tor};
 use cuprate_p2p_transport::{
-    Arti, ArtiClientConfig, ArtiServerConfig, Daemon, DaemonClientConfig, DaemonServerConfig,
+    Arti, ArtiClientConfig, ArtiServerConfig, Daemon, DaemonClientConfig, DaemonServerConfig, Socks, SocksClientConfig,
 };
 use cuprate_wire::OnionAddr;
 
@@ -195,5 +195,16 @@ pub fn transport_daemon_config(config: &Config) -> TransportConfig<Tor, Daemon> 
                 port: config.tor.daemon.listening_addr.port(),
             },
         ),
+    }
+}
+
+/// Gets the transport config for [`ClearNet`] over [`Socks`].
+pub const fn transport_clearnet_daemon_config(config: &Config) -> TransportConfig<ClearNet, Socks> {
+    TransportConfig {
+        client_config: SocksClientConfig {
+            proxy: config.tor.daemon.address,
+            authentication: None
+        },
+        server_config: None,
     }
 }

--- a/p2p/p2p-transport/src/lib.rs
+++ b/p2p/p2p-transport/src/lib.rs
@@ -10,6 +10,10 @@ pub use arti::{Arti, ArtiClientConfig, ArtiServerConfig};
 mod tor;
 pub use tor::{Daemon, DaemonClientConfig, DaemonServerConfig};
 
+/// SOCKS5 implementation
+mod socks;
+pub use socks::{Socks, SocksClientConfig};
+
 /// Disabled listener
 mod disabled;
 pub(crate) use disabled::DisabledListener;

--- a/p2p/p2p-transport/src/socks.rs
+++ b/p2p/p2p-transport/src/socks.rs
@@ -1,0 +1,75 @@
+//! Socks Transport
+//!
+//! This module defines a transport method for the `ClearNet` network zone using a generic SOCKS5 proxy.
+//!
+
+//---------------------------------------------------------------------------------------------------- Imports
+
+use std::{
+    io::{self, ErrorKind},
+    net::SocketAddr,
+};
+
+use tokio::net::tcp::{OwnedReadHalf, OwnedWriteHalf};
+use tokio_socks::tcp::Socks5Stream;
+use tokio_util::codec::{FramedRead, FramedWrite};
+
+use cuprate_p2p_core::{ClearNet, NetworkZone, Transport};
+use cuprate_wire::MoneroWireCodec;
+
+use crate::DisabledListener;
+
+//---------------------------------------------------------------------------------------------------- Configuration
+
+/// Socks5 proxied TCP transport.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct Socks;
+
+#[derive(Clone)]
+pub struct SocksClientConfig {
+    /// Proxy address
+    pub proxy: SocketAddr,
+
+    /// According to RFC 1929, if authentication is enabled, both username and password fields MUST NOT be empty.
+    pub authentication: Option<(String, String)>,
+}
+
+//---------------------------------------------------------------------------------------------------- Transport
+
+#[async_trait::async_trait]
+impl Transport<ClearNet> for Socks {
+    type ClientConfig = SocksClientConfig;
+    type ServerConfig = ();
+
+    type Stream = FramedRead<OwnedReadHalf, MoneroWireCodec>;
+    type Sink = FramedWrite<OwnedWriteHalf, MoneroWireCodec>;
+    type Listener = DisabledListener<ClearNet, OwnedReadHalf, OwnedWriteHalf>;
+
+    async fn connect_to_peer(
+        addr: <ClearNet as NetworkZone>::Addr,
+        config: &Self::ClientConfig,
+    ) -> Result<(Self::Stream, Self::Sink), io::Error> {
+        // Optional authentication
+        let proxy = if let Some((username, password)) = config.authentication.as_ref() {
+            Socks5Stream::connect_with_password(config.proxy, addr, username, password).await
+        } else {
+            Socks5Stream::connect(config.proxy, addr.to_string()).await
+        };
+
+        proxy
+            .map_err(|e| io::Error::new(ErrorKind::ConnectionAborted, e.to_string()))
+            .map(|stream| {
+                let (stream, sink) = stream.into_inner().into_split();
+                (
+                    FramedRead::new(stream, MoneroWireCodec::default()),
+                    FramedWrite::new(sink, MoneroWireCodec::default()),
+                )
+            })
+    }
+
+    async fn incoming_connection_listener(
+        _config: Self::ServerConfig,
+    ) -> Result<Self::Listener, io::Error> {
+        panic!("In proxy mode, inbound is disabled!");
+    }
+}


### PR DESCRIPTION
### What

Add support to pass P2P traffic to a specific SOCKS5 proxy. Authentication is supported. This is also used to implement `ClearNet` over `Daemon` tor anonymization of clearnet traffic.

Follows: https://github.com/Cuprate/cuprate/pull/509

### Changelog

In `cuprate-p2p-transport`:

- Added new `socks.rs` file containing `Socks` that `impl Transport<ClearNet>`. As well as `SocksClientConfig` (socks5 proxy settings).

In `cuprated`:

- Added `TryFrom<ProxySettings> for SocksClientConfig` to parse socks5 URL in user configuration. The urls are in the form of: `socks5://username:password@host:port`.
- new `socks_transport_config` and `transport_clearnet_daemon_config` helpers.
- Modified `initialize_zones_p2p` accordingly. 