### PR TITLE
 workspace: Rust 1.88..=1.90

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -365,6 +365,8 @@ precedence_bits = "deny"
 as_pointer_underscore = "deny"
 literal_string_with_formatting_args = "deny"
 manual_midpoint = "deny"
+ip_constant = "deny"
+doc_broken_link = "deny"
 
 # Warm
 cast_possible_truncation = "deny"

--- a/consensus/rules/src/blocks.rs
+++ b/consensus/rules/src/blocks.rs
@@ -53,7 +53,7 @@ pub trait RandomX {
 
 /// Returns if this height is a RandomX seed height.
 pub const fn is_randomx_seed_height(height: usize) -> bool {
-    height % RX_SEEDHASH_EPOCH_BLOCKS == 0
+    height.is_multiple_of(RX_SEEDHASH_EPOCH_BLOCKS)
 }
 
 /// Returns the RandomX seed height for this block.

--- a/storage/blockchain/src/ops/alt_block/block.rs
+++ b/storage/blockchain/src/ops/alt_block/block.rs
@@ -228,7 +228,6 @@ mod tests {
         types::AltBlockHeight,
     };
 
-    #[expect(clippy::range_plus_one)]
     #[test]
     fn all_alt_blocks() {
         let (env, _tmp) = tmp_concrete_env();

--- a/types/fixed-bytes/src/lib.rs
+++ b/types/fixed-bytes/src/lib.rs
@@ -192,7 +192,7 @@ impl<const N: usize> TryFrom<Bytes> for ByteArrayVec<N> {
     type Error = FixedByteError;
 
     fn try_from(value: Bytes) -> Result<Self, Self::Error> {
-        if value.len() % N != 0 {
+        if !value.len().is_multiple_of(N) {
             return Err(FixedByteError::InvalidLength);
         }
 
@@ -222,7 +222,7 @@ impl<const N: usize> TryFrom<Vec<u8>> for ByteArrayVec<N> {
     type Error = FixedByteError;
 
     fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {
-        if value.len() % N != 0 {
+        if !value.len().is_multiple_of(N) {
             return Err(FixedByteError::InvalidLength);
         }
 


### PR DESCRIPTION
### What
Adds/fixes lints from Rust 1.88, 1.89, 1.90.

Added clippy lints:
- [ip_constant](https://rust-lang.github.io/rust-clippy/master/index.html#ip_constant)
- [doc_broken_link](https://rust-lang.github.io/rust-clippy/master/index.html#doc_broken_link)