### PR TITLE
fix network zone config

### DIFF
--- a/binaries/cuprated/src/config/args.rs
+++ b/binaries/cuprated/src/config/args.rs
@@ -14,11 +14,10 @@ pub struct Args {
     /// The network to run on.
     #[arg(
         long,
-        default_value_t = Network::Mainnet,
         value_parser = clap::builder::PossibleValuesParser::new(["mainnet", "testnet", "stagenet"])
-            .map(|s| s.parse::<Network>().unwrap()),
+            .map(|s| Some(s.parse::<Network>().unwrap())),
     )]
-    pub network: Network,
+    pub network: Option<Network>,
 
     /// Disable fast sync, all past blocks will undergo full verification when syncing.
     ///
@@ -70,7 +69,9 @@ impl Args {
     ///
     /// This may exit the program if a config value was set that requires an early exit.
     pub const fn apply_args(&self, mut config: Config) -> Config {
-        config.network = self.network;
+        if let Some(network) = self.network {
+            config.network = network;
+        }
         config.fast_sync = config.fast_sync && !self.no_fast_sync;
 
         if let Some(outbound_connections) = self.outbound_connections {


### PR DESCRIPTION

### What

the args was _always_ overriding the config files network value. meaning you could only change the zone by changing the network arg and the files value meant nothing.

Changed to prioritise the args but to use the config files value otherwise.
