### PR TITLE
cuprated: Add graceful shutdown

### DIFF
--- a/binaries/cuprated/src/blockchain/manager.rs
+++ b/binaries/cuprated/src/blockchain/manager.rs
@@ -51,7 +51,7 @@ pub(crate) async fn init_blockchain_manager(
     syncer: Syncer,
     command_rx: mpsc::Receiver<BlockchainManagerCommand>,
 ) -> Result<(), anyhow::Error> {
-    let block_downloader_config = launch_ctx.config.block_downloader_config()?;
+    let block_downloader_config = launch_ctx.config.block_downloader_config();
     let shutdown_token = launch_ctx.task_executor.cancellation_token();
 
     // TODO: find good values for these size limits

--- a/binaries/cuprated/src/blockchain/manager.rs
+++ b/binaries/cuprated/src/blockchain/manager.rs
@@ -3,6 +3,7 @@ use std::{collections::HashMap, sync::Arc};
 use futures::StreamExt;
 use monero_oxide::block::Block;
 use tokio::sync::{mpsc, oneshot, Notify, OwnedSemaphorePermit, RwLock};
+use tokio_util::sync::CancellationToken;
 use tower::{BoxError, Service, ServiceExt};
 use tracing::error;
 
@@ -49,20 +50,23 @@ pub(crate) async fn init_blockchain_manager(
     txpool_manager_handle: TxpoolManagerHandle,
     syncer: Syncer,
     command_rx: mpsc::Receiver<BlockchainManagerCommand>,
-) {
-    let block_downloader_config = launch_ctx.config.block_downloader_config();
+) -> Result<(), anyhow::Error> {
+    let block_downloader_config = launch_ctx.config.block_downloader_config()?;
+    let shutdown_token = launch_ctx.task_executor.cancellation_token();
+
     // TODO: find good values for these size limits
     let (batch_tx, batch_rx) = mpsc::channel(1);
     let stop_current_block_downloader = Arc::new(Notify::new());
     let fast_sync_hashes = launch_ctx.config.fast_sync_hashes();
 
-    tokio::spawn(syncer.run(
+    launch_ctx.task_executor.spawn(syncer.run(
         launch_ctx.blockchain.context_svc(),
         ChainService(launch_ctx.blockchain.read(), fast_sync_hashes),
         clearnet_interface.clone(),
         batch_tx,
         Arc::clone(&stop_current_block_downloader),
         block_downloader_config,
+        shutdown_token.clone(),
     ));
 
     let manager = BlockchainManager {
@@ -79,7 +83,11 @@ pub(crate) async fn init_blockchain_manager(
         fast_sync_hashes,
     };
 
-    tokio::spawn(manager.run(batch_rx, command_rx));
+    launch_ctx
+        .task_executor
+        .spawn(manager.run(batch_rx, command_rx, shutdown_token));
+
+    Ok(())
 }
 
 /// The blockchain manager.
@@ -116,9 +124,14 @@ impl BlockchainManager {
         mut self,
         mut block_batch_rx: mpsc::Receiver<(BlockBatch, Arc<OwnedSemaphorePermit>)>,
         mut command_rx: mpsc::Receiver<BlockchainManagerCommand>,
+        shutdown_token: CancellationToken,
     ) {
         loop {
             tokio::select! {
+                biased;
+                () = shutdown_token.cancelled() => {
+                    break;
+                }
                 Some((batch, permit)) = block_batch_rx.recv() => {
                     self.handle_incoming_block_batch(
                         batch,
@@ -130,9 +143,11 @@ impl BlockchainManager {
                     self.handle_command(incoming_command).await;
                 }
                 else => {
-                    todo!("TODO: exit the BC manager")
+                    break;
                 }
             }
         }
+
+        tracing::info!("Blockchain manager shut down.");
     }
 }

--- a/binaries/cuprated/src/blockchain/syncer.rs
+++ b/binaries/cuprated/src/blockchain/syncer.rs
@@ -20,6 +20,8 @@ use cuprate_p2p::{
 };
 use cuprate_p2p_core::{client::PeerSyncCallback, ClearNet, CoreSyncData, NetworkZone};
 
+use tokio_util::sync::CancellationToken;
+
 use super::BlockchainInterface;
 
 /// An error returned from the [`Syncer`].
@@ -72,6 +74,7 @@ impl Syncer {
     /// Run the syncer.
     #[instrument(level = "debug", skip_all)]
     #[expect(clippy::significant_drop_tightening)]
+    #[expect(clippy::too_many_arguments)]
     pub async fn run<CN>(
         mut self,
         mut context_svc: BlockchainContextService,
@@ -80,6 +83,7 @@ impl Syncer {
         incoming_block_batch_tx: mpsc::Sender<(BlockBatch, Arc<OwnedSemaphorePermit>)>,
         stop_current_block_downloader: Arc<Notify>,
         block_downloader_config: BlockDownloaderConfig,
+        shutdown_token: CancellationToken,
     ) -> Result<(), SyncerError>
     where
         CN: Service<
@@ -98,7 +102,13 @@ impl Syncer {
         let mut sync_permit = Arc::new(Arc::clone(&semaphore).acquire_owned().await?);
 
         loop {
-            self.notify_syncer.notified().await;
+            tokio::select! {
+                () = shutdown_token.cancelled() => {
+                    tracing::info!("Blockchain syncer shut down.");
+                    return Ok(());
+                }
+                () = self.notify_syncer.notified() => {}
+            }
 
             tracing::trace!("Checking connected peers to see if we are behind",);
 
@@ -126,6 +136,11 @@ impl Syncer {
 
             loop {
                 tokio::select! {
+                    biased;
+                    () = shutdown_token.cancelled() => {
+                        tracing::info!("Blockchain syncer shut down.");
+                        return Ok(());
+                    }
                     () = stop_current_block_downloader.notified() => {
                         tracing::info!("Received stop signal, stopping block downloader");
 
@@ -154,6 +169,9 @@ impl Syncer {
 
                         tracing::debug!("Got batch, len: {}", batch.blocks.len());
                         if incoming_block_batch_tx.send((batch, Arc::clone(&sync_permit))).await.is_err() {
+                            if shutdown_token.is_cancelled() {
+                                return Ok(());
+                            }
                             return Err(SyncerError::IncomingBlockChannelClosed);
                         }
                     }

--- a/binaries/cuprated/src/blockchain/syncer.rs
+++ b/binaries/cuprated/src/blockchain/syncer.rs
@@ -8,6 +8,7 @@ use std::{
 
 use futures::{FutureExt, StreamExt};
 use tokio::sync::{mpsc, Notify, OwnedSemaphorePermit, Semaphore};
+use tokio_util::sync::CancellationToken;
 use tower::{Service, ServiceExt};
 use tracing::instrument;
 
@@ -19,8 +20,6 @@ use cuprate_p2p::{
     NetworkInterface, PeerSetRequest, PeerSetResponse,
 };
 use cuprate_p2p_core::{client::PeerSyncCallback, ClearNet, CoreSyncData, NetworkZone};
-
-use tokio_util::sync::CancellationToken;
 
 use super::BlockchainInterface;
 
@@ -103,6 +102,7 @@ impl Syncer {
 
         loop {
             tokio::select! {
+                biased;
                 () = shutdown_token.cancelled() => {
                     tracing::info!("Blockchain syncer shut down.");
                     return Ok(());

--- a/binaries/cuprated/src/commands.rs
+++ b/binaries/cuprated/src/commands.rs
@@ -53,6 +53,9 @@ pub enum Command {
 
     /// Pop blocks from the top of the blockchain.
     PopBlocks { numb_blocks: usize },
+
+    /// Gracefully shut down the daemon.
+    Exit,
 }
 
 /// The log output target.
@@ -93,11 +96,18 @@ pub fn command_listener(incoming_commands: mpsc::Sender<Command>) -> ! {
 /// The [`Command`] handler loop.
 pub async fn io_loop(mut incoming_commands: mpsc::Receiver<Command>, mut node: cuprated::Node) {
     let start_instant = Instant::now();
+    let shutdown_token = node.task_executor.cancellation_token();
 
     loop {
-        let Some(command) = incoming_commands.recv().await else {
-            tracing::warn!("Shutting down io_loop command channel closed.");
-            return;
+        let command = tokio::select! {
+            () = shutdown_token.cancelled() => break,
+            cmd = incoming_commands.recv() => {
+                let Some(cmd) = cmd else {
+                    tracing::warn!("Shutting down io_loop, command channel closed.");
+                    return;
+                };
+                cmd
+            }
         };
 
         match command {
@@ -142,6 +152,9 @@ pub async fn io_loop(mut incoming_commands: mpsc::Receiver<Command>, mut node: c
                     Ok(()) => println!("Popped {numb_blocks} blocks."),
                     Err(e) => println!("Failed to pop blocks: {e}"),
                 }
+            }
+            Command::Exit => {
+                node.shutdown();
             }
         }
     }

--- a/binaries/cuprated/src/commands.rs
+++ b/binaries/cuprated/src/commands.rs
@@ -100,6 +100,7 @@ pub async fn io_loop(mut incoming_commands: mpsc::Receiver<Command>, mut node: c
 
     loop {
         let command = tokio::select! {
+            biased;
             () = shutdown_token.cancelled() => break,
             cmd = incoming_commands.recv() => {
                 let Some(cmd) = cmd else {

--- a/binaries/cuprated/src/config.rs
+++ b/binaries/cuprated/src/config.rs
@@ -363,40 +363,39 @@ impl Config {
 
     /// Returns the size of the fjall cache.
     ///
-    /// # Errors
+    /// # Panics
     ///
-    /// Returns an error if `target_max_memory` is unresolved.
-    pub fn fjall_cache_size(&self) -> anyhow::Result<u64> {
-        Ok(*self
+    /// Panics if `target_max_memory` is unresolved.
+    pub fn fjall_cache_size(&self) -> u64 {
+        *self
             .storage
             .fjall_cache_size
-            .value(&(self.target_max_memory()? / 4)))
+            .value(&(self.target_max_memory() / 4))
     }
 
     /// Returns the target maximum memory usage.
     ///
-    /// # Errors
+    /// # Panics
     ///
-    /// Returns an error if `target_max_memory` is unresolved.
-    pub fn target_max_memory(&self) -> anyhow::Result<u64> {
+    /// Panics if `target_max_memory` is unresolved.
+    pub fn target_max_memory(&self) -> u64 {
         match self.target_max_memory {
             DefaultOrCustom::Default => {
-                anyhow::bail!("`target_max_memory` is unresolved; call `resolve_max_memory` first")
+                panic!("`target_max_memory` is unresolved; call `resolve_max_memory` first")
             }
-            DefaultOrCustom::Custom(size) => Ok(size),
+            DefaultOrCustom::Custom(size) => size,
         }
     }
 
     /// The [`BlockDownloaderConfig`].
     ///
-    /// # Errors
+    /// # Panics
     ///
-    /// Returns an error if `target_max_memory` is unresolved.
-    pub fn block_downloader_config(&self) -> anyhow::Result<BlockDownloaderConfig> {
-        Ok(self
-            .p2p
+    /// Panics if `target_max_memory` is unresolved.
+    pub fn block_downloader_config(&self) -> BlockDownloaderConfig {
+        self.p2p
             .block_downloader
-            .construct_inner(self.target_max_memory()?))
+            .construct_inner(self.target_max_memory())
     }
 
     /// Checks if a port can be bound to.

--- a/binaries/cuprated/src/config.rs
+++ b/binaries/cuprated/src/config.rs
@@ -362,28 +362,41 @@ impl Config {
     }
 
     /// Returns the size of the fjall cache.
-    pub fn fjall_cache_size(&self) -> u64 {
-        *self
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `target_max_memory` is unresolved.
+    pub fn fjall_cache_size(&self) -> anyhow::Result<u64> {
+        Ok(*self
             .storage
             .fjall_cache_size
-            .value(&(self.target_max_memory() / 4))
+            .value(&(self.target_max_memory()? / 4)))
     }
 
     /// Returns the target maximum memory usage.
-    pub fn target_max_memory(&self) -> u64 {
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `target_max_memory` is unresolved.
+    pub fn target_max_memory(&self) -> anyhow::Result<u64> {
         match self.target_max_memory {
             DefaultOrCustom::Default => {
-                panic!("`target_max_memory` is unresolved; call `resolve_max_memory` first")
+                anyhow::bail!("`target_max_memory` is unresolved; call `resolve_max_memory` first")
             }
-            DefaultOrCustom::Custom(size) => size,
+            DefaultOrCustom::Custom(size) => Ok(size),
         }
     }
 
     /// The [`BlockDownloaderConfig`].
-    pub fn block_downloader_config(&self) -> BlockDownloaderConfig {
-        self.p2p
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `target_max_memory` is unresolved.
+    pub fn block_downloader_config(&self) -> anyhow::Result<BlockDownloaderConfig> {
+        Ok(self
+            .p2p
             .block_downloader
-            .construct_inner(self.target_max_memory())
+            .construct_inner(self.target_max_memory()?))
     }
 
     /// Checks if a port can be bound to.

--- a/binaries/cuprated/src/lib.rs
+++ b/binaries/cuprated/src/lib.rs
@@ -160,7 +160,7 @@ impl Node {
 
         // Start the blockchain & tx-pool databases.
         let fjall_db = fjall::Database::builder(config.fjall_directory())
-            .cache_size(config.fjall_cache_size()?)
+            .cache_size(config.fjall_cache_size())
             .open()
             .context(DATABASE_CORRUPT_MSG)?;
 

--- a/binaries/cuprated/src/lib.rs
+++ b/binaries/cuprated/src/lib.rs
@@ -37,6 +37,7 @@ pub mod blockchain;
 pub mod config;
 pub mod constants;
 pub mod logging;
+pub mod monitor;
 pub mod version;
 
 mod p2p;
@@ -46,6 +47,7 @@ mod txpool;
 
 use std::sync::Arc;
 
+use anyhow::Context;
 use tokio::sync::{oneshot, RwLock};
 use tower::{Service, ServiceExt};
 use tracing::error;
@@ -58,7 +60,8 @@ use cuprate_types::blockchain::BlockchainWriteRequest;
 use crate::{
     blockchain::{BlockchainInterface, BlockchainManagerHandle, Syncer, SyncerHandle},
     config::Config,
-    constants::{DATABASE_CORRUPT_MSG, PANIC_CRITICAL_SERVICE_ERROR},
+    constants::DATABASE_CORRUPT_MSG,
+    monitor::TaskExecutor,
     tor::initialize_tor_if_enabled,
     txpool::IncomingTxHandler,
 };
@@ -91,6 +94,9 @@ pub(crate) struct LaunchContext {
 
     /// Syncer handle.
     pub syncer: SyncerHandle,
+
+    /// Task spawning and shutdown coordination.
+    pub task_executor: TaskExecutor,
 }
 
 /// An active `cuprated` node.
@@ -115,6 +121,15 @@ pub struct Node {
 
     /// The configuration this node was launched with.
     pub config: Arc<Config>,
+
+    /// Task spawning and shutdown executor.
+    pub task_executor: TaskExecutor,
+}
+
+impl Drop for Node {
+    fn drop(&mut self) {
+        self.task_executor.trigger_shutdown();
+    }
 }
 
 impl Node {
@@ -128,11 +143,11 @@ impl Node {
     /// - Global rayon thread pool (optional, uses rayon defaults if not set)
     /// - Memory resolution (call [`resolve_max_memory`](crate::config::resolve_max_memory))
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// Panics if the database is corrupt, critical services fail to start,
+    /// Returns an error if the database is corrupt, critical services fail to start,
     /// or `target_max_memory` is unresolved.
-    pub async fn launch(config: impl Into<Arc<Config>>) -> Self {
+    pub async fn launch(config: impl Into<Arc<Config>>) -> Result<Self, anyhow::Error> {
         let config: Arc<Config> = config.into();
 
         // Initialize the database thread pool.
@@ -140,14 +155,14 @@ impl Node {
             rayon::ThreadPoolBuilder::new()
                 .num_threads(config.storage.reader_threads)
                 .build()
-                .unwrap(),
+                .context("failed to build rayon database thread pool")?,
         );
 
         // Start the blockchain & tx-pool databases.
         let fjall_db = fjall::Database::builder(config.fjall_directory())
-            .cache_size(config.fjall_cache_size())
+            .cache_size(config.fjall_cache_size()?)
             .open()
-            .unwrap();
+            .context(DATABASE_CORRUPT_MSG)?;
 
         let (mut blockchain_read_handle, mut blockchain_write_handle, _) =
             cuprate_blockchain::service::init_with_pool(
@@ -155,22 +170,18 @@ impl Node {
                 fjall_db.clone(),
                 Arc::clone(&db_thread_pool),
             )
-            .inspect_err(|e| error!("Blockchain database error: {e}"))
-            .expect(DATABASE_CORRUPT_MSG);
+            .context(DATABASE_CORRUPT_MSG)?;
 
         let (txpool_read_handle, txpool_write_handle) =
             cuprate_txpool::service::init_with_pool(fjall_db, db_thread_pool)
-                .inspect_err(|e| error!("Txpool database error: {e}"))
-                .expect(DATABASE_CORRUPT_MSG);
+                .context(DATABASE_CORRUPT_MSG)?;
 
         // TODO: Add an argument/option for keeping alt blocks between restart.
         blockchain_write_handle
             .ready()
-            .await
-            .expect(PANIC_CRITICAL_SERVICE_ERROR)
+            .await?
             .call(BlockchainWriteRequest::FlushAltBlocks)
-            .await
-            .expect(PANIC_CRITICAL_SERVICE_ERROR);
+            .await?;
 
         // Check add the genesis block to the blockchain.
         blockchain::check_add_genesis(
@@ -184,7 +195,7 @@ impl Node {
         let context_svc =
             blockchain::init_consensus(blockchain_read_handle.clone(), config.context_config())
                 .await
-                .unwrap();
+                .map_err(anyhow::Error::from_boxed)?;
 
         // Create the syncer and handle.
         let (syncer, syncer_handle) = Syncer::new();
@@ -206,6 +217,7 @@ impl Node {
             blockchain: blockchain_interface,
             txpool_read: txpool_read_handle.clone(),
             syncer: syncer_handle,
+            task_executor: TaskExecutor::new(),
         };
 
         // Bootstrap or configure Tor if enabled.
@@ -248,7 +260,7 @@ impl Node {
             syncer,
             command_rx,
         )
-        .await;
+        .await?;
 
         // Initialize the RPC server(s).
         rpc::init_rpc_servers(&launch_ctx, tx_handler.clone());
@@ -269,16 +281,28 @@ impl Node {
             txpool_read,
             syncer,
             config,
+            task_executor,
             ..
         } = launch_ctx;
 
-        Self {
+        Ok(Self {
             blockchain,
             txpool: txpool_read,
             clearnet: clearnet_interface,
             tor: if tor_enabled { Some(tor_rx) } else { None },
             syncer,
             config,
-        }
+            task_executor,
+        })
+    }
+
+    /// Trigger a graceful shutdown.
+    pub fn shutdown(&self) {
+        self.task_executor.trigger_shutdown();
+    }
+
+    /// Wait for shutdown to be triggered, then await all tracked tasks.
+    pub async fn wait_for_shutdown(&self) {
+        self.task_executor.wait_for_shutdown().await;
     }
 }

--- a/binaries/cuprated/src/main.rs
+++ b/binaries/cuprated/src/main.rs
@@ -33,6 +33,7 @@ use cuprated::{
     config::{find_config, resolve_max_memory, Config},
     constants::{DEFAULT_CONFIG_STARTUP_DELAY, DEFAULT_CONFIG_WARNING},
     logging::eprintln_red,
+    monitor::TaskExecutor,
 };
 
 mod args;
@@ -71,7 +72,18 @@ fn main() {
     #[expect(clippy::significant_drop_tightening)]
     rt.block_on(async move {
         // Start the node.
-        let node = cuprated::Node::launch(config).await;
+        let node = match cuprated::Node::launch(config).await {
+            Ok(node) => node,
+            Err(e) => {
+                tracing::error!("Failed to launch node: {e:#}");
+                std::process::exit(1);
+            }
+        };
+
+        let task_executor = node.task_executor.clone();
+
+        // Spawn OS signal handler.
+        spawn_signal_handler(task_executor.clone());
 
         // If STDIN is a terminal, spawn a blocking thread for user input.
         if io::stdin().is_terminal() {
@@ -79,15 +91,66 @@ fn main() {
             std::thread::spawn(|| commands::command_listener(command_tx));
 
             // Wait on the io_loop, spawned on a separate task as this improves performance.
-            tokio::spawn(commands::io_loop(command_rx, node))
-                .await
-                .unwrap();
+            task_executor.spawn(commands::io_loop(command_rx, node));
+
+            // Wait for shutdown and all tracked tasks to finish.
+            task_executor.wait_for_shutdown().await;
         } else {
-            // If no STDIN, await OS exit signal.
+            // If no STDIN, await shutdown signal.
             info!("Terminal/TTY not detected, disabling STDIN commands");
-            tokio::signal::ctrl_c().await.unwrap();
+            node.wait_for_shutdown().await;
         }
     });
+    drop(rt);
+    info!("Shutdown complete.");
+}
+
+/// Spawn a task that listens for OS signals and initiates shutdown.
+///
+/// On the first signal, triggers a graceful shutdown via `task_executor`.
+/// On the second signal, force-exits the process with code 1.
+fn spawn_signal_handler(task_executor: TaskExecutor) {
+    tokio::spawn(async move {
+        let shutdown_token = task_executor.cancellation_token();
+        tokio::select! {
+            biased;
+            () = shutdown_token.cancelled() => {}
+            () = shutdown_signal() => {
+                eprintln!();
+                task_executor.trigger_shutdown();
+                info!("Press Ctrl+C to force exit.");
+            }
+        }
+        // Wait for second signal to force exit.
+        shutdown_signal().await;
+        eprintln!();
+        std::process::exit(1);
+    });
+}
+
+/// Wait for an OS shutdown signal (SIGINT or SIGTERM).
+async fn shutdown_signal() {
+    let ctrl_c = async {
+        tokio::signal::ctrl_c()
+            .await
+            .expect("failed to install SIGINT handler");
+    };
+
+    #[cfg(unix)]
+    let terminate = async {
+        tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+            .expect("failed to install SIGTERM handler")
+            .recv()
+            .await;
+    };
+
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+
+    tokio::select! {
+        () = ctrl_c => {}
+        () = terminate => {}
+    }
 }
 
 /// Load config: explicit path from `--config-file`, auto-detect from default

--- a/binaries/cuprated/src/monitor.rs
+++ b/binaries/cuprated/src/monitor.rs
@@ -1,0 +1,50 @@
+//! Task spawning and shutdown coordination.
+
+use std::future::Future;
+
+use tokio::task::JoinHandle;
+use tokio_util::{sync::CancellationToken, task::TaskTracker};
+use tracing::info;
+
+/// A handle for task spawning and shutdown coordination.
+#[derive(Clone, Default)]
+pub struct TaskExecutor {
+    token: CancellationToken,
+    tracker: TaskTracker,
+}
+
+impl TaskExecutor {
+    /// Create a new executor.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Spawn a tracked task.
+    pub fn spawn<F>(&self, future: F) -> JoinHandle<F::Output>
+    where
+        F: Future + Send + 'static,
+        F::Output: Send + 'static,
+    {
+        self.tracker.spawn(future)
+    }
+
+    /// Get a clone of the cancellation token.
+    pub fn cancellation_token(&self) -> CancellationToken {
+        self.token.clone()
+    }
+
+    /// Trigger a graceful shutdown.
+    pub fn trigger_shutdown(&self) {
+        if !self.token.is_cancelled() {
+            info!("Shutting down...");
+        }
+        self.token.cancel();
+    }
+
+    /// Wait for shutdown to be triggered, then await all tracked tasks.
+    pub async fn wait_for_shutdown(&self) {
+        self.token.cancelled().await;
+        self.tracker.close();
+        self.tracker.wait().await;
+    }
+}

--- a/binaries/cuprated/src/p2p.rs
+++ b/binaries/cuprated/src/p2p.rs
@@ -191,11 +191,21 @@ pub fn initialize_tor_p2p(
 ) {
     tracing::info!("Tor P2P zone will start after sync.");
 
-    tokio::spawn(async move {
-        // Wait for the node to synchronize with the network
-        if launch_ctx.syncer.wait_for_synced().await.is_err() {
-            tracing::info!("Not starting Tor P2P zone, syncer stopped");
-            return;
+    let task_executor = launch_ctx.task_executor.clone();
+    let shutdown_token = task_executor.cancellation_token();
+
+    task_executor.spawn(async move {
+        // Wait for the node to synchronize with the network, or shutdown.
+        tokio::select! {
+            result = launch_ctx.syncer.wait_for_synced() => {
+                if result.is_err() {
+                    tracing::info!("Not starting Tor P2P zone, syncer stopped");
+                    return;
+                }
+            }
+            () = shutdown_token.cancelled() => {
+                return;
+            }
         }
         tracing::info!("Starting Tor P2P zone.");
 

--- a/binaries/cuprated/src/rpc/handlers/other_json.rs
+++ b/binaries/cuprated/src/rpc/handlers/other_json.rs
@@ -84,7 +84,7 @@ pub async fn map_request(
         Req::SetLogCategories(r) => Resp::SetLogCategories(not_available()?),
         Req::GetTransactionPool(r) => Resp::GetTransactionPool(not_available()?),
         Req::GetTransactionPoolStats(r) => Resp::GetTransactionPoolStats(not_available()?),
-        Req::StopDaemon(r) => Resp::StopDaemon(not_available()?),
+        Req::StopDaemon(r) => Resp::StopDaemon(stop_daemon(state, r).await?),
         Req::GetLimit(r) => Resp::GetLimit(not_available()?),
         Req::SetLimit(r) => Resp::SetLimit(not_available()?),
         Req::OutPeers(r) => Resp::OutPeers(not_available()?),
@@ -568,10 +568,13 @@ async fn get_transaction_pool_stats(
 
 /// <https://github.com/monero-project/monero/blob/cc73fe71162d564ffda8e549b79a350bca53c454/src/rpc/core_rpc_server.cpp#L1780-L1788>
 async fn stop_daemon(
-    mut state: CupratedRpcHandler,
+    state: CupratedRpcHandler,
     _: StopDaemonRequest,
 ) -> Result<StopDaemonResponse, Error> {
-    blockchain_manager::stop(todo!()).await?;
+    if state.is_restricted() {
+        return Err(anyhow!("stop_daemon not allowed in restricted mode"));
+    }
+    state.task_executor.trigger_shutdown();
     Ok(StopDaemonResponse { status: Status::Ok })
 }
 

--- a/binaries/cuprated/src/rpc/rpc_handler.rs
+++ b/binaries/cuprated/src/rpc/rpc_handler.rs
@@ -22,7 +22,8 @@ use cuprate_types::BlockTemplate;
 use cuprate_helper::network::Network;
 
 use crate::{
-    blockchain::BlockchainManagerHandle, rpc::handlers, txpool::IncomingTxHandler, LaunchContext,
+    blockchain::BlockchainManagerHandle, monitor::TaskExecutor, rpc::handlers,
+    txpool::IncomingTxHandler, LaunchContext,
 };
 
 /// TODO: use real type when public.
@@ -182,6 +183,9 @@ pub struct CupratedRpcHandler {
 
     /// The time this node was launched as a UNIX timestamp.
     pub start_instant_unix: u64,
+
+    /// Task spawning and shutdown coordination.
+    pub task_executor: TaskExecutor,
 }
 
 impl CupratedRpcHandler {
@@ -205,6 +209,7 @@ impl CupratedRpcHandler {
             txpool_read: launch_ctx.txpool_read.clone(),
             blockchain_manager: launch_ctx.blockchain.manager(),
             start_instant_unix,
+            task_executor: launch_ctx.task_executor.clone(),
         }
     }
 }

--- a/binaries/cuprated/src/rpc/server.rs
+++ b/binaries/cuprated/src/rpc/server.rs
@@ -7,6 +7,7 @@ use std::{
 
 use anyhow::Error;
 use tokio::net::TcpListener;
+use tokio_util::sync::CancellationToken;
 use tower::limit::rate::RateLimitLayer;
 use tower_http::limit::RequestBodyLimitLayer;
 use tracing::{info, warn};
@@ -70,15 +71,18 @@ pub fn init_rpc_servers(launch_ctx: &LaunchContext, tx_handler: IncomingTxHandle
 
         let rpc_handler = CupratedRpcHandler::new(restricted, tx_handler.clone(), launch_ctx);
 
-        tokio::task::spawn(async move {
+        let shutdown_token = launch_ctx.task_executor.cancellation_token();
+        launch_ctx.task_executor.spawn(async move {
             run_rpc_server(
                 rpc_handler,
                 restricted,
                 SocketAddr::new(addr, port),
                 request_byte_limit,
+                shutdown_token,
             )
             .await
             .unwrap();
+            info!(restricted, "RPC server shut down.");
         });
     }
 }
@@ -91,6 +95,7 @@ async fn run_rpc_server(
     restricted: bool,
     address: SocketAddr,
     request_byte_limit: usize,
+    shutdown_token: CancellationToken,
 ) -> Result<(), Error> {
     info!(
         restricted,
@@ -118,7 +123,9 @@ async fn run_rpc_server(
     //
     // TODO: impl custom server code, don't use axum.
     let listener = TcpListener::bind(address).await?;
-    axum::serve(listener, router).await?;
+    axum::serve(listener, router)
+        .with_graceful_shutdown(shutdown_token.cancelled_owned())
+        .await?;
 
     Ok(())
 }

--- a/binaries/cuprated/src/txpool/incoming_tx.rs
+++ b/binaries/cuprated/src/txpool/incoming_tx.rs
@@ -140,6 +140,7 @@ impl IncomingTxHandler {
             diffuse_service,
             dandelion_pool_manager.clone(),
             txpool_config,
+            launch_ctx.task_executor.clone(),
         )
         .await;
 

--- a/binaries/cuprated/src/txpool/manager.rs
+++ b/binaries/cuprated/src/txpool/manager.rs
@@ -8,7 +8,7 @@ use futures::StreamExt;
 use indexmap::IndexMap;
 use rand::Rng;
 use tokio::sync::{mpsc, oneshot};
-use tokio_util::{time::delay_queue, time::DelayQueue};
+use tokio_util::{sync::CancellationToken, time::delay_queue, time::DelayQueue};
 use tower::{Service, ServiceExt};
 use tracing::{instrument, Instrument, Span};
 
@@ -28,6 +28,7 @@ use cuprate_types::TransactionVerificationData;
 use crate::{
     config::TxpoolConfig,
     constants::PANIC_CRITICAL_SERVICE_ERROR,
+    monitor::TaskExecutor,
     p2p::{CrossNetworkInternalPeerId, NetworkInterfaces},
     txpool::{
         dandelion::DiffuseService,
@@ -49,6 +50,7 @@ pub async fn start_txpool_manager(
     diffuse_service: DiffuseService<ClearNet>,
     dandelion_pool_manager: DandelionPoolService<DandelionTx, TxId, CrossNetworkInternalPeerId>,
     config: TxpoolConfig,
+    task_executor: TaskExecutor,
 ) -> TxpoolManagerHandle {
     let TxpoolReadResponse::Backlog(backlog) = txpool_read_handle
         .ready()
@@ -110,7 +112,8 @@ pub async fn start_txpool_manager(
     let (tx_tx, tx_rx) = mpsc::channel(INCOMING_TX_QUEUE_SIZE);
     let (spent_kis_tx, spent_kis_rx) = mpsc::channel(1);
 
-    tokio::spawn(manager.run(tx_rx, spent_kis_rx));
+    let shutdown_token = task_executor.cancellation_token();
+    task_executor.spawn(manager.run(tx_rx, spent_kis_rx, shutdown_token));
 
     TxpoolManagerHandle {
         tx_tx,
@@ -456,9 +459,18 @@ impl TxpoolManager {
             TxState<CrossNetworkInternalPeerId>,
         )>,
         mut block_rx: mpsc::Receiver<(Vec<[u8; 32]>, oneshot::Sender<()>)>,
+        shutdown_token: CancellationToken,
     ) {
         loop {
             tokio::select! {
+                biased;
+                () = shutdown_token.cancelled() => {
+                    break;
+                }
+                Some((spent_kis, tx)) = block_rx.recv() => {
+                    self.new_block(spent_kis).await;
+                    let _ = tx.send(());
+                }
                 Some(tx) = self.tx_timeouts.next() => {
                     self.handle_tx_timeout(tx.into_inner()).await;
                 }
@@ -468,12 +480,10 @@ impl TxpoolManager {
                 Some(tx) = self.promote_tx_channel.recv() => {
                     self.promote_tx(tx).await;
                 }
-                Some((spent_kis, tx)) = block_rx.recv() => {
-                    self.new_block(spent_kis).await;
-                    let _ = tx.send(());
-                }
             }
         }
+
+        tracing::info!("Txpool manager shut down.");
     }
 }
 

--- a/storage/blockchain/src/database.rs
+++ b/storage/blockchain/src/database.rs
@@ -346,7 +346,7 @@ impl BlockchainDatabase {
 
 impl Drop for BlockchainDatabase {
     fn drop(&mut self) {
-        tracing::info!("Syncing blockchain database to storage.");
+        tracing::info!(parent: &tracing::Span::none(), "Syncing blockchain database to storage.");
 
         let _ = self.fjall.persist(PersistMode::SyncAll);
 


### PR DESCRIPTION
### What
Ports over the graceful shutdown logic from fjall-wip branch: https://github.com/Cuprate/cuprate/blob/fjall-wip/binaries/cuprated/src/monitor.rs

Depends on the embeddable version #592

### Why
More idiomatic shutdown pattern, previously every exit was equivalent to a crash

### Where
- `cuprated`:
  - `monitor.rs` - `TaskExecutor` handle (cancellation token + task tracker)
  - `config.rs` - `target_max_memory` / `fjall_cache_size` / `block_downloader_config` return Result instead of panicking on unresolved memory
  - `main.rs` - wires up executor, OS signal handler, double-Ctrl+C force exit, shutdown wait loop
  - `commands.rs` - add `Exit` command
  - `blockchain/manager.rs, syncer.rs` - shutdown token in `select` loops, replace `todo!()` with `break`
  - `txpool/manager.rs, incoming_tx.rs` - shutdown token, change ordering by priority due to using `biased`
  - `rpc/server.rs` - `with_graceful_shutdown` on axum, tracked spawns, shutdown token plumbed through
  - `rpc/handlers/other_json.rs` - wiring for `stop_daemon` RPC
  - `lib.rs` - `Node::launch` returns `Result`, creates and distributes `TaskExecutor`, Drop impl
- `storage/blockchain`:
  - `database.rs` - detach drop-log `info!` from caller span

### How
`monitor.rs` introduces `TaskExecutor`, took nomenclature inspo from [reth](https://reth.rs/docs/reth_ethereum/tasks/type.TaskExecutor.html). Instead of how reth does it though with a [static](https://github.com/paradigmxyz/reth/pull/15360/changes), its threaded into the functions to support running multiple `Node` instances in the same process

All `tokio::spawn` replaced with `TaskExecutor::spawn`. Task select loops now use `biased` ordering with the shutdown token as higher priority. 

On shutdown signal, the token is cancelled -> tasks wind down one by one, and `main()` waits on task tracker to finish unwinding before dropping the runtime.

`Node::launch` now returns `Result<Self, anyhow::Error>` instead of panicking on database/service init failures.

Double Ctrl+C force exits.