### PR TITLE
add linear tapes database (part 1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -691,7 +691,7 @@ dependencies = [
  "iana-time-zone",
  "num-traits",
  "serde",
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -1375,6 +1375,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuprate-linear-tapes"
+version = "0.0.1"
+dependencies = [
+ "cuprate-rcu-ring",
+ "memmap2",
+ "tempfile",
+]
+
+[[package]]
 name = "cuprate-p2p"
 version = "0.1.0"
 dependencies = [
@@ -1466,6 +1475,14 @@ dependencies = [
  "borsh",
  "cuprate-constants",
  "thiserror 2.0.16",
+]
+
+[[package]]
+name = "cuprate-rcu-ring"
+version = "0.0.1"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6968,7 +6985,7 @@ dependencies = [
  "windows-collections",
  "windows-core",
  "windows-future",
- "windows-link",
+ "windows-link 0.1.3",
  "windows-numerics",
 ]
 
@@ -6989,7 +7006,7 @@ checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link",
+ "windows-link 0.1.3",
  "windows-result",
  "windows-strings",
 ]
@@ -7001,7 +7018,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
  "windows-core",
- "windows-link",
+ "windows-link 0.1.3",
  "windows-threading",
 ]
 
@@ -7034,13 +7051,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
 name = "windows-numerics"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core",
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -7049,7 +7072,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -7058,7 +7081,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -7089,6 +7112,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7110,7 +7142,7 @@ version = "0.53.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
  "windows_i686_gnu 0.53.0",
@@ -7127,7 +7159,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,8 @@ members = [
 	"storage/service",
 	"storage/txpool",
 	"storage/database",
+	"storage/linear-tape",
+	"storage/linear-tape/rcu-ring",
 
 	# Types
 	"types/types",
@@ -87,6 +89,8 @@ default-members = [
 	"storage/service",
 	"storage/txpool",
 	"storage/database",
+	"storage/linear-tape",
+	"storage/linear-tape/rcu-ring",
 
 	# Types
 	"types/types",
@@ -152,6 +156,8 @@ cuprate-blockchain        = { path = "storage/blockchain",        default-featur
 cuprate-database          = { path = "storage/database",          default-features = false }
 cuprate-database-service  = { path = "storage/service",           default-features = false }
 cuprate-txpool            = { path = "storage/txpool",            default-features = false }
+cuprate-linear-tapes      = { path = "storage/linear-tape",       default-features = false }
+cuprate-rcu-ring          = { path = "storage/linear-tape/rcu-ring",default-features = false }
 cuprate-pruning           = { path = "pruning",                   default-features = false }
 cuprate-test-utils        = { path = "test-utils",                default-features = false }
 cuprate-types             = { path = "types/types",               default-features = false }
@@ -187,6 +193,7 @@ futures               = { version = "0.3", default-features = false }
 hex                   = { version = "0.4", default-features = false }
 hex-literal           = { version = "1", default-features = false }
 indexmap              = { version = "2", default-features = false }
+memmap2               = { version = "0.9", default-features = false }
 monero-address        = { git = "https://github.com/monero-oxide/monero-oxide.git", rev = "68d5a5e", default-features = false }
 monero-oxide          = { git = "https://github.com/monero-oxide/monero-oxide.git", rev = "68d5a5e", default-features = false }
 nu-ansi-term          = { version = "0.46", default-features = false }
@@ -345,7 +352,6 @@ unseparated_literal_suffix = "deny"
 unnecessary_safety_doc = "deny"
 unnecessary_safety_comment = "deny"
 unnecessary_self_imports = "deny"
-string_to_string = "deny"
 rest_pat_in_fully_bound_structs = "deny"
 redundant_type_annotations = "deny"
 infinite_loop = "deny"

--- a/storage/linear-tape/Cargo.toml
+++ b/storage/linear-tape/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name        = "cuprate-linear-tapes"
+version     = "0.0.1"
+edition     = "2021"
+description = "Cuprate's database abstraction"
+license     = "MIT"
+authors     = ["Boog900"]
+repository  = "https://github.com/Cuprate/cuprate/tree/main/storage/linear-tape"
+keywords    = ["cuprate", "database"]
+
+[dependencies]
+memmap2 = { workspace = true }
+cuprate-rcu-ring = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }
+
+[lints]
+workspace = true

--- a/storage/linear-tape/rcu-ring/Cargo.toml
+++ b/storage/linear-tape/rcu-ring/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name        = "cuprate-rcu-ring"
+version     = "0.0.1"
+edition     = "2021"
+description = "A read-copy-update type that is backed by raw bytes"
+license     = "MIT"
+authors     = ["Boog900"]
+repository  = "https://github.com/Cuprate/cuprate/tree/main/storage/linear-tape/rcu-ring"
+keywords    = ["cuprate", "database", "rcu"]
+
+[target.'cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))'.dependencies]
+libc = "0.2"
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61.0", features = ["Win32_System_Threading", "Win32_Foundation", "Win32_System_WindowsProgramming"] }

--- a/storage/linear-tape/rcu-ring/src/atomic_wait.rs
+++ b/storage/linear-tape/rcu-ring/src/atomic_wait.rs
@@ -1,0 +1,156 @@
+/// Code modified from: <https://github.com/m-ou-se/atomic-wait>
+/// We need to support intra-process futexs which that crate doesn't.
+/*
+Copyright (c) 2022, Mara Bos <m-ou.se@m-ou.se>
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSEARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+pub use futex::*;
+
+#[cfg(windows)]
+mod futex {
+    use std::sync::atomic::AtomicU32;
+
+    use windows_sys::Win32::System::{
+        Threading::{WaitOnAddress, WakeByAddressAll, WakeByAddressSingle},
+        WindowsProgramming::INFINITE,
+    };
+
+    #[inline]
+    pub fn wait(a: &AtomicU32, expected: u32) {
+        let ptr: *const AtomicU32 = a;
+        let expected_ptr: *const u32 = &expected;
+        unsafe { WaitOnAddress(ptr.cast(), expected_ptr.cast(), 4, INFINITE) };
+    }
+
+    #[inline]
+    pub fn wake_one(ptr: *const AtomicU32) {
+        unsafe { WakeByAddressSingle(ptr.cast()) };
+    }
+
+    #[inline]
+    pub fn wake_all(ptr: *const AtomicU32) {
+        unsafe { WakeByAddressAll(ptr.cast()) };
+    }
+}
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+mod futex {
+    use std::sync::atomic::AtomicU32;
+
+    #[inline]
+    pub fn wait(a: &AtomicU32, expected: u32) {
+        unsafe {
+            libc::syscall(
+                libc::SYS_futex,
+                a,
+                libc::FUTEX_WAIT,
+                expected,
+                core::ptr::null::<libc::timespec>(),
+            );
+        };
+    }
+
+    #[inline]
+    pub fn wake_one(ptr: *const AtomicU32) {
+        unsafe {
+            libc::syscall(libc::SYS_futex, ptr, libc::FUTEX_WAKE, 1i32);
+        };
+    }
+
+    #[inline]
+    pub fn wake_all(ptr: *const AtomicU32) {
+        unsafe {
+            libc::syscall(libc::SYS_futex, ptr, libc::FUTEX_WAKE, i32::MAX);
+        };
+    }
+}
+
+#[cfg(target_os = "freebsd")]
+mod futex {
+    use std::sync::atomic::AtomicU32;
+
+    #[inline]
+    pub fn wait(a: &AtomicU32, expected: u32) {
+        let ptr: *const AtomicU32 = a;
+        unsafe {
+            libc::_umtx_op(
+                ptr as *mut libc::c_void,
+                libc::UMTX_OP_WAIT_UINT,
+                expected as libc::c_ulong,
+                core::ptr::null_mut(),
+                core::ptr::null_mut(),
+            );
+        };
+    }
+
+    #[inline]
+    pub fn wake_one(ptr: *const AtomicU32) {
+        unsafe {
+            libc::_umtx_op(
+                ptr as *mut libc::c_void,
+                libc::UMTX_OP_WAKE,
+                1 as libc::c_ulong,
+                core::ptr::null_mut(),
+                core::ptr::null_mut(),
+            );
+        };
+    }
+
+    #[inline]
+    pub fn wake_all(ptr: *const AtomicU32) {
+        unsafe {
+            libc::_umtx_op(
+                ptr as *mut libc::c_void,
+                libc::UMTX_OP_WAKE,
+                i32::MAX as libc::c_ulong,
+                core::ptr::null_mut(),
+                core::ptr::null_mut(),
+            );
+        };
+    }
+}
+
+// for any other OS we just use a spin lock, notably macOS is included here.
+
+#[cfg(not(any(
+    windows,
+    target_os = "linux",
+    target_os = "android",
+    target_os = "freebsd"
+)))]
+mod futex {
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    #[inline]
+    pub fn wait(a: &AtomicU32, expected: u32) {
+        while a.load(Ordering::Relaxed) == expected {
+            std::hint::spin_loop();
+        }
+    }
+
+    #[inline]
+    pub fn wake_one(_ptr: *const AtomicU32) {}
+
+    #[inline]
+    pub fn wake_all(_ptr: *const AtomicU32) {}
+}

--- a/storage/linear-tape/rcu-ring/src/lib.rs
+++ b/storage/linear-tape/rcu-ring/src/lib.rs
@@ -1,0 +1,304 @@
+//! # Rcu-Tape
+//!
+//! A sort-of implementation of a read-copy-update synchronization mechanism: <https://en.wikipedia.org/wiki/Read-copy-update>
+//!
+//! This crate exposes and [`RcuRing`] type, which implements an RCU mechanism over a raw byte buffer,
+//! treating the byte buffer as a contiguous ring of slots to use for the data (with some header bytes
+//! at the start).
+//!
+//! It supports multiple readers and a single writer, writing to the next slot. The number of slots
+//! is configurable, the more slots you have, the more space is required, but the less waiting writers
+//! will have to do to make sure all readers finish reading old data.
+//!
+//! This is only a sort-of RCU as technically readers could wait on a writer while a writer is doing a commit.
+//! If the reader reads the old ptr but sees the marker that the slot is old it will keep trying the ptr until
+//! it sees the new value. In practice this can be avoided with enough slots.
+//!
+//! This is a low-level synchronization primitive.
+use std::sync::atomic::{AtomicU32, Ordering};
+
+pub(crate) mod atomic_wait;
+mod mutex;
+mod state;
+
+use mutex::{Mutex, MutexGuard};
+use state::DataSlotState;
+
+/// The size of the RCU header.
+///
+/// The header contains the writer mutex and the current slot idx.
+const HEADER_LEN: usize = 8;
+
+/// A handle to a slot in the RcuRing.
+///
+/// This handle holds a sort of read guard to prevent a writer writing to this slot.
+pub struct DataHandle<'a> {
+    data_slot_state: DataSlotState<'a>,
+    /// The data in this slot.
+    ///
+    /// This is guaranteed to be at least 8-byte aligned.
+    pub data: &'a [u8],
+}
+
+impl Drop for DataHandle<'_> {
+    fn drop(&mut self) {
+        self.data_slot_state.remove_reader();
+    }
+}
+
+/// A write guard, which allows updating the RcuRing.
+pub struct WriteGuard<'a> {
+    _mutex_guard: MutexGuard<'a>,
+    /// The [`DataSlotState`] of the current slot used for readers.
+    current_data_slot_state: DataSlotState<'a>,
+    /// The [`AtomicU32`] which holds the index of the data-slot.
+    current_data_slot_idx: &'static AtomicU32,
+    /// The index of the slot we are writing to.
+    next_data_slot_idx: u32,
+    /// The [`DataSlotState`] of the slot we are writing to.
+    next_data_slot_state: DataSlotState<'a>,
+    /// The data of the slot we are writing to.
+    data: &'a mut [u8],
+}
+
+impl WriteGuard<'_> {
+    /// Returns a mutable pointer to the data in the slot we are writing to.
+    ///
+    /// This is guaranteed to be at least 8-byte aligned.
+    pub fn data_mut(&mut self) -> &mut [u8] {
+        self.data
+    }
+
+    /// The current index up-to-date readers will see.
+    pub fn current_data_slot_idx(&self) -> usize {
+        self.current_data_slot_idx.load(Ordering::Relaxed) as usize
+    }
+
+    /// Push an update to the RcuRing.
+    ///
+    /// You should not use this guard after calling this function.
+    pub fn push_update(&mut self) {
+        self.data = &mut [];
+        self.current_data_slot_state.mark_old();
+        self.next_data_slot_state.clear_old();
+        self.current_data_slot_idx
+            .store(self.next_data_slot_idx, Ordering::Release);
+    }
+}
+
+/// A RCU (read-copy-update) Ring.
+///
+/// This type is backed by a single contiguous byte buffer and allows multiple readers to read a value
+/// and a single writer to concurrently be writing data, which can then be atomically flushed to the
+/// ring for new readers to see.
+///
+/*
+Current format:
+
+    Header:
+        writer_mutex: (4 bytes)
+        current_data_slot_idx: (4 bytes)
+    Ring (data_slots_ring_len amount):
+        data_slot_state: (4 bytes)
+        last_op: (4 bytes)
+        data: (data_len bytes)
+ */
+pub struct RcuRing {
+    /// The length of the data in a single data-slot.
+    data_len: usize,
+    /// The buffer which holds all slots.
+    buffer: *mut u8,
+    /// A mutex for a writer.
+    writer_mutex: Mutex<'static>,
+    /// The index of the current slot for readers.
+    current_data_slot_idx: &'static AtomicU32,
+    /// The amount of data-slots.
+    data_slots_ring_len: usize,
+}
+
+// We have internal synchronisation to make this safe.
+unsafe impl Send for RcuRing {}
+unsafe impl Sync for RcuRing {}
+
+impl RcuRing {
+    /// Creates a new [`RcuRing`].
+    ///
+    /// `data_slots_ring_len` must be at least 2.
+    ///
+    /// # Safety
+    ///
+    /// - `buffer` must be 8-byte aligned and have no other code with any references to it (multiple instances of [`RcuRing`] is ok).
+    /// - `buffer` must have at least [`required_len`] bytes.
+    /// - `buffer` must be fully zeroed if this is the first instance, future instances can use the same
+    ///   buffer.
+    /// - `data_len` must be a multiple of 8.
+    pub unsafe fn new_from_ptr(
+        buffer: *mut u8,
+        data_len: usize,
+        data_slots_ring_len: usize,
+    ) -> Self {
+        // Make sure buffer is 8-byte aligned and data_len is a multiple of 8.
+        assert_eq!(buffer.addr() & 7, 0);
+        assert_eq!(data_len & 7, 0);
+        assert!(data_slots_ring_len > 1);
+
+        unsafe {
+            let writer_mutex_au32 = atomic_u32_from_u8_ptr(buffer);
+            let current_data_slot_idx = atomic_u32_from_u8_ptr(buffer.add(4));
+
+            Self {
+                data_len,
+                buffer,
+                writer_mutex: Mutex::new(writer_mutex_au32),
+                current_data_slot_idx,
+                data_slots_ring_len,
+            }
+        }
+    }
+
+    /// Start a new reader, returning a guard that prevents any writers from mutating the slot
+    /// the reader is pointing to.
+    ///
+    /// This could lead to a deadlock if a read handle is held, and you try to start a writer.
+    pub fn start_read(&self) -> DataHandle<'_> {
+        loop {
+            // Load the current index with an `Acquire` so we load all the writers writes.
+            let current_idx = self.current_data_slot_idx.load(Ordering::Acquire) as usize;
+
+            let data_slot_ptr = self.data_slot_ptr(current_idx);
+
+            let data_slot_state = unsafe { DataSlotState::from_u8_ptr(data_slot_ptr) };
+
+            // Try to add a reader to the state, continuing if it has been marked as old.
+            if !data_slot_state.check_add_reader() {
+                std::hint::spin_loop();
+                continue;
+            }
+
+            // Get the data slice.
+            // Safety:
+            //     - the ptr is valid as that is a requirement for `RcuRing`
+            //     - no writer will be writing to this slot as we have added a read to the slot state.
+            let data =
+                unsafe { std::slice::from_raw_parts(data_slot_ptr.add(8).cast(), self.data_len) };
+
+            return DataHandle {
+                data_slot_state,
+                data,
+            };
+        }
+    }
+
+    /// Start a writer to this RCU.
+    ///
+    /// Only 1 writer can exist at a time, this is enforced in the ring, if you hold a write and try to
+    /// start another it will block the thread.
+    ///
+    /// - `current_op` is a user-defined value, that you can use with `wait_for_all_readers`
+    /// - `wait_for_all_readers` is a function that returns a `bool`, it accepts the `op` of the writer
+    ///   which wrote to the _previous_ slot (the `current_op` of the last write operation).
+    ///
+    /// If `wait_for_all_readers` is `true` this will wait for all readers to be updated to the latest data slot,
+    /// if it is `false` we will only wait for the next slot that we want to write to be free of readers.
+    pub fn start_write(
+        &self,
+        current_op: u32,
+        wait_for_all_readers: impl FnOnce(u32) -> bool,
+    ) -> WriteGuard<'_> {
+        let _mutex_guard = self.writer_mutex.lock();
+
+        // Get the current reader slot.
+        let current_idx = self.current_data_slot_idx.load(Ordering::Acquire) as usize;
+        let current_data_slot_ptr = self.data_slot_ptr(current_idx);
+        let current_data_slot_state = unsafe { DataSlotState::from_u8_ptr(current_data_slot_ptr) };
+
+        // Get the operation of the last writer.
+        let last_op = unsafe { current_data_slot_ptr.add(4).cast::<u32>().read() };
+
+        // Get the data in the current reader.
+        let current_data =
+            unsafe { std::slice::from_raw_parts(current_data_slot_ptr.add(8), self.data_len) };
+
+        // Wait for the next slot or for all readers to be at the current slot.
+        let next_idx = if wait_for_all_readers(last_op) {
+            self.wait_for_all_readers(current_idx)
+        } else {
+            self.wait_for_next_free_slot(current_idx)
+        };
+
+        // Get the ptr to the next slot.
+        let data_slot_ptr = self.data_slot_ptr(next_idx);
+
+        // Write our current_op to it.
+        unsafe { data_slot_ptr.add(4).cast::<u32>().write(current_op) };
+
+        let next_data_slot_state = unsafe { DataSlotState::from_u8_ptr(data_slot_ptr) };
+
+        // Get a mutable reference to the data we can edit.
+        let data = unsafe { std::slice::from_raw_parts_mut(data_slot_ptr.add(8), self.data_len) };
+
+        // Update it with the data currently being read.
+        data.copy_from_slice(current_data);
+
+        WriteGuard {
+            _mutex_guard,
+            current_data_slot_state,
+            current_data_slot_idx: self.current_data_slot_idx,
+            next_data_slot_idx: next_idx as u32,
+            next_data_slot_state,
+            data,
+        }
+    }
+
+    /// Waits for the next reader slot to be have no readers.
+    fn wait_for_next_free_slot(&self, current_idx: usize) -> usize {
+        let next_free_slot = (current_idx + 1) % self.data_slots_ring_len;
+        let data_slot_ptr = self.data_slot_ptr(next_free_slot);
+
+        let data_slot_state = unsafe { DataSlotState::from_u8_ptr(data_slot_ptr) };
+
+        data_slot_state.wait_for_readers();
+
+        next_free_slot
+    }
+
+    /// Waits for all slots apart from `current_idx` to have no readers.
+    ///
+    /// This can be used to ensure all readers have updated to the new value.
+    pub fn wait_for_all_readers(&self, current_idx: usize) -> usize {
+        for i in 1..self.data_slots_ring_len {
+            let data_slot_ptr = self.data_slot_ptr((current_idx + i) % self.data_slots_ring_len);
+
+            let data_slot_state = unsafe { DataSlotState::from_u8_ptr(data_slot_ptr) };
+
+            data_slot_state.wait_for_readers();
+        }
+
+        (current_idx + 1) % self.data_slots_ring_len
+    }
+
+    /// Returns a ptr to the start of the data slot at the given index.
+    fn data_slot_ptr(&self, idx: usize) -> *mut u8 {
+        let mdata_slot_ptr_offset = HEADER_LEN + data_slot_len(self.data_len) * idx;
+
+        unsafe { self.buffer.add(mdata_slot_ptr_offset) }
+    }
+}
+
+/// Returns the length of a data slot.
+const fn data_slot_len(data_len: usize) -> usize {
+    8 + data_len
+}
+
+/// Returns the length the byte buffer needs to be for the given parameters.
+pub const fn required_len(data_len: usize, data_slot_ring_len: usize) -> usize {
+    8 + data_slot_len(data_len) * data_slot_ring_len
+}
+
+unsafe fn atomic_u32_from_u8_ptr(ptr: *mut u8) -> &'static AtomicU32 {
+    let ptr = ptr.cast::<u32>();
+
+    assert!(ptr.cast::<AtomicU32>().is_aligned());
+
+    unsafe { AtomicU32::from_ptr(ptr) }
+}

--- a/storage/linear-tape/rcu-ring/src/mutex.rs
+++ b/storage/linear-tape/rcu-ring/src/mutex.rs
@@ -1,0 +1,64 @@
+use std::sync::atomic::{AtomicU32, Ordering};
+
+use crate::atomic_wait::{wait, wake_one};
+
+/// A mutex based on: https://marabos.nl/atomics/building-locks.html#mutex without any tied data.
+pub struct Mutex<'a> {
+    /// 0: unlocked
+    /// 1: locked, no other threads waiting
+    /// 2: locked, other threads waiting
+    state: &'a AtomicU32,
+}
+
+impl<'a> Mutex<'a> {
+    /// Creates a new mutex from a reference to an [`AtomicU32`].
+    pub fn new(state: &'a AtomicU32) -> Self {
+        Self { state }
+    }
+
+    /// lock the mutex, returning a [`MutexGuard`]
+    pub fn lock(&self) -> MutexGuard<'_> {
+        if self
+            .state
+            .compare_exchange(0, 1, Ordering::Acquire, Ordering::Relaxed)
+            .is_err()
+        {
+            // The lock was already locked. :(
+            lock_contended(self.state);
+        }
+        MutexGuard { mutex: self }
+    }
+}
+
+fn lock_contended(state: &AtomicU32) {
+    let mut spin_count = 0;
+
+    while state.load(Ordering::Relaxed) == 1 && spin_count < 100 {
+        spin_count += 1;
+        std::hint::spin_loop();
+    }
+
+    if state
+        .compare_exchange(0, 1, Ordering::Acquire, Ordering::Relaxed)
+        .is_ok()
+    {
+        return;
+    }
+
+    while state.swap(2, Ordering::Acquire) != 0 {
+        wait(state, 2);
+    }
+}
+
+/// A mutex guard that drops the lock when dropped.
+pub struct MutexGuard<'a> {
+    mutex: &'a Mutex<'a>,
+}
+
+impl Drop for MutexGuard<'_> {
+    fn drop(&mut self) {
+        if self.mutex.state.swap(0, Ordering::Release) == 2 {
+            wake_one(self.mutex.state);
+        }
+    }
+}

--- a/storage/linear-tape/rcu-ring/src/state.rs
+++ b/storage/linear-tape/rcu-ring/src/state.rs
@@ -1,0 +1,115 @@
+use std::sync::atomic::{fence, AtomicU32, Ordering};
+
+use crate::atomic_wait::{wait, wake_all};
+
+/// The state of a data-slot.
+///
+/// Tracks the number of readers and if the data has been marked as old.
+pub(crate) struct DataSlotState<'a>(&'a AtomicU32);
+
+/// A bit-flag for if the data is old.
+const DATA_SLOT_OLD: u32 = 1 << 31;
+/// A bit-flag for if a writer is waiting.
+const WRITER_WAITING: u32 = 1 << 30;
+
+/// The mask to `&` with to get the amount of readers using this slot.
+const READER_COUNT_MASK: u32 = !(DATA_SLOT_OLD | WRITER_WAITING);
+
+impl DataSlotState<'_> {
+    /// Creates a new [`DataSlotState`] from a ptr.
+    ///
+    /// # Safety
+    ///
+    /// see: [`AtomicU32::from_ptr`]
+    pub(crate) unsafe fn from_u8_ptr(ptr: *mut u8) -> Self {
+        let ptr = ptr.cast::<u32>();
+
+        assert!(ptr.cast::<AtomicU32>().is_aligned());
+
+        // Safety: the callers must ensure the requirements, hence this function is `unsafe`.
+        unsafe { Self(AtomicU32::from_ptr(ptr)) }
+    }
+
+    /// Add a new reader to the count, returning if a reader has been added ([`true`]) or ([`false`])
+    /// if the data-slot is old and the pointer to the slot should be re-read.
+    pub(crate) fn check_add_reader(&self) -> bool {
+        // We can use a `Relaxed` ordering here as we `Acquire` in the next call
+        let mut state = self.0.load(Ordering::Relaxed);
+
+        loop {
+            // Check if the data is old.
+            if state & DATA_SLOT_OLD == DATA_SLOT_OLD {
+                return false;
+            }
+
+            // Check we have room for another reader.
+            if state & READER_COUNT_MASK == READER_COUNT_MASK - 1 {
+                panic!("Too many readers");
+            }
+
+            // We use `Acquire` here as I think it might be possible for a thread to see
+            // the old data-slot ptr that points to the same slot as a writer just updated to. This
+            // `Acquire` then synchronizes with the `Release` in clear old.
+            match self.0.compare_exchange_weak(
+                state,
+                state + 1,
+                Ordering::Acquire,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => return true,
+                Err(new) => {
+                    state = new;
+                    std::hint::spin_loop();
+                }
+            }
+        }
+    }
+
+    /// Mark this data-slot as old.
+    pub(crate) fn mark_old(&self) {
+        // Relaxed as we don't need any ordering requirements here.
+        self.0.fetch_or(DATA_SLOT_OLD, Ordering::Relaxed);
+    }
+
+    /// Clear the old mark for this data-slot, returning the state to its default.
+    pub(crate) fn clear_old(&self) {
+        // Release for the reason in `check_add_reader`
+        self.0.store(0, Ordering::Release);
+    }
+
+    /// Waits for all the readers to finish their read operation and drop their handle to this
+    /// data-slot.
+    pub(crate) fn wait_for_readers(&self) {
+        let mut i = 0;
+        let mut old = self.0.fetch_or(WRITER_WAITING, Ordering::Relaxed);
+        loop {
+            if old & READER_COUNT_MASK == 0 {
+                // We have to use `Acquire` here to synchronise with the readers `Release` when dropping
+                // the count to prevent writing to data they are reading.
+                // We use a `fence` instead of using `Acquire` for every load for efficiency.
+                fence(Ordering::Acquire);
+                return;
+            }
+
+            if i > 100 {
+                wait(self.0, old | WRITER_WAITING);
+            } else {
+                std::hint::spin_loop();
+            }
+
+            i += 1;
+            old = self.0.load(Ordering::Relaxed);
+        }
+    }
+
+    /// Drop the readers count by 1.
+    pub fn remove_reader(&self) {
+        // `Release` ordering so this can't be reordered to before a data access.
+        let old = self.0.fetch_sub(1, Ordering::Release);
+
+        // if this is that last reader and a writer is waiting, wake
+        if old & READER_COUNT_MASK == 1 && old & WRITER_WAITING == WRITER_WAITING {
+            wake_all(self.0)
+        }
+    }
+}

--- a/storage/linear-tape/src/blob_tape.rs
+++ b/storage/linear-tape/src/blob_tape.rs
@@ -1,0 +1,188 @@
+use std::{cmp::max, io, ops::Range};
+
+use crate::unsafe_tape::UnsafeTape;
+
+/// A trait for a type that can be turned into a blob of data.
+pub trait Blob {
+    /// The length of the bytes.
+    fn len(&self) -> usize;
+
+    /// Writes self to `buf`.
+    ///
+    /// `buf` will have a length of exactly [`Self::len`].
+    fn write(&self, buf: &mut [u8]);
+}
+
+impl Blob for [u8] {
+    fn len(&self) -> usize {
+        <[u8]>::len(self)
+    }
+
+    fn write(&self, buf: &mut [u8]) {
+        buf.copy_from_slice(self);
+    }
+}
+
+/// A blob tape appender.
+pub struct BlobTapeAppender<'a> {
+    /// The current [`UnsafeTape`] which is stored in the database object and may be being used
+    /// by readers.
+    pub(crate) backing_file: &'a UnsafeTape,
+    /// A mutable reference to a slot we can put a new instance of a tape in, if it needed a resize.
+    pub(crate) resized_backing_file: &'a mut Option<UnsafeTape>,
+    /// The minimum amount to resize by.
+    pub(crate) min_resize: u64,
+    /// The current amount of bytes used in the database, that up-to-date readers will be seeing.
+    pub(crate) current_used_bytes: usize,
+    /// The amount of bytes that have been added to this tape.
+    pub(crate) bytes_added: &'a mut usize,
+}
+
+impl BlobTapeAppender<'_> {
+    /// Returns the backing tape handle that should be used for all operations in this writer
+    fn backing_file(&self) -> &UnsafeTape {
+        // If we have a resized tape then we need to use that, otherwise we can use the tape currently
+        // in the database object.
+        self.resized_backing_file
+            .as_ref()
+            .unwrap_or(self.backing_file)
+    }
+
+    /// Resize the tape to fit adding data of the given length.
+    ///
+    /// If [`None`] it will resize to the size needed to see all data in the database.
+    fn resize_to_fit_extra(&mut self, needed_bytes: Option<usize>) -> io::Result<()> {
+        // If we actually need to fit more data, make sure we don't do a resize less than `min_resize`, otherwise just accept
+        // whatever the length of the file is.
+        let extra_bytes =
+            needed_bytes.map_or(0, |needed_bytes| max(needed_bytes as u64, self.min_resize));
+
+        let new_size = (self.current_used_bytes + *self.bytes_added) as u64 + extra_bytes;
+
+        // If we have already created a new handle just resize that - we are the only place with a handle to it.
+        if let Some(resized_backing_file) = self.resized_backing_file.as_mut() {
+            resized_backing_file.resize_to_bytes(new_size)?;
+            return Ok(());
+        }
+
+        // Otherwise we need to make a new handle as other places could be reading from the handle.
+        *self.resized_backing_file = Some(self.backing_file.resize_to_bytes_copy(new_size)?);
+
+        Ok(())
+    }
+
+    /// Attempt to get a range of bytes from the database.
+    ///
+    /// returns [`None`] if the range covers bytes outside the tape.
+    ///
+    /// # Errors
+    ///
+    /// This will error if a resize is needed and a resize attempt failed.
+    pub fn try_get_range(&mut self, range: Range<usize>) -> io::Result<Option<&[u8]>> {
+        if self.current_used_bytes + *self.bytes_added < range.start
+            || self.current_used_bytes + *self.bytes_added < range.end
+        {
+            return Ok(None);
+        }
+
+        if self.backing_file().map_size() < self.current_used_bytes + *self.bytes_added {
+            self.resize_to_fit_extra(None)?;
+        }
+
+        // Safety: This is synchronised by the metadata, and we just checked the slice is in range above.
+        unsafe { Ok(Some(self.backing_file().range(range))) }
+    }
+
+    /// Push some bytes onto the tape.
+    ///
+    /// On success this returns the index of the first added byte.
+    ///
+    /// # Errors
+    ///
+    /// This will error if a resize is needed and the resize fails.
+    pub fn push_bytes<B: Blob + ?Sized>(&mut self, blob: &B) -> io::Result<usize> {
+        let blob_len = blob.len();
+        if self.backing_file().map_size() < self.current_used_bytes + *self.bytes_added + blob_len {
+            self.resize_to_fit_extra(Some(blob_len))?;
+        }
+
+        let start = self.current_used_bytes + *self.bytes_added;
+        let end = start + blob_len;
+
+        // Safety: we just checked this slice is in range.
+        let buf = unsafe { self.backing_file().range_mut(start..end) };
+
+        blob.write(buf);
+
+        *self.bytes_added += blob_len;
+
+        Ok(start)
+    }
+
+    /// Cancel any current changes to this specific tape.
+    pub fn cancel(&mut self) {
+        *self.bytes_added = 0;
+    }
+}
+
+/// A popper for a blob tape database.
+pub struct BlobTapePopper<'a> {
+    #[expect(dead_code)]
+    /// The backing tape (unused currently, but this type could access data in the future?)
+    pub(crate) backing_file: &'a UnsafeTape,
+    /// A mutable reference to the new value for the amount of used bytes in this tape.
+    pub(crate) current_used_bytes: &'a mut usize,
+}
+
+impl BlobTapePopper<'_> {
+    /// Set the length of the tape to the given length.
+    ///
+    /// # Panics
+    ///
+    /// This will panic if you give a value higher than the last recorded one.
+    /// So once you call this function with a value, if you call it again it must be with a value
+    /// less than or equal to.
+    pub fn set_new_len(&mut self, new_len: usize) {
+        assert!(new_len <= *self.current_used_bytes);
+        *self.current_used_bytes = new_len;
+    }
+}
+
+/// A reader for a blob tape.
+pub struct BlobTapeReader<'a> {
+    /// The backing tape file.
+    pub(crate) backing_file: &'a UnsafeTape,
+    /// The amount of bytes we are allowed to read.
+    pub(crate) used_bytes: usize,
+}
+
+impl BlobTapeReader<'_> {
+    /// The current length of the tape, from this readers' perspective.
+    pub fn len(&self) -> usize {
+        self.used_bytes
+    }
+
+    /// Try to get a slice from the database.
+    ///
+    /// Returns [`None`] if the range covers more bytes than we can read.
+    pub fn try_get_range(&self, range: Range<usize>) -> Option<&[u8]> {
+        if self.used_bytes < range.start || self.used_bytes < range.end {
+            return None;
+        }
+
+        // Safety: This is synchronised by the metadata, and we just checked the slice is in range above.
+        unsafe { Some(self.backing_file.range(range)) }
+    }
+
+    /// Try to get a slice from the database.
+    ///
+    /// Returns [`None`] if  [`Self::len`] < `start_idx` + `len`
+    pub fn try_get_slice(&self, start_idx: usize, len: usize) -> Option<&[u8]> {
+        if self.used_bytes < start_idx + len {
+            return None;
+        }
+
+        // Safety: This is synchronised by the metadata, and we just checked the slice is in range above.
+        unsafe { Some(self.backing_file.slice(start_idx, len)) }
+    }
+}

--- a/storage/linear-tape/src/fixed_size.rs
+++ b/storage/linear-tape/src/fixed_size.rs
@@ -1,0 +1,191 @@
+use std::{cmp::max, io, marker::PhantomData, ops::Range};
+
+use crate::unsafe_tape::UnsafeTape;
+
+/// A type that can be inserted into a fixed-sized tape.
+pub trait Entry: Sized {
+    /// The size of this type on disk.
+    const SIZE: usize;
+
+    /// Write the item to the byte slice provided, this slice will be the exact length of [`Self::SIZE`].
+    ///
+    /// There are no guarantees made on the contents of the bytes before being written to or the byte's alignment.
+    fn write(&self, to: &mut [u8]);
+
+    /// Read an item from a byte slice, this slice will be the exact length of [`Self::SIZE`].
+    ///
+    /// There are no guarantees made on the byte's alignment.
+    fn read(from: &[u8]) -> Self;
+
+    /// Write a batch of items to the slice provided, this slice will be the exact length of [`Self::SIZE`] * len.
+    ///
+    /// There are no guarantees made on the contents of the bytes before being written to or the byte's alignment.
+    fn batch_write(from: &[Self], mut to: &mut [u8]) {
+        for this in from {
+            this.write(&mut to[..Self::SIZE]);
+            to = &mut to[Self::SIZE..];
+        }
+    }
+}
+
+/// A reader for a fixed-sized tape.
+pub struct FixedSizedTapeReader<'a, E: Entry> {
+    /// The backing tape file.
+    pub(crate) backing_file: &'a UnsafeTape,
+    /// The amount of fixed-sized objects in the tape.
+    pub(crate) len: usize,
+    pub(crate) phantom: PhantomData<E>,
+}
+
+impl<E: Entry> FixedSizedTapeReader<'_, E> {
+    /// Returns the amount of entries in the tape.
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Try to get a value from the tape.
+    ///
+    /// returns [`None`] if the index is out of range.
+    pub fn try_get(&self, i: usize) -> Option<E> {
+        if self.len <= i {
+            return None;
+        }
+
+        // Safety: we checked the index is in range above.
+        unsafe { Some(E::read(self.backing_file.range(entry_byte_range::<E>(i)))) }
+    }
+}
+
+/// An appender for a fixed-sized tape.
+pub struct FixedSizedTapeAppender<'a, E: Entry> {
+    /// The backing tape file that all up-to-date readers see.
+    pub(crate) backing_file: &'a UnsafeTape,
+    /// A mutable reference to a slot we can put a new instance of a tape in, if it needed a resize.
+    pub(crate) resized_backing_file: &'a mut Option<UnsafeTape>,
+
+    /// The minimum amount to resize by.
+    pub(crate) min_resize: u64,
+    /// The current amount of bytes used in the database, that up-to-date readers will be seeing.
+    pub(crate) current_used_bytes: usize,
+    /// The amount of bytes that have been added to this tape.
+    pub(crate) bytes_added: &'a mut usize,
+
+    pub(crate) phantom: PhantomData<E>,
+}
+
+impl<E: Entry> FixedSizedTapeAppender<'_, E> {
+    /// Returns the backing tape handle that should be used for all operations in this writer
+    fn backing_file(&self) -> &UnsafeTape {
+        // If we have a resized tape then we need to use that, otherwise we can use the tape currently
+        // in the database object.
+        self.resized_backing_file
+            .as_ref()
+            .unwrap_or(self.backing_file)
+    }
+
+    /// Resize the tape to fit adding data of the given length.
+    ///
+    /// If [`None`] it will resize to the size needed to see all data in the database.
+    fn resize_to_fit_extra(&mut self, needed_bytes: Option<usize>) -> io::Result<()> {
+        // If we actually need to fit more data, make sure we don't do a resize less than `min_resize`, otherwise just accept
+        // whatever the length of the file is.
+        let extra_bytes =
+            needed_bytes.map_or(0, |needed_bytes| max(needed_bytes as u64, self.min_resize));
+
+        let new_size = (self.current_used_bytes + *self.bytes_added) as u64 + extra_bytes;
+
+        if let Some(resized_backing_file) = self.resized_backing_file.as_mut() {
+            resized_backing_file.resize_to_bytes(new_size)?;
+            return Ok(());
+        }
+
+        *self.resized_backing_file = Some(self.backing_file.resize_to_bytes_copy(new_size)?);
+
+        Ok(())
+    }
+
+    /// Try to get a value from the tape.
+    ///
+    /// returns [`None`] if the index is out of range.
+    ///
+    /// # Errors
+    ///
+    /// This will error if a resize attempt failed.
+    pub fn try_get(&mut self, i: usize) -> io::Result<Option<E>> {
+        if self.len() <= i {
+            return Ok(None);
+        }
+
+        if self.backing_file().map_size() < self.current_used_bytes + *self.bytes_added {
+            self.resize_to_fit_extra(None)?;
+        }
+
+        // Safety: we just checked we have enough bytes above.
+        unsafe {
+            Ok(Some(E::read(
+                self.backing_file().range(entry_byte_range::<E>(i)),
+            )))
+        }
+    }
+
+    /// Returns the length of the tape including data written in this transaction.
+    pub fn len(&self) -> usize {
+        (self.current_used_bytes + *self.bytes_added) / E::SIZE
+    }
+
+    /// Push some entries onto the tape.
+    ///
+    /// # Errors
+    ///
+    /// This will error if a resize is needed and a resize attempt failed.
+    pub fn push_entries(&mut self, entries: &[E]) -> io::Result<()> {
+        let bytes_needed = entries.len() * E::SIZE;
+
+        if self.backing_file().map_size()
+            < bytes_needed + self.current_used_bytes + *self.bytes_added
+        {
+            self.resize_to_fit_extra(Some(bytes_needed))?;
+        }
+
+        let start = self.current_used_bytes + *self.bytes_added;
+        let end = start + bytes_needed;
+
+        // Safety: We take a mutable reference to self and the range this writer can write in is synchronised by the
+        // metadata.
+        let buf = unsafe { self.backing_file().range_mut(start..end) };
+
+        E::batch_write(entries, buf);
+
+        *self.bytes_added += bytes_needed;
+
+        Ok(())
+    }
+}
+
+/// A fixed-sized tape popper.
+pub struct FixedSizedTapePopper<'a, E: Entry> {
+    #[expect(dead_code)]
+    /// The backing tape (unused currently, but this type could access data in the future?)
+    pub(crate) backing_file: &'a UnsafeTape,
+    /// A mutable reference to the new value for the amount of used bytes in this tape.
+    pub(crate) current_used_bytes: &'a mut usize,
+    pub(crate) phantom: PhantomData<E>,
+}
+
+impl<E: Entry> FixedSizedTapePopper<'_, E> {
+    /// Pop some entries from the tape.
+    ///
+    /// # Panics
+    ///
+    /// This will panic if more entries are popped than are in the tape.
+    pub fn pop_entries(&mut self, amt: usize) {
+        *self.current_used_bytes = self.current_used_bytes.checked_sub(amt * E::SIZE).unwrap();
+    }
+}
+
+const fn entry_byte_range<E: Entry>(i: usize) -> Range<usize> {
+    let start = i * E::SIZE;
+    let end = start + E::SIZE;
+
+    start..end
+}

--- a/storage/linear-tape/src/lib.rs
+++ b/storage/linear-tape/src/lib.rs
@@ -1,0 +1,568 @@
+//! # Linear Tapes
+//!
+//! ## Overview
+//!
+//! This crate implements a database system that is specialised for storing data in contiguous tapes,
+//! and appending/popping data to/from them.
+//!
+//! [`LinearTapes`] supports atomically updating multiple tapes at a time with concurrent readers. Write
+//! operations have been split into two separate operations: [`Popper`] and [`Appender`], this means you
+//! cannot pop and append to different tapes in the same operation.
+//!
+//! ## Tapes
+//!
+//! There are two type of tapes, blob and fixed size. You can have a [`LinearTapes`] database made of a mix
+//! of them.
+//!
+//! - fixed sized tapes store fixed sized values and allows direct indexing to get values.
+//! - blob tapes store raw bytes, you must store the index the values are at to retrieve them.
+//!
+//! # Safety
+//!
+//! All databases are backed by a memory map, which practically can not be worked on in Rust in completely safe code.
+//! So you must make sure the file is not edited in a way that is not allowed by this crate.
+//!
+#![expect(clippy::missing_const_for_fn, clippy::len_without_is_empty)]
+#[cfg(test)]
+use tempfile as _;
+
+use std::{
+    collections::HashMap,
+    fs::create_dir_all,
+    io,
+    path::{Path, PathBuf},
+    ptr,
+    sync::atomic::{fence, AtomicBool, AtomicPtr, Ordering},
+};
+
+mod blob_tape;
+mod fixed_size;
+mod metadata;
+mod unsafe_tape;
+
+pub use blob_tape::{Blob, BlobTapeAppender, BlobTapePopper, BlobTapeReader};
+pub use fixed_size::{Entry, FixedSizedTapeAppender, FixedSizedTapePopper, FixedSizedTapeReader};
+use metadata::{Metadata, APPEND_OP, POP_OP};
+use unsafe_tape::UnsafeTape;
+
+/// The length of the RCU ring for the metadata.
+/// More means slow read operations won't slow writes as much, but more slots will need to be checked
+/// for no readers when it is required that all readers have seen that latest value. Also, more means
+/// more copies of the metadata.
+const METADATA_RING_LEN: usize = 8;
+
+/// Advice to give the OS when opening the memory map file.
+#[derive(Copy, Clone)]
+pub enum Advice {
+    /// [`memmap2::Advice::Normal`]
+    Normal,
+    /// [`memmap2::Advice::Random`]
+    Random,
+    /// [`memmap2::Advice::Sequential`]
+    Sequential,
+}
+
+impl Advice {
+    const fn to_memmap2_advice(self) -> memmap2::Advice {
+        match self {
+            Self::Normal => memmap2::Advice::Normal,
+            Self::Random => memmap2::Advice::Random,
+            Self::Sequential => memmap2::Advice::Sequential,
+        }
+    }
+}
+
+/// The method to use when flushing data.
+#[derive(Copy, Clone)]
+pub enum Flush {
+    /// Function will block until data is persisted.
+    Sync,
+    /// The flush will be queued, this could leave the database in an invalid state if not all data
+    /// is persisted.
+    Async,
+    /// No explicit synchronisation will be done, the OS has complete control of when data will be persisted.
+    NoSync,
+}
+
+/// A database resize is needed as the underlying data has grown beyond it.
+#[derive(Copy, Clone, Debug)]
+pub struct ResizeNeeded;
+
+/// A tape in the database.
+pub struct Tapes {
+    /// The name of the tape, must be unique.
+    pub name: &'static str,
+    /// The path to use for the tape, if [`None`] will use the default of being under a `tapes` directory
+    /// in the metadata directory.
+    pub path: Option<PathBuf>,
+    /// The advice to open on the database with.
+    pub advice: Advice,
+}
+
+/// Linear tapes database.
+///
+/// A linear tape stores data contiguously in the order it is inserted.
+pub struct LinearTapes {
+    /// The metadata of this database, tracks its state and ensure atomic updates.
+    metadata: Metadata,
+    /// A map of a tape's name to its index in the list of tapes.
+    tapes_to_index: HashMap<&'static str, usize>,
+
+    /// A list of pointers to potentially old tape instances that have not been dropped yet as they could
+    /// still have readers.
+    old_tapes: Box<[AtomicPtr<UnsafeTape>]>,
+    /// An atomic bool for if we have any old tapes that need to be dropped.
+    old_tapes_need_flush: AtomicBool,
+
+    /// The list of current tape instances.
+    tapes: Box<[AtomicPtr<UnsafeTape>]>,
+
+    /// The minimum step to resize a tape by.
+    min_resize: u64,
+}
+
+impl Drop for LinearTapes {
+    fn drop(&mut self) {
+        // Safety: this has been dropped so we know there are no readers pointing to this instance.
+        unsafe { self.flush_old_tapes() };
+        for tape in &self.tapes {
+            // Safety: same as above.
+            unsafe {
+                drop(Box::from_raw(tape.load(Ordering::Acquire)));
+            }
+        }
+    }
+}
+
+impl LinearTapes {
+    /// Open an [`LinearTapes`] database.
+    ///
+    /// # Safety
+    ///
+    /// This is marked unsafe as modifications to the underlying file can lead to UB.
+    /// You must ensure across all processes that no unsafe accesses are done.
+    pub unsafe fn new<P: AsRef<Path>>(
+        mut tapes: Vec<Tapes>,
+        metadata_path: P,
+        min_resize: u64,
+    ) -> Result<Self, io::Error> {
+        create_dir_all(metadata_path.as_ref())?;
+
+        tapes.sort_unstable_by_key(|tape| tape.name);
+        // Safety: the requirement is on the caller to uphold the invariants.
+        let metadata = unsafe {
+            Metadata::open(
+                metadata_path.as_ref().join("metadata.tapes"),
+                tapes.len(),
+                METADATA_RING_LEN,
+            )?
+        };
+
+        let default_tape_path = metadata_path.as_ref().join("tapes");
+        create_dir_all(default_tape_path.as_path())?;
+
+        let tapes_to_index = tapes.iter().enumerate().map(|(i, t)| (t.name, i)).collect();
+
+        let (old_tapes, tapes) = tapes
+            .iter()
+            .map(|tape| {
+                let path = tape.path.as_ref().unwrap_or(&default_tape_path);
+
+                // Safety: the requirement is on the caller to uphold the invariants.
+                unsafe {
+                    let tape = Box::into_raw(Box::new(UnsafeTape::open(
+                        path.join(format!("{}.tape", tape.name)),
+                        tape.advice,
+                        min_resize,
+                    )?));
+
+                    Ok::<_, io::Error>((AtomicPtr::new(ptr::null_mut()), AtomicPtr::new(tape)))
+                }
+            })
+            .collect::<Result<(Vec<_>, Vec<_>), _>>()?;
+
+        Ok(Self {
+            tapes_to_index,
+            metadata,
+            old_tapes: old_tapes.into_boxed_slice(),
+            old_tapes_need_flush: AtomicBool::new(false),
+            min_resize,
+            tapes: tapes.into_boxed_slice(),
+        })
+    }
+
+    /// Flush old database tapes.
+    ///
+    /// # Safety
+    ///
+    /// It must be ensured no other thread is using these tapes.
+    unsafe fn flush_old_tapes(&self) {
+        for old_tape in &self.old_tapes {
+            let ptr = old_tape.swap(ptr::null_mut(), Ordering::Relaxed);
+            if ptr.is_null() {
+                continue;
+            }
+
+            // Make sure the allocations don't get reordered to after the pointer was written.
+            fence(Ordering::Acquire);
+            // Safety: the above fence means we will see the allocation and its on the caller of this
+            // function to ensure there are no users of this tape.
+            unsafe {
+                drop(Box::from_raw(ptr));
+            }
+        }
+    }
+
+    /// Start a new database appender.
+    ///
+    /// Only one write operation can be active at a given time, this will block if another write operation
+    /// is active util it is finished. Also after a pop operation the next appender must wait for all readers
+    /// to no longer be accessing the bytes in the range popped, so this thread will block waiting for readers
+    /// to not be accessing old state if it follows a pop.
+    ///
+    /// Once you have finished appending data to the tapes your changes must be commited with [`Appender::flush`].
+    pub fn appender(&self) -> Appender<'_> {
+        let meta_guard = self.metadata.start_write(APPEND_OP);
+
+        // Check if we need to drop an old tape handle.
+        // We can use `Relaxed` here as this will be synchronised with the writer mutex in the meta_guard.
+        if self
+            .old_tapes_need_flush
+            .compare_exchange(true, false, Ordering::Relaxed, Ordering::Relaxed)
+            .is_ok()
+        {
+            // wait for al readers to be on the current data slot, so we know they are not using the
+            // old tape pointer.
+            self.metadata
+                .wait_for_all_readers(meta_guard.current_data_slot_idx());
+            // Safety: we just check above for all readers to be updated.
+            unsafe { self.flush_old_tapes() };
+        }
+
+        Appender {
+            meta_guard,
+            tapes: self,
+            min_resize: self.min_resize,
+            added_bytes: vec![0; self.tapes.len()],
+            resized_tapes: (0..self.tapes.len()).map(|_| None).collect(),
+        }
+    }
+
+    /// Start a new database appender.
+    ///
+    /// Only one write operation can be active at a given time, this will block if another write operation
+    /// is active util it is finished.
+    ///
+    /// Once you have finished popping data from the tapes your changes must be commited with [`Popper::flush`]
+    pub fn popper(&self) -> Popper<'_> {
+        let meta_guard = self.metadata.start_write(POP_OP);
+
+        if self
+            .old_tapes_need_flush
+            .compare_exchange(true, false, Ordering::Relaxed, Ordering::Relaxed)
+            .is_ok()
+        {
+            self.metadata
+                .wait_for_all_readers(meta_guard.current_data_slot_idx());
+            // Safety: same as the appender.
+            unsafe { self.flush_old_tapes() };
+        }
+
+        Popper {
+            meta_guard,
+            tapes: self,
+        }
+    }
+
+    /// Start a database reader.
+    ///
+    /// # Errors
+    ///
+    /// This will error if the underlying data in any tape has outgrown our memory map, this can only
+    /// happen if another instance of [`LinearTapes`] has extended the file. If all writers and reader
+    /// go through the same [`LinearTapes`] this will never error.
+    ///
+    /// When this errors you will need to resize the tape with: (TODO: reader resizes (will require a specific function that takes the write lock.)
+    pub fn reader(&self) -> Result<Reader<'_>, ResizeNeeded> {
+        let meta_guard = self.metadata.start_read();
+
+        let loaded_tapes = self
+            .tapes
+            .iter()
+            .map(|tape_ptr| tape_ptr.load(Ordering::Relaxed).cast_const())
+            .collect::<Vec<_>>();
+        // Make sure the allocations don't get reordered to after the pointers were written.
+        fence(Ordering::Acquire);
+
+        for (i, tape) in loaded_tapes.iter().enumerate() {
+            // Safety: We are holding a reader guard so this will not be dropped.
+            let tape = unsafe { &**tape };
+
+            let bytes_used = meta_guard[i];
+
+            if tape.map_size() < bytes_used {
+                return Err(ResizeNeeded);
+            }
+        }
+
+        Ok(Reader {
+            meta_guard,
+            loaded_tapes,
+            tapes: self,
+        })
+    }
+}
+
+/// An appender for a [`LinearTapes`] database, allows atomically pushing data to multiple tapes.
+///
+/// To push data to a tape you must open an appender for that tape:
+/// - for fixed sized tapes: [`Appender::fixed_sized_tape_appender`]
+/// - for blob tapes: [`Appender::blob_tape_appender`]
+///
+/// Once finished changes must be commited with: [`Appender::flush`]
+pub struct Appender<'a> {
+    /// The metadata guard for this writer.
+    meta_guard: metadata::MetadataWriteGuard<'a>,
+    /// The tapes database.
+    tapes: &'a LinearTapes,
+    /// The minimum step to resize a tape by.
+    min_resize: u64,
+    /// A vec with the same length as the amount of tapes, representing the amount of bytes that have
+    /// been added to each.
+    added_bytes: Vec<usize>,
+    /// A vec with the same length as the amount of tapes, which holds new tapes handles that have been resized.
+    resized_tapes: Vec<Option<UnsafeTape>>,
+}
+
+impl Appender<'_> {
+    /// Opens a handle to append to a fixed-sized tape.
+    pub fn fixed_sized_tape_appender<'a, E: Entry>(
+        &'a mut self,
+        table_name: &'static str,
+    ) -> FixedSizedTapeAppender<'a, E> {
+        let i = *self
+            .tapes
+            .tapes_to_index
+            .get(table_name)
+            .expect("Tape was not specified when opening tapes");
+
+        let tape = &self.tapes.tapes[i];
+
+        FixedSizedTapeAppender {
+            // Safety: We are holding a write lock and only writers will drop tapes.
+            backing_file: unsafe { &*tape.load(Ordering::Acquire) },
+            resized_backing_file: &mut self.resized_tapes[i],
+            min_resize: self.min_resize,
+            phantom: Default::default(),
+            current_used_bytes: self.meta_guard.tables_len_mut()[i],
+            bytes_added: &mut self.added_bytes[i],
+        }
+    }
+
+    /// Opens a handle to append to a blob tape.
+    pub fn blob_tape_appender<'a>(&'a mut self, table_name: &'static str) -> BlobTapeAppender<'a> {
+        let i = *self
+            .tapes
+            .tapes_to_index
+            .get(table_name)
+            .expect("Tape was not specified when opening tapes");
+
+        let tape = &self.tapes.tapes[i];
+
+        BlobTapeAppender {
+            // Safety: We are holding a write lock and only writers will drop tapes.
+            backing_file: unsafe { &*tape.load(Ordering::Acquire) },
+            resized_backing_file: &mut self.resized_tapes[i],
+            min_resize: self.min_resize,
+            current_used_bytes: self.meta_guard.tables_len_mut()[i],
+            bytes_added: &mut self.added_bytes[i],
+        }
+    }
+
+    /// Flush the changes to the database.
+    ///
+    /// Using a [`Flush`] mode other than [`Flush::Sync`] can leave the database in an invalid state if a crash
+    /// happens before all changes are flushed to permanent storage.
+    pub fn flush(mut self, mode: Flush) -> io::Result<()> {
+        // First check if any resize happened.
+        let mut resize_happened = false;
+        for (i, resized_tape) in self.resized_tapes.iter_mut().enumerate() {
+            if let Some(resized_tape) = resized_tape.take() {
+                let resized_tape = Box::into_raw(Box::new(resized_tape));
+
+                // We use `Release` here to prevent the allocation above from being reordered after this store.
+                let old_tape = self.tapes.tapes[i].swap(resized_tape, Ordering::Release);
+                let null = self.tapes.old_tapes[i].swap(old_tape, Ordering::Relaxed);
+
+                // Can't happen, but make sure we don't leak any data.
+                assert!(null.is_null());
+
+                resize_happened = true;
+            }
+        }
+
+        if resize_happened {
+            // Tell the next write it needs to drop the old tape, this is synchronised with the write lock
+            // so `Relaxed` is fine.
+            self.tapes
+                .old_tapes_need_flush
+                .store(true, Ordering::Relaxed);
+        }
+
+        // flush each tapes changes to disk.
+        // `Acquire` so we don't see the pointer before the allocation is done.
+        match mode {
+            Flush::Sync => {
+                for (i, tape) in self.tapes.tapes.iter().enumerate() {
+                    if self.added_bytes[i] != 0 {
+                        // Safety: We are holding a write lock and only writers will drop tapes.
+                        unsafe { &*tape.load(Ordering::Acquire) }.flush_range(
+                            self.meta_guard.tables_len_mut()[i],
+                            self.added_bytes[i],
+                        )?;
+                    }
+                }
+            }
+            Flush::Async => {
+                for (i, tape) in self.tapes.tapes.iter().enumerate() {
+                    if self.added_bytes[i] != 0 {
+                        // Safety: We are holding a write lock and only writers will drop tapes.
+                        unsafe { &*tape.load(Ordering::Acquire) }.flush_range_async(
+                            self.meta_guard.tables_len_mut()[i],
+                            self.added_bytes[i],
+                        )?;
+                    }
+                }
+            }
+            Flush::NoSync => {}
+        }
+
+        // Updated the length of each table in the metadata.
+        for (len, added_bytes) in self
+            .meta_guard
+            .tables_len_mut()
+            .iter_mut()
+            .zip(&self.added_bytes)
+        {
+            *len += added_bytes;
+        }
+
+        // push the update for readers to see.
+        self.meta_guard.push_update(mode)
+    }
+}
+
+/// A popper for a [`LinearTapes`] database, allows atomically popping data from multiple tapes.
+///
+/// To pop data from a tape you must open a popper for that tape:
+/// - for fixed sized tapes: [`Popper::fixed_sized_tape_popper`]
+/// - for blob tapes: [`Popper::blob_tape_popper`]
+///
+/// Once finished changes must be commited with: [`Popper::flush`]
+pub struct Popper<'a> {
+    /// The metadata guard for this writer.
+    meta_guard: metadata::MetadataWriteGuard<'a>,
+    /// Tha tapes database.
+    tapes: &'a LinearTapes,
+}
+
+impl Popper<'_> {
+    /// Opens a handle to pop from a fixed-sized tape.
+    pub fn fixed_sized_tape_popper<'a, E: Entry>(
+        &'a mut self,
+        table_name: &'static str,
+    ) -> FixedSizedTapePopper<'a, E> {
+        let i = *self
+            .tapes
+            .tapes_to_index
+            .get(table_name)
+            .expect("Tape was not specified when opening tapes");
+
+        let tape = &self.tapes.tapes[i];
+
+        FixedSizedTapePopper {
+            // Safety: We are holding a write lock and only writers will drop tapes.
+            backing_file: unsafe { &*tape.load(Ordering::Acquire) },
+            phantom: Default::default(),
+            current_used_bytes: &mut self.meta_guard.tables_len_mut()[i],
+        }
+    }
+
+    /// Opens a handle to pop from a blob tape.
+    pub fn blob_tape_popper<'a>(&'a mut self, table_name: &'static str) -> BlobTapePopper<'a> {
+        let i = *self
+            .tapes
+            .tapes_to_index
+            .get(table_name)
+            .expect("Tape was not specified when opening tapes");
+
+        let tape = &self.tapes.tapes[i];
+
+        BlobTapePopper {
+            // Safety: We are holding a write lock and only writers will drop tapes.
+            backing_file: unsafe { &*tape.load(Ordering::Acquire) },
+            current_used_bytes: &mut self.meta_guard.tables_len_mut()[i],
+        }
+    }
+
+    /// Flush the changes to the database.
+    ///
+    /// Using a [`Flush`] mode other than [`Flush::Sync`] can leave the database in an invalid state if a crash
+    /// happens before all changes are flushed to permanent storage.
+    pub fn flush(mut self, mode: Flush) -> io::Result<()> {
+        // The poppers update the count directly + we don't need to flush anything to the files.
+        self.meta_guard.push_update(mode)
+    }
+}
+
+/// A [`LinearTapes`] database reader.
+///
+/// This type holds a read handle to the database so should not be kept around for longer than necessary.
+pub struct Reader<'a> {
+    /// A write guard for the metadata
+    meta_guard: metadata::MetadataHandle<'a>,
+    /// The ptrs to the tapes, guaranteed to be safe to read from, upto the lengths in the metadata.
+    loaded_tapes: Vec<*const UnsafeTape>,
+    /// The tapes.
+    tapes: &'a LinearTapes,
+}
+
+impl Reader<'_> {
+    /// Opens a handle to read from a fixed-sized tape.
+    pub fn fixed_sized_tape_reader<'a, E: Entry>(
+        &'a self,
+        table_name: &'static str,
+    ) -> FixedSizedTapeReader<'a, E> {
+        let i = *self
+            .tapes
+            .tapes_to_index
+            .get(table_name)
+            .expect("Tape was not specified when opening tapes");
+
+        // Safety: We are holding a reader guard so this will not be dropped.
+        let backing_file = unsafe { &*self.loaded_tapes[i] };
+
+        FixedSizedTapeReader {
+            backing_file,
+            phantom: Default::default(),
+            len: self.meta_guard[i],
+        }
+    }
+
+    /// Opens a handle to read from a blob tape.
+    pub fn blob_tape_tape_reader<'a>(&'a self, table_name: &'static str) -> BlobTapeReader<'a> {
+        let i = *self
+            .tapes
+            .tapes_to_index
+            .get(table_name)
+            .expect("Tape was not specified when opening tapes");
+
+        // Safety: We are holding a reader guard so this will not be dropped.
+        let backing_file = unsafe { &*self.loaded_tapes[i] };
+
+        BlobTapeReader {
+            backing_file,
+            used_bytes: self.meta_guard[i],
+        }
+    }
+}

--- a/storage/linear-tape/src/lib.rs
+++ b/storage/linear-tape/src/lib.rs
@@ -220,7 +220,7 @@ impl LinearTapes {
     /// to no longer be accessing the bytes in the range popped, so this thread will block waiting for readers
     /// to not be accessing old state if it follows a pop.
     ///
-    /// Once you have finished appending data to the tapes your changes must be commited with [`Appender::flush`].
+    /// Once you have finished appending data to the tapes your changes must be committed with [`Appender::flush`].
     pub fn appender(&self) -> Appender<'_> {
         let meta_guard = self.metadata.start_write(APPEND_OP);
 
@@ -253,7 +253,7 @@ impl LinearTapes {
     /// Only one write operation can be active at a given time, this will block if another write operation
     /// is active util it is finished.
     ///
-    /// Once you have finished popping data from the tapes your changes must be commited with [`Popper::flush`]
+    /// Once you have finished popping data from the tapes your changes must be committed with [`Popper::flush`]
     pub fn popper(&self) -> Popper<'_> {
         let meta_guard = self.metadata.start_write(POP_OP);
 
@@ -319,7 +319,7 @@ impl LinearTapes {
 /// - for fixed sized tapes: [`Appender::fixed_sized_tape_appender`]
 /// - for blob tapes: [`Appender::blob_tape_appender`]
 ///
-/// Once finished changes must be commited with: [`Appender::flush`]
+/// Once finished changes must be committed with: [`Appender::flush`]
 pub struct Appender<'a> {
     /// The metadata guard for this writer.
     meta_guard: metadata::MetadataWriteGuard<'a>,
@@ -458,11 +458,11 @@ impl Appender<'_> {
 /// - for fixed sized tapes: [`Popper::fixed_sized_tape_popper`]
 /// - for blob tapes: [`Popper::blob_tape_popper`]
 ///
-/// Once finished changes must be commited with: [`Popper::flush`]
+/// Once finished changes must be committed with: [`Popper::flush`]
 pub struct Popper<'a> {
     /// The metadata guard for this writer.
     meta_guard: metadata::MetadataWriteGuard<'a>,
-    /// Tha tapes database.
+    /// The tapes database.
     tapes: &'a LinearTapes,
 }
 

--- a/storage/linear-tape/src/metadata.rs
+++ b/storage/linear-tape/src/metadata.rs
@@ -1,0 +1,147 @@
+use std::{
+    fs::OpenOptions,
+    io::{self, Write},
+    ops::Deref,
+    path::Path,
+};
+
+use cuprate_rcu_ring::{required_len, DataHandle, RcuRing, WriteGuard};
+use memmap2::{MmapOptions, MmapRaw};
+
+use crate::Flush;
+
+/// The u32 value which represents an append operation.
+pub(crate) const APPEND_OP: u32 = 0;
+/// The u32 value which represents a pop operation.
+pub(crate) const POP_OP: u32 = 1;
+
+/// A read handle to the metadata.
+pub(crate) struct MetadataHandle<'a> {
+    data_handle: DataHandle<'a>,
+}
+
+impl Deref for MetadataHandle<'_> {
+    type Target = [usize];
+    fn deref(&self) -> &Self::Target {
+        // Safety:
+        //    RcuRing ensures the returned slice is 8-byte aligned.
+        //    We only support 64-bit targets.
+        unsafe {
+            std::slice::from_raw_parts(
+                self.data_handle.data.as_ptr().cast(),
+                self.data_handle.data.len() / 8,
+            )
+        }
+    }
+}
+
+/// A write guard for updating the metadata.
+///
+/// Changes must be flushed with [`MetadataWriteGuard::push_update`] to be seen.
+pub(crate) struct MetadataWriteGuard<'a> {
+    write_guard: WriteGuard<'a>,
+    mmap: &'a MmapRaw,
+}
+
+impl MetadataWriteGuard<'_> {
+    /// Returns the lengths of all tables.
+    pub(crate) fn tables_len_mut(&mut self) -> &mut [usize] {
+        let len = self.write_guard.data_mut().len();
+        // Safety:
+        //    RcuRing ensures the returned slice is 8-byte aligned.
+        //    We only support 64-bit targets.
+        unsafe {
+            std::slice::from_raw_parts_mut(self.write_guard.data_mut().as_mut_ptr().cast(), len / 8)
+        }
+    }
+
+    pub(crate) fn current_data_slot_idx(&self) -> usize {
+        self.write_guard.current_data_slot_idx()
+    }
+
+    /// Push the changes made during this write.
+    ///
+    /// This guard must not be used after this call.
+    pub(crate) fn push_update(&mut self, mode: Flush) -> io::Result<()> {
+        self.write_guard.push_update();
+
+        match mode {
+            Flush::Sync => self.mmap.flush(),
+            Flush::Async => self.mmap.flush_async(),
+            Flush::NoSync => Ok(()),
+        }
+    }
+}
+
+/// The metadata of the liner tapes databases.
+///
+/// Handles tracking their lengths and atomically updating them.
+pub(crate) struct Metadata {
+    mmap: MmapRaw,
+    rcu_ring: RcuRing,
+}
+
+impl Metadata {
+    /// Opens the metadata file for the tapes.
+    pub(crate) unsafe fn open<P: AsRef<Path>>(
+        path: P,
+        tables: usize,
+        metadata_ring_len: usize,
+    ) -> io::Result<Self> {
+        let mut file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .truncate(false)
+            .create(true)
+            .open(path.as_ref())?;
+
+        let len = file.metadata()?.len();
+        let expected_len = required_len(tables * 8, metadata_ring_len);
+
+        if len == 0 {
+            file.write_all(&vec![0; expected_len])?;
+        }
+
+        let len = file.metadata()?.len();
+
+        if len != expected_len as u64 {
+            return Err(io::Error::other("metadata file incorrect size"));
+        }
+
+        let mmap = MmapOptions::new().map_raw(&file)?;
+
+        mmap.lock()?;
+
+        let ptr = mmap.as_mut_ptr();
+
+        // Safety: we just checked the length of the file, and wrote zeros if there wasn't enough.
+        unsafe {
+            let rcu_ring = RcuRing::new_from_ptr(ptr, tables * 8, metadata_ring_len);
+
+            Ok(Self { mmap, rcu_ring })
+        }
+    }
+
+    /// Start a reader for the metadata.
+    pub(crate) fn start_read(&self) -> MetadataHandle<'_> {
+        let data_handle = self.rcu_ring.start_read();
+
+        MetadataHandle { data_handle }
+    }
+
+    pub(crate) fn wait_for_all_readers(&self, current_slot_idx: usize) {
+        self.rcu_ring.wait_for_all_readers(current_slot_idx);
+    }
+
+    /// Start a writer for the metadata.
+    pub(crate) fn start_write(&self, op: u32) -> MetadataWriteGuard<'_> {
+        let write_guard = self
+            .rcu_ring
+            .start_write(op, |last_op| last_op == POP_OP && op != POP_OP);
+
+        MetadataWriteGuard {
+            write_guard,
+            mmap: &self.mmap,
+        }
+    }
+}

--- a/storage/linear-tape/src/unsafe_tape.rs
+++ b/storage/linear-tape/src/unsafe_tape.rs
@@ -1,0 +1,154 @@
+#![expect(clippy::undocumented_unsafe_blocks)]
+
+use std::{
+    cmp::max,
+    fs::{File, OpenOptions},
+    io,
+    ops::Range,
+    path::Path,
+    slice,
+};
+
+use memmap2::{MmapOptions, MmapRaw};
+
+use crate::Advice;
+
+#[cfg(target_endian = "big")]
+const BE_NOT_SUPPORTED: u8 = panic!();
+
+/// A raw tape database that is used to build the other tape databases.
+pub(crate) struct UnsafeTape {
+    /// The [`File`] that the memory map points to.
+    file: File,
+    /// The memory map.
+    mmap: MmapRaw,
+    /// The [`Advice`] used on the database.
+    advice: Advice,
+}
+
+impl UnsafeTape {
+    /// Open an [`UnsafeTape`].
+    ///
+    /// # Safety
+    ///
+    /// This is marked unsafe as modifications to the underlying file can lead to UB.
+    pub(crate) unsafe fn open<P: AsRef<Path>>(
+        path: P,
+        advice: Advice,
+        initial_map_size: u64,
+    ) -> io::Result<Self> {
+        let file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .truncate(false)
+            .create(true)
+            .open(path.as_ref())?;
+
+        let len = file.metadata()?.len();
+
+        if len < initial_map_size {
+            file.set_len(initial_map_size)?;
+        }
+
+        let mmap = MmapOptions::new().map_raw(&file)?;
+        mmap.advise(advice.to_memmap2_advice())?;
+
+        Ok(Self { file, mmap, advice })
+    }
+
+    /// Take a slice of bytes from the memory map.
+    ///
+    /// # Safety
+    ///
+    /// This memory map must be initialised in this range.
+    pub(crate) unsafe fn slice(&self, start: usize, len: usize) -> &[u8] {
+        unsafe {
+            let ptr = self.mmap.as_ptr().add(start);
+            slice::from_raw_parts(ptr, len)
+        }
+    }
+
+    /// Take a range of bytes from the memory map.
+    ///
+    /// # Safety
+    ///
+    /// This memory map must be initialised in this range.
+    pub(crate) unsafe fn range(&self, range: Range<usize>) -> &[u8] {
+        unsafe {
+            let ptr = self.mmap.as_ptr().add(range.start);
+            slice::from_raw_parts(ptr, range.len())
+        }
+    }
+
+    /// Take a mutable range of bytes from the memory map.
+    ///
+    /// # Safety
+    ///
+    /// This memory map must be initialised in this range, and there must not be multiple references to the same range.
+    #[expect(clippy::mut_from_ref)]
+    pub(crate) unsafe fn range_mut(&self, range: Range<usize>) -> &mut [u8] {
+        unsafe {
+            let ptr = self.mmap.as_mut_ptr().add(range.start);
+            slice::from_raw_parts_mut(ptr, range.len())
+        }
+    }
+
+    /// Take a mutable range of bytes from the memory map.
+    ///
+    /// # Safety
+    ///
+    /// This memory map must be initialised in this range.
+    pub(crate) fn flush_range(&self, offset: usize, len: usize) -> io::Result<()> {
+        self.mmap.flush_range(offset, len)
+    }
+
+    /// Take a mutable range of bytes from the memory map.
+    ///
+    /// # Safety
+    ///
+    /// This memory map must be initialised in this range.
+    pub(crate) fn flush_range_async(&self, offset: usize, len: usize) -> io::Result<()> {
+        self.mmap.flush_async_range(offset, len)
+    }
+
+    /// Returns the total map size, including the header which can't be used for values.
+    pub(crate) fn map_size(&self) -> usize {
+        self.mmap.len()
+    }
+
+    /// Resizes the current database to `needed_len`.
+    pub(crate) fn resize_to_bytes(&mut self, needed_len: u64) -> io::Result<()> {
+        let current_len = self.file.metadata()?.len();
+        let new_len = max(current_len, needed_len);
+
+        if new_len != current_len {
+            self.file.set_len(max(current_len, needed_len))?;
+        }
+
+        let mmap = MmapOptions::new().map_raw(&self.file)?;
+        mmap.advise(self.advice.to_memmap2_advice())?;
+
+        self.mmap = mmap;
+
+        Ok(())
+    }
+
+    /// Opens a new copy of this database that has been resized to `needed_len`.
+    pub(crate) fn resize_to_bytes_copy(&self, needed_len: u64) -> io::Result<Self> {
+        let current_len = self.file.metadata()?.len();
+        let new_len = max(current_len, needed_len);
+
+        if new_len != current_len {
+            self.file.set_len(max(current_len, needed_len))?;
+        }
+
+        let mmap = MmapOptions::new().map_raw(&self.file)?;
+        mmap.advise(self.advice.to_memmap2_advice())?;
+
+        Ok(Self {
+            file: self.file.try_clone()?,
+            mmap,
+            advice: self.advice,
+        })
+    }
+}


### PR DESCRIPTION

### What

This PR is the first part of updating the database to use linear tapes to store certain data, this PR contains the linear tape impl but makes no changes to current code.

### Why
Using the tape is faster for the operations we do a lot, and makes the DB significantly smaller.

### Where
All new code

