### PR TITLE
cuprated: Add graceful shutdown, pt2: service error propagation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1074,7 +1074,6 @@ dependencies = [
  "randomx-rs",
  "rayon",
  "strum",
- "thiserror 2.0.18",
  "thread_local",
  "tokio",
  "tokio-util",

--- a/binaries/cuprated/src/blockchain.rs
+++ b/binaries/cuprated/src/blockchain.rs
@@ -19,17 +19,18 @@ use cuprate_types::{
     VerifiedBlockInformation,
 };
 
-use crate::constants::PANIC_CRITICAL_SERVICE_ERROR;
-
 mod chain_service;
+mod error;
 mod fast_sync;
 pub mod interface;
 mod manager;
 mod syncer;
 mod types;
 
+pub use error::{BlockManagerError, BlockValidationError, IncomingBlockError};
 pub use fast_sync::get_fast_sync_hashes;
 pub use interface::BlockchainManagerHandle;
+pub use manager::IncomingBlockOk;
 pub use syncer::BlockchainSyncerHandle;
 pub use types::ConsensusBlockchainReadHandle;
 
@@ -100,17 +101,16 @@ pub async fn check_add_genesis(
     blockchain_read_handle: &mut BlockchainReadHandle,
     blockchain_write_handle: &mut BlockchainWriteHandle,
     network: Network,
-) {
+) -> anyhow::Result<()> {
     // Try to get the chain height, will fail if the genesis block is not in the DB.
     if blockchain_read_handle
         .ready()
-        .await
-        .expect(PANIC_CRITICAL_SERVICE_ERROR)
+        .await?
         .call(BlockchainReadRequest::ChainHeight)
         .await
         .is_ok()
     {
-        return;
+        return Ok(());
     }
 
     let genesis = generate_genesis_block(network);
@@ -120,8 +120,7 @@ pub async fn check_add_genesis(
 
     blockchain_write_handle
         .ready()
-        .await
-        .expect(PANIC_CRITICAL_SERVICE_ERROR)
+        .await?
         .call(BlockchainWriteRequest::WriteBlock(
             VerifiedBlockInformation {
                 block_blob: genesis.serialize(),
@@ -138,8 +137,9 @@ pub async fn check_add_genesis(
                 block: genesis,
             },
         ))
-        .await
-        .expect(PANIC_CRITICAL_SERVICE_ERROR);
+        .await?;
+
+    Ok(())
 }
 
 /// Initializes the consensus services.

--- a/binaries/cuprated/src/blockchain.rs
+++ b/binaries/cuprated/src/blockchain.rs
@@ -27,7 +27,7 @@ mod manager;
 mod syncer;
 mod types;
 
-pub use error::{BlockValidationError, IncomingBlockError};
+pub use error::IncomingBlockError;
 pub use fast_sync::get_fast_sync_hashes;
 pub use interface::BlockchainManagerHandle;
 pub use manager::IncomingBlockOk;

--- a/binaries/cuprated/src/blockchain.rs
+++ b/binaries/cuprated/src/blockchain.rs
@@ -27,7 +27,7 @@ mod manager;
 mod syncer;
 mod types;
 
-pub use error::{BlockManagerError, BlockValidationError, IncomingBlockError};
+pub use error::{BlockValidationError, IncomingBlockError};
 pub use fast_sync::get_fast_sync_hashes;
 pub use interface::BlockchainManagerHandle;
 pub use manager::IncomingBlockOk;

--- a/binaries/cuprated/src/blockchain/error.rs
+++ b/binaries/cuprated/src/blockchain/error.rs
@@ -3,7 +3,6 @@
 use cuprate_blockchain::BlockchainError;
 use cuprate_consensus::ExtendedConsensusError;
 use cuprate_consensus_rules::{blocks::BlockError, hard_forks::HardForkError, ConsensusError};
-use cuprate_txpool::TxPoolError;
 use cuprate_types::TxConversionError;
 
 macro_rules! impl_internal_from {
@@ -110,4 +109,4 @@ impl From<ConsensusError> for IncomingBlockError {
     }
 }
 
-impl_internal_from!(BlockchainError, TxPoolError, TxConversionError);
+impl_internal_from!(BlockchainError, TxConversionError);

--- a/binaries/cuprated/src/blockchain/error.rs
+++ b/binaries/cuprated/src/blockchain/error.rs
@@ -20,11 +20,6 @@ macro_rules! impl_internal_from {
 /// A validation failure - the peer should be banned.
 #[derive(Debug, thiserror::Error)]
 pub enum BlockValidationError {
-    /// The block was received as an alt block but already exists on the
-    /// main chain.
-    #[error("Alt block already in main chain.")]
-    AlreadyInMainChain,
-
     /// The block failed consensus validation.
     #[error(transparent)]
     Consensus(ExtendedConsensusError),

--- a/binaries/cuprated/src/blockchain/error.rs
+++ b/binaries/cuprated/src/blockchain/error.rs
@@ -60,9 +60,13 @@ impl From<ConsensusError> for BlockManagerError {
 /// An error returned from [`BlockchainManagerHandle::handle_incoming_block`](super::interface::BlockchainManagerHandle::handle_incoming_block).
 #[derive(Debug, thiserror::Error)]
 pub enum IncomingBlockError {
-    /// Surfaced from the blockchain manager.
+    /// The peer sent us an invalid block; ban them.
     #[error(transparent)]
-    Manager(#[from] BlockManagerError),
+    Validation(BlockValidationError),
+
+    /// A node-side failure.
+    #[error(transparent)]
+    Internal(tower::BoxError),
 
     /// We are missing the block's parent.
     #[error("The block has an unknown parent.")]
@@ -83,9 +87,18 @@ pub enum IncomingBlockError {
     ChannelClosed,
 }
 
+impl From<BlockManagerError> for IncomingBlockError {
+    fn from(e: BlockManagerError) -> Self {
+        match e {
+            BlockManagerError::Validation(v) => Self::Validation(v),
+            BlockManagerError::Internal(i) => Self::Internal(i),
+        }
+    }
+}
+
 impl From<ConsensusError> for IncomingBlockError {
     fn from(e: ConsensusError) -> Self {
-        Self::Manager(e.into())
+        BlockManagerError::from(e).into()
     }
 }
 

--- a/binaries/cuprated/src/blockchain/error.rs
+++ b/binaries/cuprated/src/blockchain/error.rs
@@ -1,0 +1,92 @@
+//! Error types for the blockchain manager interface.
+
+use cuprate_blockchain::BlockchainError;
+use cuprate_consensus::ExtendedConsensusError;
+use cuprate_consensus_rules::ConsensusError;
+use cuprate_txpool::TxPoolError;
+use cuprate_types::TxConversionError;
+
+macro_rules! impl_internal_from {
+    ($($t:ty),* $(,)?) => {$(
+        impl From<$t> for BlockManagerError {
+            fn from(e: $t) -> Self { Self::Internal(e.into()) }
+        }
+        impl From<$t> for IncomingBlockError {
+            fn from(e: $t) -> Self { BlockManagerError::from(e).into() }
+        }
+    )*};
+}
+
+/// A validation failure - the peer should be banned.
+#[derive(Debug, thiserror::Error)]
+pub enum BlockValidationError {
+    /// The block was received as an alt block but already exists on the
+    /// main chain.
+    #[error("Alt block already in main chain.")]
+    AlreadyInMainChain,
+
+    /// The block failed consensus validation.
+    #[error(transparent)]
+    Consensus(ExtendedConsensusError),
+}
+
+/// An error from the blockchain manager's internal handlers.
+#[derive(Debug, thiserror::Error)]
+pub enum BlockManagerError {
+    /// The peer sent us an invalid block; ban them.
+    #[error(transparent)]
+    Validation(#[from] BlockValidationError),
+
+    /// A node-side failure.
+    #[error(transparent)]
+    Internal(#[from] tower::BoxError),
+}
+
+impl From<ExtendedConsensusError> for BlockManagerError {
+    fn from(e: ExtendedConsensusError) -> Self {
+        if let ExtendedConsensusError::DBErr(e) = e {
+            return Self::Internal(e);
+        }
+        BlockValidationError::Consensus(e).into()
+    }
+}
+
+impl From<ConsensusError> for BlockManagerError {
+    fn from(e: ConsensusError) -> Self {
+        BlockValidationError::Consensus(e.into()).into()
+    }
+}
+
+/// An error returned from [`BlockchainManagerHandle::handle_incoming_block`](super::interface::BlockchainManagerHandle::handle_incoming_block).
+#[derive(Debug, thiserror::Error)]
+pub enum IncomingBlockError {
+    /// Surfaced from the blockchain manager.
+    #[error(transparent)]
+    Manager(#[from] BlockManagerError),
+
+    /// We are missing the block's parent.
+    #[error("The block has an unknown parent.")]
+    Orphan,
+
+    /// Some transactions in the block were unknown.
+    ///
+    /// The inner values are the block hash and the indexes of the missing txs in the block.
+    #[error("Unknown transactions in block.")]
+    UnknownTransactions([u8; 32], Vec<usize>),
+
+    /// The block claimed more transactions than it contained.
+    #[error("Too many transactions given for block.")]
+    TooManyTxs,
+
+    /// The blockchain manager command channel is closed.
+    #[error("The blockchain manager command channel is closed.")]
+    ChannelClosed,
+}
+
+impl From<ConsensusError> for IncomingBlockError {
+    fn from(e: ConsensusError) -> Self {
+        Self::Manager(e.into())
+    }
+}
+
+impl_internal_from!(BlockchainError, TxPoolError, TxConversionError);

--- a/binaries/cuprated/src/blockchain/error.rs
+++ b/binaries/cuprated/src/blockchain/error.rs
@@ -2,7 +2,7 @@
 
 use cuprate_blockchain::BlockchainError;
 use cuprate_consensus::ExtendedConsensusError;
-use cuprate_consensus_rules::ConsensusError;
+use cuprate_consensus_rules::{blocks::BlockError, hard_forks::HardForkError, ConsensusError};
 use cuprate_txpool::TxPoolError;
 use cuprate_types::TxConversionError;
 
@@ -20,9 +20,13 @@ macro_rules! impl_internal_from {
 /// A validation failure - the peer should be banned.
 #[derive(Debug, thiserror::Error)]
 pub enum BlockValidationError {
-    /// The block failed consensus validation.
+    /// Invalid hard-fork rules.
     #[error(transparent)]
-    Consensus(ExtendedConsensusError),
+    HardFork(HardForkError),
+
+    /// Any other consensus rule violation.
+    #[error(transparent)]
+    Other(ExtendedConsensusError),
 }
 
 /// An error from the blockchain manager's internal handlers.
@@ -30,7 +34,7 @@ pub enum BlockValidationError {
 pub enum BlockManagerError {
     /// The peer sent us an invalid block; ban them.
     #[error(transparent)]
-    Validation(#[from] BlockValidationError),
+    Validation(BlockValidationError),
 
     /// A node-side failure.
     #[error(transparent)]
@@ -39,16 +43,25 @@ pub enum BlockManagerError {
 
 impl From<ExtendedConsensusError> for BlockManagerError {
     fn from(e: ExtendedConsensusError) -> Self {
-        if let ExtendedConsensusError::DBErr(e) = e {
-            return Self::Internal(e);
+        match e {
+            ExtendedConsensusError::DBErr(e) => Self::Internal(e),
+            ExtendedConsensusError::ConErr(ConsensusError::Block(BlockError::HardForkError(e))) => {
+                Self::Validation(BlockValidationError::HardFork(e))
+            }
+
+            ExtendedConsensusError::ConErr(_)
+            | ExtendedConsensusError::TxsIncludedWithBlockIncorrect
+            | ExtendedConsensusError::OneOrMoreBatchVerificationStatementsInvalid
+            | ExtendedConsensusError::NoBlocksToVerify => {
+                Self::Validation(BlockValidationError::Other(e))
+            }
         }
-        BlockValidationError::Consensus(e).into()
     }
 }
 
 impl From<ConsensusError> for BlockManagerError {
     fn from(e: ConsensusError) -> Self {
-        BlockValidationError::Consensus(e.into()).into()
+        ExtendedConsensusError::ConErr(e).into()
     }
 }
 

--- a/binaries/cuprated/src/blockchain/error.rs
+++ b/binaries/cuprated/src/blockchain/error.rs
@@ -1,43 +1,25 @@
 //! Error types for the blockchain manager interface.
 
 use cuprate_blockchain::BlockchainError;
-use cuprate_consensus_rules::{blocks::BlockError, hard_forks::HardForkError, ConsensusError};
+use cuprate_consensus::{block::BlockVerificationError, ExtendedConsensusError};
+use cuprate_consensus_rules::ConsensusError;
 use cuprate_txpool::TxPoolError;
 
 use crate::monitor::FatalError;
 
-/// A validation failure - the peer should be banned.
-#[derive(Debug, thiserror::Error)]
-pub enum BlockValidationError {
-    /// Invalid hard-fork rules.
-    #[error(transparent)]
-    HardFork(HardForkError),
-
-    /// Any other consensus rule violation.
-    #[error(transparent)]
-    Consensus(ConsensusError),
-}
-
-impl From<ConsensusError> for BlockValidationError {
-    fn from(e: ConsensusError) -> Self {
-        match e {
-            ConsensusError::Block(BlockError::HardForkError(hf)) => Self::HardFork(hf),
-            ConsensusError::Block(e) => Self::Consensus(ConsensusError::Block(e)),
-            ConsensusError::Transaction(e) => Self::Consensus(ConsensusError::Transaction(e)),
-        }
-    }
-}
-
 /// An error returned from [`BlockchainManagerHandle::handle_incoming_block`](super::interface::BlockchainManagerHandle::handle_incoming_block).
 #[derive(Debug, thiserror::Error)]
 pub enum IncomingBlockError {
-    /// The peer sent us an invalid block; ban them.
-    #[error(transparent)]
-    Validation(BlockValidationError),
+    /// The peer sent us an invalid block.
+    #[error("Block verification failed: {}", .inner)]
+    Validation {
+        pow_valid: bool,
+        inner: ConsensusError,
+    },
 
     /// We cannot recover; shut the node down.
     #[error(transparent)]
-    Fatal(FatalError),
+    Fatal(#[from] FatalError),
 
     /// We are missing the block's parent.
     #[error("The block has an unknown parent.")]
@@ -52,15 +34,16 @@ pub enum IncomingBlockError {
     /// The block claimed more transactions than it contained.
     #[error("Too many transactions given for block.")]
     TooManyTxs,
-
-    /// The blockchain manager command channel is closed.
-    #[error("The blockchain manager command channel is closed.")]
-    ChannelClosed,
 }
 
-impl From<ConsensusError> for IncomingBlockError {
-    fn from(e: ConsensusError) -> Self {
-        Self::Validation(e.into())
+impl From<BlockVerificationError> for IncomingBlockError {
+    fn from(error: BlockVerificationError) -> Self {
+        let BlockVerificationError { pow_valid, inner } = error;
+
+        match inner {
+            ExtendedConsensusError::FatalError(error) => Self::Fatal(error),
+            ExtendedConsensusError::ConsensusError(inner) => Self::Validation { pow_valid, inner },
+        }
     }
 }
 
@@ -71,7 +54,7 @@ impl From<BlockchainError> for IncomingBlockError {
 }
 
 impl From<TxPoolError> for IncomingBlockError {
-    fn from(e: TxPoolError) -> Self {
-        Self::Fatal(e.into())
+    fn from(v: TxPoolError) -> Self {
+        Self::Fatal(v.into())
     }
 }

--- a/binaries/cuprated/src/blockchain/error.rs
+++ b/binaries/cuprated/src/blockchain/error.rs
@@ -3,18 +3,8 @@
 use cuprate_blockchain::BlockchainError;
 use cuprate_consensus::ExtendedConsensusError;
 use cuprate_consensus_rules::{blocks::BlockError, hard_forks::HardForkError, ConsensusError};
-use cuprate_types::TxConversionError;
 
-macro_rules! impl_internal_from {
-    ($($t:ty),* $(,)?) => {$(
-        impl From<$t> for BlockManagerError {
-            fn from(e: $t) -> Self { Self::Internal(e.into()) }
-        }
-        impl From<$t> for IncomingBlockError {
-            fn from(e: $t) -> Self { BlockManagerError::from(e).into() }
-        }
-    )*};
-}
+use crate::monitor::FatalError;
 
 /// A validation failure - the peer should be banned.
 #[derive(Debug, thiserror::Error)]
@@ -25,42 +15,17 @@ pub enum BlockValidationError {
 
     /// Any other consensus rule violation.
     #[error(transparent)]
-    Other(ExtendedConsensusError),
+    Consensus(ExtendedConsensusError),
 }
 
-/// An error from the blockchain manager's internal handlers.
-#[derive(Debug, thiserror::Error)]
-pub enum BlockManagerError {
-    /// The peer sent us an invalid block; ban them.
-    #[error(transparent)]
-    Validation(BlockValidationError),
-
-    /// A node-side failure.
-    #[error(transparent)]
-    Internal(#[from] tower::BoxError),
-}
-
-impl From<ExtendedConsensusError> for BlockManagerError {
-    fn from(e: ExtendedConsensusError) -> Self {
+impl From<ConsensusError> for BlockValidationError {
+    fn from(e: ConsensusError) -> Self {
         match e {
-            ExtendedConsensusError::DBErr(e) => Self::Internal(e),
-            ExtendedConsensusError::ConErr(ConsensusError::Block(BlockError::HardForkError(e))) => {
-                Self::Validation(BlockValidationError::HardFork(e))
-            }
-
-            ExtendedConsensusError::ConErr(_)
-            | ExtendedConsensusError::TxsIncludedWithBlockIncorrect
-            | ExtendedConsensusError::OneOrMoreBatchVerificationStatementsInvalid
-            | ExtendedConsensusError::NoBlocksToVerify => {
-                Self::Validation(BlockValidationError::Other(e))
+            ConsensusError::Block(BlockError::HardForkError(hf)) => Self::HardFork(hf),
+            ConsensusError::Block(_) | ConsensusError::Transaction(_) => {
+                Self::Consensus(ExtendedConsensusError::ConErr(e))
             }
         }
-    }
-}
-
-impl From<ConsensusError> for BlockManagerError {
-    fn from(e: ConsensusError) -> Self {
-        ExtendedConsensusError::ConErr(e).into()
     }
 }
 
@@ -71,9 +36,9 @@ pub enum IncomingBlockError {
     #[error(transparent)]
     Validation(BlockValidationError),
 
-    /// A node-side failure.
+    /// We cannot recover; shut the node down.
     #[error(transparent)]
-    Internal(tower::BoxError),
+    Fatal(FatalError),
 
     /// We are missing the block's parent.
     #[error("The block has an unknown parent.")]
@@ -94,19 +59,14 @@ pub enum IncomingBlockError {
     ChannelClosed,
 }
 
-impl From<BlockManagerError> for IncomingBlockError {
-    fn from(e: BlockManagerError) -> Self {
-        match e {
-            BlockManagerError::Validation(v) => Self::Validation(v),
-            BlockManagerError::Internal(i) => Self::Internal(i),
-        }
-    }
-}
-
 impl From<ConsensusError> for IncomingBlockError {
     fn from(e: ConsensusError) -> Self {
-        BlockManagerError::from(e).into()
+        Self::Validation(e.into())
     }
 }
 
-impl_internal_from!(BlockchainError, TxConversionError);
+impl From<BlockchainError> for IncomingBlockError {
+    fn from(e: BlockchainError) -> Self {
+        Self::Fatal(e.into())
+    }
+}

--- a/binaries/cuprated/src/blockchain/error.rs
+++ b/binaries/cuprated/src/blockchain/error.rs
@@ -1,7 +1,6 @@
 //! Error types for the blockchain manager interface.
 
 use cuprate_blockchain::BlockchainError;
-use cuprate_consensus::ExtendedConsensusError;
 use cuprate_consensus_rules::{blocks::BlockError, hard_forks::HardForkError, ConsensusError};
 
 use crate::monitor::FatalError;
@@ -15,16 +14,15 @@ pub enum BlockValidationError {
 
     /// Any other consensus rule violation.
     #[error(transparent)]
-    Consensus(ExtendedConsensusError),
+    Consensus(ConsensusError),
 }
 
 impl From<ConsensusError> for BlockValidationError {
     fn from(e: ConsensusError) -> Self {
         match e {
             ConsensusError::Block(BlockError::HardForkError(hf)) => Self::HardFork(hf),
-            ConsensusError::Block(_) | ConsensusError::Transaction(_) => {
-                Self::Consensus(ExtendedConsensusError::ConErr(e))
-            }
+            ConsensusError::Block(e) => Self::Consensus(ConsensusError::Block(e)),
+            ConsensusError::Transaction(e) => Self::Consensus(ConsensusError::Transaction(e)),
         }
     }
 }

--- a/binaries/cuprated/src/blockchain/error.rs
+++ b/binaries/cuprated/src/blockchain/error.rs
@@ -2,6 +2,7 @@
 
 use cuprate_blockchain::BlockchainError;
 use cuprate_consensus_rules::{blocks::BlockError, hard_forks::HardForkError, ConsensusError};
+use cuprate_txpool::TxPoolError;
 
 use crate::monitor::FatalError;
 
@@ -65,6 +66,12 @@ impl From<ConsensusError> for IncomingBlockError {
 
 impl From<BlockchainError> for IncomingBlockError {
     fn from(e: BlockchainError) -> Self {
+        Self::Fatal(e.into())
+    }
+}
+
+impl From<TxPoolError> for IncomingBlockError {
+    fn from(e: TxPoolError) -> Self {
         Self::Fatal(e.into())
     }
 }

--- a/binaries/cuprated/src/blockchain/error.rs
+++ b/binaries/cuprated/src/blockchain/error.rs
@@ -11,9 +11,11 @@ use crate::monitor::FatalError;
 #[derive(Debug, thiserror::Error)]
 pub enum IncomingBlockError {
     /// The peer sent us an invalid block.
-    #[error("Block verification failed: {}", .inner)]
+    #[error("Block verification failed: {inner}")]
     Validation {
+        /// Whether the block's proof-of-work was verified before the failure.
         pow_valid: bool,
+        /// The consensus rule that was broken.
         inner: ConsensusError,
     },
 
@@ -34,6 +36,10 @@ pub enum IncomingBlockError {
     /// The block claimed more transactions than it contained.
     #[error("Too many transactions given for block.")]
     TooManyTxs,
+
+    /// The blockchain manager command channel is closed.
+    #[error("The blockchain manager command channel is closed.")]
+    ChannelClosed,
 }
 
 impl From<BlockVerificationError> for IncomingBlockError {

--- a/binaries/cuprated/src/blockchain/interface.rs
+++ b/binaries/cuprated/src/blockchain/interface.rs
@@ -94,9 +94,11 @@ impl BlockchainManagerHandle {
 
         let TxpoolReadResponse::TxsForBlock { mut txs, missing } = txpool_read_handle
             .ready()
-            .await?
+            .await
+            .expect("Txpool read service is always ready.")
             .call(TxpoolReadRequest::TxsForBlock(block.transactions.clone()))
-            .await?
+            .await
+            .map_err(|e| IncomingBlockError::Internal(e.into()))?
         else {
             unreachable!()
         };

--- a/binaries/cuprated/src/blockchain/interface.rs
+++ b/binaries/cuprated/src/blockchain/interface.rs
@@ -11,7 +11,7 @@ use monero_oxide::{block::Block, transaction::Transaction};
 use tokio::sync::{mpsc, oneshot};
 use tower::{Service, ServiceExt};
 
-use cuprate_blockchain::service::BlockchainReadHandle;
+use cuprate_blockchain::{service::BlockchainReadHandle, BlockchainError};
 use cuprate_consensus::transactions::new_tx_verification_data;
 use cuprate_txpool::service::{
     interface::{TxpoolReadRequest, TxpoolReadResponse},
@@ -19,9 +19,9 @@ use cuprate_txpool::service::{
 };
 use cuprate_types::blockchain::{BlockchainReadRequest, BlockchainResponse};
 
-use crate::{
-    blockchain::manager::{BlockchainManagerCommand, IncomingBlockOk},
-    constants::PANIC_CRITICAL_SERVICE_ERROR,
+use crate::blockchain::{
+    manager::{BlockchainManagerCommand, IncomingBlockOk},
+    IncomingBlockError,
 };
 
 /// Handle for the blockchain manager.
@@ -40,25 +40,6 @@ pub struct BlockchainManagerHandle {
     /// time for new blocks, so we would lose the benefit of sharded locks. A dashmap is made up of `RwLocks`
     /// which are also more expensive than `Mutex`s.
     blocks_being_handled: Arc<Mutex<HashSet<[u8; 32]>>>,
-}
-
-/// An error that can be returned from [`BlockchainManagerHandle::handle_incoming_block`].
-#[derive(Debug, thiserror::Error)]
-pub enum IncomingBlockError {
-    /// Some transactions in the block were unknown.
-    ///
-    /// The inner values are the block hash and the indexes of the missing txs in the block.
-    #[error("Unknown transactions in block.")]
-    UnknownTransactions([u8; 32], Vec<usize>),
-    /// We are missing the block's parent.
-    #[error("The block has an unknown parent.")]
-    Orphan,
-    /// The block was invalid.
-    #[error(transparent)]
-    InvalidBlock(anyhow::Error),
-    /// The blockchain manager command channel is closed.
-    #[error("The blockchain manager command channel is closed.")]
-    ChannelClosed,
 }
 
 impl BlockchainManagerHandle {
@@ -98,34 +79,24 @@ impl BlockchainManagerHandle {
         txpool_read_handle: &mut TxpoolReadHandle,
     ) -> Result<IncomingBlockOk, IncomingBlockError> {
         if given_txs.len() > block.transactions.len() {
-            return Err(IncomingBlockError::InvalidBlock(anyhow::anyhow!(
-                "Too many transactions given for block"
-            )));
+            return Err(IncomingBlockError::TooManyTxs);
         }
 
-        if !block_exists(block.header.previous, blockchain_read_handle)
-            .await
-            .expect(PANIC_CRITICAL_SERVICE_ERROR)
-        {
+        if !block_exists(block.header.previous, blockchain_read_handle).await? {
             return Err(IncomingBlockError::Orphan);
         }
 
         let block_hash = block.hash();
 
-        if block_exists(block_hash, blockchain_read_handle)
-            .await
-            .expect(PANIC_CRITICAL_SERVICE_ERROR)
-        {
+        if block_exists(block_hash, blockchain_read_handle).await? {
             return Ok(IncomingBlockOk::AlreadyHave);
         }
 
         let TxpoolReadResponse::TxsForBlock { mut txs, missing } = txpool_read_handle
             .ready()
-            .await
-            .expect(PANIC_CRITICAL_SERVICE_ERROR)
+            .await?
             .call(TxpoolReadRequest::TxsForBlock(block.transactions.clone()))
-            .await
-            .expect(PANIC_CRITICAL_SERVICE_ERROR)
+            .await?
         else {
             unreachable!()
         };
@@ -142,11 +113,7 @@ impl BlockchainManagerHandle {
                     return Err(IncomingBlockError::UnknownTransactions(block_hash, missing));
                 };
 
-                txs.insert(
-                    needed_hash,
-                    new_tx_verification_data(tx)
-                        .map_err(|e| IncomingBlockError::InvalidBlock(e.into()))?,
-                );
+                txs.insert(needed_hash, new_tx_verification_data(tx)?);
             }
         }
 
@@ -185,7 +152,6 @@ impl BlockchainManagerHandle {
         response_rx
             .await
             .map_err(|_| IncomingBlockError::ChannelClosed)?
-            .map_err(IncomingBlockError::InvalidBlock)
     }
 
     /// Pop blocks from the top of the blockchain.
@@ -211,7 +177,7 @@ impl BlockchainManagerHandle {
 async fn block_exists(
     block_hash: [u8; 32],
     blockchain_read_handle: &mut BlockchainReadHandle,
-) -> Result<bool, anyhow::Error> {
+) -> Result<bool, BlockchainError> {
     let BlockchainResponse::FindBlock(chain) = blockchain_read_handle
         .ready()
         .await?

--- a/binaries/cuprated/src/blockchain/interface.rs
+++ b/binaries/cuprated/src/blockchain/interface.rs
@@ -94,11 +94,9 @@ impl BlockchainManagerHandle {
 
         let TxpoolReadResponse::TxsForBlock { mut txs, missing } = txpool_read_handle
             .ready()
-            .await
-            .expect("Txpool read service is always ready.")
+            .await?
             .call(TxpoolReadRequest::TxsForBlock(block.transactions.clone()))
-            .await
-            .map_err(|e| IncomingBlockError::Fatal(e.into()))?
+            .await?
         else {
             unreachable!()
         };

--- a/binaries/cuprated/src/blockchain/interface.rs
+++ b/binaries/cuprated/src/blockchain/interface.rs
@@ -150,11 +150,11 @@ impl BlockchainManagerHandle {
                 response_tx,
             })
             .await
-            .map_err(|_| IncomingBlockError::Fatal("Blockchain manager channel closed".into()))?;
+            .map_err(|_| IncomingBlockError::ChannelClosed)?;
 
         response_rx
             .await
-            .map_err(|_| IncomingBlockError::Fatal("Blockchain manager channel closed".into()))?
+            .map_err(|_| IncomingBlockError::ChannelClosed)?
     }
 
     /// Pop blocks from the top of the blockchain.

--- a/binaries/cuprated/src/blockchain/interface.rs
+++ b/binaries/cuprated/src/blockchain/interface.rs
@@ -98,7 +98,7 @@ impl BlockchainManagerHandle {
             .expect("Txpool read service is always ready.")
             .call(TxpoolReadRequest::TxsForBlock(block.transactions.clone()))
             .await
-            .map_err(|e| IncomingBlockError::Internal(e.into()))?
+            .map_err(|e| IncomingBlockError::Fatal(e.into()))?
         else {
             unreachable!()
         };

--- a/binaries/cuprated/src/blockchain/interface.rs
+++ b/binaries/cuprated/src/blockchain/interface.rs
@@ -12,7 +12,7 @@ use tokio::sync::{mpsc, oneshot};
 use tower::{Service, ServiceExt};
 
 use cuprate_blockchain::{service::BlockchainReadHandle, BlockchainError};
-use cuprate_consensus::transactions::new_tx_verification_data;
+use cuprate_consensus::{block::BlockVerificationError, transactions::new_tx_verification_data};
 use cuprate_txpool::service::{
     interface::{TxpoolReadRequest, TxpoolReadResponse},
     TxpoolReadHandle,
@@ -113,7 +113,10 @@ impl BlockchainManagerHandle {
                     return Err(IncomingBlockError::UnknownTransactions(block_hash, missing));
                 };
 
-                txs.insert(needed_hash, new_tx_verification_data(tx)?);
+                txs.insert(
+                    needed_hash,
+                    new_tx_verification_data(tx).map_err(BlockVerificationError::invalid_pow)?,
+                );
             }
         }
 
@@ -147,11 +150,11 @@ impl BlockchainManagerHandle {
                 response_tx,
             })
             .await
-            .map_err(|_| IncomingBlockError::ChannelClosed)?;
+            .map_err(|_| IncomingBlockError::Fatal("Blockchain manager channel closed".into()))?;
 
         response_rx
             .await
-            .map_err(|_| IncomingBlockError::ChannelClosed)?
+            .map_err(|_| IncomingBlockError::Fatal("Blockchain manager channel closed".into()))?
     }
 
     /// Pop blocks from the top of the blockchain.

--- a/binaries/cuprated/src/blockchain/manager.rs
+++ b/binaries/cuprated/src/blockchain/manager.rs
@@ -7,11 +7,15 @@ use tokio_util::sync::CancellationToken;
 use tower::{BoxError, Service, ServiceExt};
 use tracing::error;
 
-use cuprate_blockchain::service::{BlockchainReadHandle, BlockchainWriteHandle};
+use cuprate_blockchain::{
+    service::{BlockchainReadHandle, BlockchainWriteHandle},
+    BlockchainError,
+};
 use cuprate_consensus::{
     BlockChainContextRequest, BlockChainContextResponse, BlockchainContextService,
     ExtendedConsensusError,
 };
+use cuprate_consensus_rules::ConsensusError;
 use cuprate_p2p::{
     block_downloader::{self, BlockBatch},
     BroadcastSvc, NetworkInterface,
@@ -20,16 +24,72 @@ use cuprate_p2p_core::ClearNet;
 use cuprate_txpool::service::TxpoolWriteHandle;
 use cuprate_types::{
     blockchain::{BlockchainReadRequest, BlockchainResponse},
-    Chain, TransactionVerificationData,
+    Chain, TransactionVerificationData, TxConversionError,
 };
 
 use crate::{
     blockchain::{
-        chain_service::ChainService, syncer::BlockchainSyncer, types::ConsensusBlockchainReadHandle,
+        chain_service::ChainService, syncer::BlockchainSyncer,
+        types::ConsensusBlockchainReadHandle, BlockValidationError, IncomingBlockError,
     },
+    monitor::FatalError,
     txpool::TxpoolManagerHandle,
     LaunchContext,
 };
+
+/// An error from the blockchain manager's internal handlers.
+#[derive(Debug, thiserror::Error)]
+pub enum BlockManagerError {
+    /// The peer sent us an invalid block; ban them.
+    #[error(transparent)]
+    Validation(BlockValidationError),
+
+    /// We cannot recover; shut the node down.
+    #[error(transparent)]
+    Fatal(#[from] FatalError),
+}
+
+impl From<ExtendedConsensusError> for BlockManagerError {
+    fn from(e: ExtendedConsensusError) -> Self {
+        match e {
+            ExtendedConsensusError::DBErr(e) => Self::Fatal(e),
+            ExtendedConsensusError::ConErr(e) => Self::Validation(e.into()),
+
+            ExtendedConsensusError::TxsIncludedWithBlockIncorrect
+            | ExtendedConsensusError::OneOrMoreBatchVerificationStatementsInvalid
+            | ExtendedConsensusError::NoBlocksToVerify => {
+                Self::Validation(BlockValidationError::Consensus(e))
+            }
+        }
+    }
+}
+
+impl From<ConsensusError> for BlockManagerError {
+    fn from(e: ConsensusError) -> Self {
+        Self::Validation(e.into())
+    }
+}
+
+impl From<BlockManagerError> for IncomingBlockError {
+    fn from(e: BlockManagerError) -> Self {
+        match e {
+            BlockManagerError::Validation(e) => Self::Validation(e),
+            BlockManagerError::Fatal(e) => Self::Fatal(e),
+        }
+    }
+}
+
+impl From<BlockchainError> for BlockManagerError {
+    fn from(e: BlockchainError) -> Self {
+        Self::Fatal(e.into())
+    }
+}
+
+impl From<TxConversionError> for BlockManagerError {
+    fn from(e: TxConversionError) -> Self {
+        Self::Fatal(e.into())
+    }
+}
 
 mod commands;
 mod handler;
@@ -135,7 +195,7 @@ impl BlockchainManager {
         mut block_batch_rx: mpsc::Receiver<(BlockBatch, Arc<OwnedSemaphorePermit>)>,
         mut command_rx: mpsc::Receiver<BlockchainManagerCommand>,
         shutdown_token: CancellationToken,
-    ) -> anyhow::Result<()> {
+    ) -> Result<(), FatalError> {
         loop {
             tokio::select! {
                 biased;
@@ -143,16 +203,12 @@ impl BlockchainManager {
                     break;
                 }
                 Some((batch, permit)) = block_batch_rx.recv() => {
-                    self.handle_incoming_block_batch(batch)
-                        .await
-                        .map_err(anyhow::Error::from_boxed)?;
+                    self.handle_incoming_block_batch(batch).await?;
 
                     drop(permit);
                 }
                 Some(incoming_command) = command_rx.recv() => {
-                    self.handle_command(incoming_command)
-                        .await
-                        .map_err(anyhow::Error::from_boxed)?;
+                    self.handle_command(incoming_command).await?;
                 }
             }
         }

--- a/binaries/cuprated/src/blockchain/manager.rs
+++ b/binaries/cuprated/src/blockchain/manager.rs
@@ -7,15 +7,10 @@ use tokio_util::sync::CancellationToken;
 use tower::{BoxError, Service, ServiceExt};
 use tracing::error;
 
-use cuprate_blockchain::{
-    service::{BlockchainReadHandle, BlockchainWriteHandle},
-    BlockchainError,
-};
+use cuprate_blockchain::service::{BlockchainReadHandle, BlockchainWriteHandle};
 use cuprate_consensus::{
     BlockChainContextRequest, BlockChainContextResponse, BlockchainContextService,
-    ExtendedConsensusError,
 };
-use cuprate_consensus_rules::ConsensusError;
 use cuprate_p2p::{
     block_downloader::{self, BlockBatch},
     BroadcastSvc, NetworkInterface,
@@ -24,7 +19,7 @@ use cuprate_p2p_core::ClearNet;
 use cuprate_txpool::service::TxpoolWriteHandle;
 use cuprate_types::{
     blockchain::{BlockchainReadRequest, BlockchainResponse},
-    Chain, TransactionVerificationData, TxConversionError,
+    Chain, TransactionVerificationData,
 };
 
 use crate::{

--- a/binaries/cuprated/src/blockchain/manager.rs
+++ b/binaries/cuprated/src/blockchain/manager.rs
@@ -54,12 +54,6 @@ impl From<ExtendedConsensusError> for BlockManagerError {
         match e {
             ExtendedConsensusError::DBErr(e) => Self::Fatal(e),
             ExtendedConsensusError::ConErr(e) => Self::Validation(e.into()),
-
-            ExtendedConsensusError::TxsIncludedWithBlockIncorrect
-            | ExtendedConsensusError::OneOrMoreBatchVerificationStatementsInvalid
-            | ExtendedConsensusError::NoBlocksToVerify => {
-                Self::Validation(BlockValidationError::Consensus(e))
-            }
         }
     }
 }

--- a/binaries/cuprated/src/blockchain/manager.rs
+++ b/binaries/cuprated/src/blockchain/manager.rs
@@ -27,7 +27,6 @@ use crate::{
     blockchain::{
         chain_service::ChainService, syncer::BlockchainSyncer, types::ConsensusBlockchainReadHandle,
     },
-    constants::PANIC_CRITICAL_SERVICE_ERROR,
     txpool::TxpoolManagerHandle,
     LaunchContext,
 };
@@ -66,15 +65,18 @@ pub(crate) async fn init_blockchain_manager(
         launch_ctx.config.offline,
     );
 
-    launch_ctx.task_executor.spawn(syncer.run(
-        launch_ctx.blockchain.context_svc(),
-        ChainService(launch_ctx.blockchain.read(), fast_sync_hashes),
-        clearnet_interface.clone(),
-        batch_tx,
-        Arc::clone(&stop_current_block_downloader),
-        block_downloader_config,
-        shutdown_token.clone(),
-    ));
+    launch_ctx.task_executor.spawn_critical(
+        "blockchain syncer",
+        syncer.run(
+            launch_ctx.blockchain.context_svc(),
+            ChainService(launch_ctx.blockchain.read(), fast_sync_hashes),
+            clearnet_interface.clone(),
+            batch_tx,
+            Arc::clone(&stop_current_block_downloader),
+            block_downloader_config,
+            shutdown_token.clone(),
+        ),
+    );
 
     let manager = BlockchainManager {
         blockchain_write_handle,
@@ -90,9 +92,10 @@ pub(crate) async fn init_blockchain_manager(
         fast_sync_hashes,
     };
 
-    launch_ctx
-        .task_executor
-        .spawn(manager.run(batch_rx, command_rx, shutdown_token));
+    launch_ctx.task_executor.spawn_critical(
+        "blockchain manager",
+        manager.run(batch_rx, command_rx, shutdown_token),
+    );
 
     Ok(())
 }
@@ -132,7 +135,7 @@ impl BlockchainManager {
         mut block_batch_rx: mpsc::Receiver<(BlockBatch, Arc<OwnedSemaphorePermit>)>,
         mut command_rx: mpsc::Receiver<BlockchainManagerCommand>,
         shutdown_token: CancellationToken,
-    ) {
+    ) -> anyhow::Result<()> {
         loop {
             tokio::select! {
                 biased;
@@ -140,21 +143,21 @@ impl BlockchainManager {
                     break;
                 }
                 Some((batch, permit)) = block_batch_rx.recv() => {
-                    self.handle_incoming_block_batch(
-                        batch,
-                    ).await;
+                    self.handle_incoming_block_batch(batch)
+                        .await
+                        .map_err(anyhow::Error::from_boxed)?;
 
                     drop(permit);
                 }
                 Some(incoming_command) = command_rx.recv() => {
-                    self.handle_command(incoming_command).await;
-                }
-                else => {
-                    break;
+                    self.handle_command(incoming_command)
+                        .await
+                        .map_err(anyhow::Error::from_boxed)?;
                 }
             }
         }
 
         tracing::info!("Blockchain manager shut down.");
+        Ok(())
     }
 }

--- a/binaries/cuprated/src/blockchain/manager.rs
+++ b/binaries/cuprated/src/blockchain/manager.rs
@@ -29,61 +29,12 @@ use cuprate_types::{
 
 use crate::{
     blockchain::{
-        chain_service::ChainService, syncer::BlockchainSyncer,
-        types::ConsensusBlockchainReadHandle, BlockValidationError, IncomingBlockError,
+        chain_service::ChainService, syncer::BlockchainSyncer, types::ConsensusBlockchainReadHandle,
     },
     monitor::FatalError,
     txpool::TxpoolManagerHandle,
     LaunchContext,
 };
-
-/// An error from the blockchain manager's internal handlers.
-#[derive(Debug, thiserror::Error)]
-pub enum BlockManagerError {
-    /// The peer sent us an invalid block; ban them.
-    #[error(transparent)]
-    Validation(BlockValidationError),
-
-    /// We cannot recover; shut the node down.
-    #[error(transparent)]
-    Fatal(#[from] FatalError),
-}
-
-impl From<ExtendedConsensusError> for BlockManagerError {
-    fn from(e: ExtendedConsensusError) -> Self {
-        match e {
-            ExtendedConsensusError::DBErr(e) => Self::Fatal(e),
-            ExtendedConsensusError::ConErr(e) => Self::Validation(e.into()),
-        }
-    }
-}
-
-impl From<ConsensusError> for BlockManagerError {
-    fn from(e: ConsensusError) -> Self {
-        Self::Validation(e.into())
-    }
-}
-
-impl From<BlockManagerError> for IncomingBlockError {
-    fn from(e: BlockManagerError) -> Self {
-        match e {
-            BlockManagerError::Validation(e) => Self::Validation(e),
-            BlockManagerError::Fatal(e) => Self::Fatal(e),
-        }
-    }
-}
-
-impl From<BlockchainError> for BlockManagerError {
-    fn from(e: BlockchainError) -> Self {
-        Self::Fatal(e.into())
-    }
-}
-
-impl From<TxConversionError> for BlockManagerError {
-    fn from(e: TxConversionError) -> Self {
-        Self::Fatal(e.into())
-    }
-}
 
 mod commands;
 mod handler;

--- a/binaries/cuprated/src/blockchain/manager/commands.rs
+++ b/binaries/cuprated/src/blockchain/manager/commands.rs
@@ -6,6 +6,8 @@ use tokio::sync::oneshot;
 
 use cuprate_types::TransactionVerificationData;
 
+use crate::blockchain::IncomingBlockError;
+
 /// The blockchain manager commands.
 #[expect(clippy::large_enum_variant)]
 pub enum BlockchainManagerCommand {
@@ -16,7 +18,7 @@ pub enum BlockchainManagerCommand {
         /// All the transactions defined in [`Block::transactions`].
         prepped_txs: HashMap<[u8; 32], TransactionVerificationData>,
         /// The channel to send the response down.
-        response_tx: oneshot::Sender<Result<IncomingBlockOk, anyhow::Error>>,
+        response_tx: oneshot::Sender<Result<IncomingBlockOk, IncomingBlockError>>,
     },
     /// Pop blocks from the top of the blockchain.
     PopBlocks {

--- a/binaries/cuprated/src/blockchain/manager/handler.rs
+++ b/binaries/cuprated/src/blockchain/manager/handler.rs
@@ -23,7 +23,11 @@ use cuprate_consensus::{
 use cuprate_consensus_context::{distribution::rct_output_count, BlockchainContext, NewBlockData};
 use cuprate_fast_sync::{block_to_verified_block_information, fast_sync_stop_height};
 use cuprate_helper::cast::usize_to_u64;
-use cuprate_p2p::{block_downloader::BlockBatch, constants::LONG_BAN, BroadcastRequest};
+use cuprate_p2p::{
+    block_downloader::BlockBatch,
+    constants::{LONG_BAN, MEDIUM_BAN},
+    BroadcastRequest,
+};
 use cuprate_txpool::service::interface::TxpoolWriteRequest;
 use cuprate_types::{
     blockchain::{BlockchainReadRequest, BlockchainResponse, BlockchainWriteRequest},
@@ -246,8 +250,12 @@ impl super::BlockchainManager {
         {
             Ok(v) => v,
             Err(BlockManagerError::Internal(e)) => return Err(e),
-            Err(BlockManagerError::Validation(_)) => {
-                batch.peer_handle.ban_peer(LONG_BAN);
+            Err(BlockManagerError::Validation(e)) => {
+                let duration = match e {
+                    BlockValidationError::HardFork(_) => MEDIUM_BAN,
+                    BlockValidationError::Other(_) => LONG_BAN,
+                };
+                batch.peer_handle.ban_peer(duration);
                 self.stop_current_block_downloader.notify_waiters();
                 return Ok(());
             }
@@ -255,6 +263,7 @@ impl super::BlockchainManager {
 
         for (block, txs) in prepped_blocks {
             let hash = block.block_hash;
+            let block_version = block.hf_version.as_u8();
             let verified_block = match verify_prepped_main_chain_block(
                 block,
                 txs,
@@ -268,12 +277,27 @@ impl super::BlockchainManager {
                 Ok(block) => block,
                 Err(BlockManagerError::Internal(e)) => return Err(e),
                 Err(BlockManagerError::Validation(e)) => {
-                    warn!(
-                        "Failed to verify block: {}, error {}, banning peer.",
-                        hex::encode(hash),
-                        e
-                    );
-                    batch.peer_handle.ban_peer(LONG_BAN);
+                    let duration = match e {
+                        BlockValidationError::HardFork(e) => {
+                            warn!(
+                                "Failed to verify block: {}, error {} (block v{}, current v{}), banning peer.",
+                                hex::encode(hash),
+                                e,
+                                block_version,
+                                self.blockchain_context_service.blockchain_context().current_hf.as_u8()
+                            );
+                            MEDIUM_BAN
+                        }
+                        BlockValidationError::Other(e) => {
+                            warn!(
+                                "Failed to verify block: {}, error {}, banning peer.",
+                                hex::encode(hash),
+                                e
+                            );
+                            LONG_BAN
+                        }
+                    };
+                    batch.peer_handle.ban_peer(duration);
                     self.stop_current_block_downloader.notify_waiters();
                     return Ok(());
                 }
@@ -335,6 +359,7 @@ impl super::BlockchainManager {
 
         while let Some((block, txs)) = blocks.next() {
             let hash = block.hash();
+            let block_version = block.header.hardfork_version;
 
             // async blocks work as try blocks.
             let res = async {
@@ -355,12 +380,27 @@ impl super::BlockchainManager {
             match res {
                 Err(BlockManagerError::Internal(e)) => return Err(e),
                 Err(BlockManagerError::Validation(e)) => {
-                    warn!(
-                        "Failed to verify block: {}, error {}, banning peer.",
-                        hex::encode(hash),
-                        e
-                    );
-                    batch.peer_handle.ban_peer(LONG_BAN);
+                    let duration = match e {
+                        BlockValidationError::HardFork(e) => {
+                            warn!(
+                                "Failed to verify block: {}, error {} (block v{}, current v{}), banning peer.",
+                                hex::encode(hash),
+                                e,
+                                block_version,
+                                self.blockchain_context_service.blockchain_context().current_hf.as_u8()
+                            );
+                            MEDIUM_BAN
+                        }
+                        BlockValidationError::Other(e) => {
+                            warn!(
+                                "Failed to verify block: {}, error {}, banning peer.",
+                                hex::encode(hash),
+                                e
+                            );
+                            LONG_BAN
+                        }
+                    };
+                    batch.peer_handle.ban_peer(duration);
                     self.stop_current_block_downloader.notify_waiters();
                     return Ok(());
                 }

--- a/binaries/cuprated/src/blockchain/manager/handler.rs
+++ b/binaries/cuprated/src/blockchain/manager/handler.rs
@@ -27,51 +27,52 @@ use cuprate_p2p::{block_downloader::BlockBatch, constants::LONG_BAN, BroadcastRe
 use cuprate_txpool::service::interface::TxpoolWriteRequest;
 use cuprate_types::{
     blockchain::{BlockchainReadRequest, BlockchainResponse, BlockchainWriteRequest},
-    AltBlockInformation, Chain, ChainId, HardFork, TransactionVerificationData,
+    AltBlockInformation, Chain, ChainId, HardFork, TransactionVerificationData, TxConversionError,
     VerifiedBlockInformation, VerifiedTransactionInformation,
 };
 
-use crate::{
-    blockchain::manager::commands::{BlockchainManagerCommand, IncomingBlockOk},
-    constants::PANIC_CRITICAL_SERVICE_ERROR,
+use crate::blockchain::{
+    manager::commands::{BlockchainManagerCommand, IncomingBlockOk},
+    BlockManagerError, BlockValidationError,
 };
 
 impl super::BlockchainManager {
     /// Handle an incoming command from another part of Cuprate.
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// This function will panic if any internal service returns an unexpected error that we cannot
-    /// recover from.
-    pub async fn handle_command(&mut self, command: BlockchainManagerCommand) {
+    /// This function will return an [`Err`] if any internal service returns an unexpected error.
+    pub async fn handle_command(
+        &mut self,
+        command: BlockchainManagerCommand,
+    ) -> Result<(), tower::BoxError> {
         match command {
             BlockchainManagerCommand::AddBlock {
                 block,
                 prepped_txs,
                 response_tx,
-            } => {
-                let res = self.handle_incoming_block(block, prepped_txs).await;
-
-                drop(response_tx.send(res));
-            }
+            } => match self.handle_incoming_block(block, prepped_txs).await {
+                Err(BlockManagerError::Internal(e)) => return Err(e),
+                res => {
+                    let _ = response_tx.send(res.map_err(Into::into));
+                }
+            },
             BlockchainManagerCommand::PopBlocks {
                 numb_blocks,
                 response_tx,
             } => {
                 let reorg_lock = Arc::clone(&self.reorg_lock);
                 let _guard = reorg_lock.write().await;
-                self.pop_blocks(numb_blocks).await;
+                self.pop_blocks(numb_blocks).await?;
                 self.blockchain_write_handle
                     .ready()
-                    .await
-                    .expect(PANIC_CRITICAL_SERVICE_ERROR)
+                    .await?
                     .call(BlockchainWriteRequest::FlushAltBlocks)
-                    .await
-                    .expect(PANIC_CRITICAL_SERVICE_ERROR);
-                #[expect(clippy::let_underscore_must_use)]
+                    .await?;
                 let _ = response_tx.send(());
             }
         }
+        Ok(())
     }
 
     /// Broadcast a valid block to the network.
@@ -95,9 +96,9 @@ impl super::BlockchainManager {
     ///
     /// Otherwise, this function will validate and add the block to the main chain.
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// This function will panic if any internal service returns an unexpected error that we cannot
+    /// This function will return an [`Err`] if any internal service returns an unexpected error that we cannot
     /// recover from.
     #[instrument(
         name = "incoming_block",
@@ -112,7 +113,7 @@ impl super::BlockchainManager {
         &mut self,
         block: Block,
         prepared_txs: HashMap<[u8; 32], TransactionVerificationData>,
-    ) -> Result<IncomingBlockOk, anyhow::Error> {
+    ) -> Result<IncomingBlockOk, BlockManagerError> {
         if block.header.previous
             != self
                 .blockchain_context_service
@@ -149,7 +150,7 @@ impl super::BlockchainManager {
         .await?;
 
         self.add_valid_block_to_main_chain(verified_block, BlockSource::Incoming)
-            .await;
+            .await?;
 
         info!(
             hash = hex::encode(
@@ -168,10 +169,14 @@ impl super::BlockchainManager {
     /// This function will route to [`Self::handle_incoming_block_batch_main_chain`] or [`Self::handle_incoming_block_batch_alt_chain`]
     /// depending on if the first block in the batch follows from the top of our chain.
     ///
+    /// # Errors
+    ///
+    /// This function will return an [`Err`] if any internal service returns an unexpected
+    /// error that we cannot recover from.
+    ///
     /// # Panics
     ///
-    /// This function will panic if the batch is empty or if any internal service returns an unexpected
-    /// error that we cannot recover from or if the incoming batch contains no blocks.
+    /// This function will panic if the incoming batch contains no blocks.
     #[instrument(
         name = "incoming_block_batch",
         skip_all,
@@ -181,7 +186,10 @@ impl super::BlockchainManager {
             len = batch.blocks.len()
         )
     )]
-    pub async fn handle_incoming_block_batch(&mut self, batch: BlockBatch) {
+    pub async fn handle_incoming_block_batch(
+        &mut self,
+        batch: BlockBatch,
+    ) -> Result<(), tower::BoxError> {
         let (first_block, _) = batch
             .blocks
             .first()
@@ -193,9 +201,9 @@ impl super::BlockchainManager {
                 .blockchain_context()
                 .top_hash
         {
-            self.handle_incoming_block_batch_main_chain(batch).await;
+            self.handle_incoming_block_batch_main_chain(batch).await
         } else {
-            self.handle_incoming_block_batch_alt_chain(batch).await;
+            self.handle_incoming_block_batch_alt_chain(batch).await
         }
     }
 
@@ -207,26 +215,42 @@ impl super::BlockchainManager {
     /// This function will also handle banning the peer and canceling the block downloader if the
     /// block is invalid.
     ///
+    /// # Errors
+    ///
+    /// This function will return an [`Err`] if any internal service returns an unexpected error that we cannot
+    /// recover from.
+    ///
     /// # Panics
     ///
-    /// This function will panic if any internal service returns an unexpected error that we cannot
-    /// recover from or if the incoming batch contains no blocks.
-    async fn handle_incoming_block_batch_main_chain(&mut self, batch: BlockBatch) {
-        if batch.blocks.last().unwrap().0.number() < fast_sync_stop_height(self.fast_sync_hashes) {
-            self.handle_incoming_block_batch_fast_sync(batch).await;
-            return;
+    /// This function will panic if the incoming batch contains no blocks.
+    async fn handle_incoming_block_batch_main_chain(
+        &mut self,
+        batch: BlockBatch,
+    ) -> Result<(), tower::BoxError> {
+        let (last_block, _) = batch
+            .blocks
+            .last()
+            .expect("Block batch should not be empty");
+
+        if last_block.number() < fast_sync_stop_height(self.fast_sync_hashes) {
+            return self.handle_incoming_block_batch_fast_sync(batch).await;
         }
 
-        let Ok((prepped_blocks, mut output_cache)) = batch_prepare_main_chain_blocks(
+        let (prepped_blocks, mut output_cache) = match batch_prepare_main_chain_blocks(
             batch.blocks,
             &mut self.blockchain_context_service,
             self.blockchain_read_handle.clone(),
         )
         .await
-        else {
-            batch.peer_handle.ban_peer(LONG_BAN);
-            self.stop_current_block_downloader.notify_waiters();
-            return;
+        .map_err(BlockManagerError::from)
+        {
+            Ok(v) => v,
+            Err(BlockManagerError::Internal(e)) => return Err(e),
+            Err(BlockManagerError::Validation(_)) => {
+                batch.peer_handle.ban_peer(LONG_BAN);
+                self.stop_current_block_downloader.notify_waiters();
+                return Ok(());
+            }
         };
 
         for (block, txs) in prepped_blocks {
@@ -239,9 +263,11 @@ impl super::BlockchainManager {
                 Some(&mut output_cache),
             )
             .await
+            .map_err(BlockManagerError::from)
             {
                 Ok(block) => block,
-                Err(e) => {
+                Err(BlockManagerError::Internal(e)) => return Err(e),
+                Err(BlockManagerError::Validation(e)) => {
                     warn!(
                         "Failed to verify block: {}, error {}, banning peer.",
                         hex::encode(hash),
@@ -249,23 +275,27 @@ impl super::BlockchainManager {
                     );
                     batch.peer_handle.ban_peer(LONG_BAN);
                     self.stop_current_block_downloader.notify_waiters();
-                    return;
+                    return Ok(());
                 }
             };
 
             self.add_valid_block_to_main_chain(verified_block, BlockSource::BatchSync)
-                .await;
+                .await?;
         }
         info!(fast_sync = false, "Successfully added block batch");
+        Ok(())
     }
 
     /// Handles an incoming block batch while we are under the fast sync height.
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// This function will panic if any internal service returns an unexpected error that we cannot
+    /// This function will return an [`Err`] if any internal service returns an unexpected error that we cannot
     /// recover from.
-    async fn handle_incoming_block_batch_fast_sync(&mut self, batch: BlockBatch) {
+    async fn handle_incoming_block_batch_fast_sync(
+        &mut self,
+        batch: BlockBatch,
+    ) -> Result<(), tower::BoxError> {
         let mut valid_blocks = Vec::with_capacity(batch.blocks.len());
         for (block, txs) in batch.blocks {
             let block = block_to_verified_block_information(
@@ -273,15 +303,16 @@ impl super::BlockchainManager {
                 txs,
                 self.blockchain_context_service.blockchain_context(),
             );
-            self.add_valid_block_to_blockchain_cache(&block).await;
+            self.add_valid_block_to_blockchain_cache(&block).await?;
 
             valid_blocks.push(block);
         }
 
         self.batch_add_valid_block_to_blockchain_database(valid_blocks)
-            .await;
+            .await?;
 
         info!(fast_sync = true, "Successfully added block batch");
+        Ok(())
     }
 
     /// Handles an incoming [`BlockBatch`] that does not follow the main-chain.
@@ -292,11 +323,14 @@ impl super::BlockchainManager {
     /// This function will also handle banning the peer and canceling the block downloader if the
     /// alt block is invalid or if a reorg fails.
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// This function will panic if any internal service returns an unexpected error that we cannot
+    /// This function will return an [`Err`] if any internal service returns an unexpected error that we cannot
     /// recover from.
-    async fn handle_incoming_block_batch_alt_chain(&mut self, mut batch: BlockBatch) {
+    async fn handle_incoming_block_batch_alt_chain(
+        &mut self,
+        mut batch: BlockBatch,
+    ) -> Result<(), tower::BoxError> {
         let mut blocks = batch.blocks.into_iter();
 
         while let Some((block, txs)) = blocks.next() {
@@ -310,16 +344,17 @@ impl super::BlockchainManager {
                         let tx = new_tx_verification_data(tx)?;
                         Ok((tx.tx_hash, tx))
                     })
-                    .collect::<Result<_, anyhow::Error>>()?;
+                    .collect::<Result<_, BlockManagerError>>()?;
 
                 let reorged = self.handle_incoming_alt_block(block, txs).await?;
 
-                Ok::<_, anyhow::Error>(reorged)
+                Ok::<_, BlockManagerError>(reorged)
             }
             .await;
 
             match res {
-                Err(e) => {
+                Err(BlockManagerError::Internal(e)) => return Err(e),
+                Err(BlockManagerError::Validation(e)) => {
                     warn!(
                         "Failed to verify block: {}, error {}, banning peer.",
                         hex::encode(hash),
@@ -327,18 +362,17 @@ impl super::BlockchainManager {
                     );
                     batch.peer_handle.ban_peer(LONG_BAN);
                     self.stop_current_block_downloader.notify_waiters();
-                    return;
+                    return Ok(());
                 }
                 Ok(AddAltBlock::Reorged) => {
                     // Collect the remaining blocks and add them to the main chain instead.
                     batch.blocks = blocks.collect();
 
                     if batch.blocks.is_empty() {
-                        return;
+                        return Ok(());
                     }
 
-                    self.handle_incoming_block_batch_main_chain(batch).await;
-                    return;
+                    return self.handle_incoming_block_batch_main_chain(batch).await;
                 }
                 // continue adding alt blocks.
                 Ok(AddAltBlock::NewlyCached(_) | AddAltBlock::AlreadyCached) => (),
@@ -346,6 +380,7 @@ impl super::BlockchainManager {
         }
 
         info!(alt_chain = true, "Successfully added block batch");
+        Ok(())
     }
 
     /// Handles an incoming alt [`Block`].
@@ -359,32 +394,26 @@ impl super::BlockchainManager {
     /// This will return an [`Err`] if:
     ///  - The alt block was invalid.
     ///  - An attempt to reorg the chain failed.
-    ///
-    /// # Panics
-    ///
-    /// This function will panic if any internal service returns an unexpected error that we cannot
-    /// recover from.
+    ///  - Any internal service returns an unexpected error.
     async fn handle_incoming_alt_block(
         &mut self,
         block: Block,
         prepared_txs: HashMap<[u8; 32], TransactionVerificationData>,
-    ) -> Result<AddAltBlock, anyhow::Error> {
+    ) -> Result<AddAltBlock, BlockManagerError> {
         // Check if a block already exists.
         let BlockchainResponse::FindBlock(chain) = self
             .blockchain_read_handle
             .ready()
-            .await
-            .expect(PANIC_CRITICAL_SERVICE_ERROR)
+            .await?
             .call(BlockchainReadRequest::FindBlock(block.hash()))
-            .await
-            .expect(PANIC_CRITICAL_SERVICE_ERROR)
+            .await?
         else {
             unreachable!();
         };
 
         match chain {
             Some((Chain::Alt(_), _)) => return Ok(AddAltBlock::AlreadyCached),
-            Some((Chain::Main, _)) => anyhow::bail!("Alt block already in main chain"),
+            Some((Chain::Main, _)) => return Err(BlockValidationError::AlreadyInMainChain.into()),
             None => (),
         }
 
@@ -406,8 +435,7 @@ impl super::BlockchainManager {
         let block_blob = Bytes::copy_from_slice(&alt_block_info.block_blob);
         self.blockchain_write_handle
             .ready()
-            .await
-            .expect(PANIC_CRITICAL_SERVICE_ERROR)
+            .await?
             .call(BlockchainWriteRequest::WriteAltBlock(alt_block_info))
             .await?;
 
@@ -422,31 +450,25 @@ impl super::BlockchainManager {
     ///
     /// # Errors
     ///
-    /// This function will return an [`Err`] if the re-org was unsuccessful, if this happens the chain
-    /// will be returned back into its state it was at when then function was called.
-    ///
-    /// # Panics
-    ///
-    /// This function will panic if any internal service returns an unexpected error that we cannot
-    /// recover from.
+    /// This function will return an [`Err`] if any internal service returns an unexpected error,
+    /// or if the re-org was unsuccessful. If this happens the chain
+    /// will be returned to the state it was in when the function was called.
     #[instrument(name = "try_do_reorg", skip_all, level = "info")]
     async fn try_do_reorg(
         &mut self,
         top_alt_block: AltBlockInformation,
-    ) -> Result<(), anyhow::Error> {
+    ) -> Result<(), BlockManagerError> {
         let reorg_lock = Arc::clone(&self.reorg_lock);
         let _guard = reorg_lock.write().await;
 
         let BlockchainResponse::AltBlocksInChain(mut alt_blocks) = self
             .blockchain_read_handle
             .ready()
-            .await
-            .expect(PANIC_CRITICAL_SERVICE_ERROR)
+            .await?
             .call(BlockchainReadRequest::AltBlocksInChain(
                 top_alt_block.chain_id,
             ))
-            .await
-            .map_err(|e| anyhow::anyhow!(e))?
+            .await?
         else {
             unreachable!();
         };
@@ -463,7 +485,7 @@ impl super::BlockchainManager {
 
         let old_main_chain_id = self
             .pop_blocks(current_main_chain_height - split_height)
-            .await;
+            .await?;
 
         let reorg_res = self.verify_add_alt_blocks_to_main_chain(alt_blocks).await;
 
@@ -480,7 +502,7 @@ impl super::BlockchainManager {
                 Ok(())
             }
             Err(e) => {
-                self.reverse_reorg(old_main_chain_id).await;
+                self.reverse_reorg(old_main_chain_id).await?;
                 Err(e)
             }
         }
@@ -491,22 +513,20 @@ impl super::BlockchainManager {
     /// This function takes the old chain's [`ChainId`] and reverts the chain state to back to before
     /// the reorg was attempted.
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// This function will panic if any internal service returns an unexpected error that we cannot
+    /// This function will return an [`Err`] if any internal service returns an unexpected error that we cannot
     /// recover from.
     #[instrument(name = "reverse_reorg", skip_all, level = "info")]
-    async fn reverse_reorg(&mut self, old_main_chain_id: ChainId) {
+    async fn reverse_reorg(&mut self, old_main_chain_id: ChainId) -> Result<(), tower::BoxError> {
         warn!("Reorg failed, reverting to old chain.");
 
         let BlockchainResponse::AltBlocksInChain(mut blocks) = self
             .blockchain_read_handle
             .ready()
-            .await
-            .expect(PANIC_CRITICAL_SERVICE_ERROR)
+            .await?
             .call(BlockchainReadRequest::AltBlocksInChain(old_main_chain_id))
-            .await
-            .expect(PANIC_CRITICAL_SERVICE_ERROR)
+            .await?
         else {
             unreachable!();
         };
@@ -521,7 +541,7 @@ impl super::BlockchainManager {
 
         if numb_blocks > 0 {
             self.pop_blocks(current_main_chain_height - split_height)
-                .await;
+                .await?;
         }
 
         for block in blocks {
@@ -530,51 +550,46 @@ impl super::BlockchainManager {
                 self.blockchain_context_service.blockchain_context(),
             );
             self.add_valid_block_to_main_chain(verified_block, BlockSource::Reorg)
-                .await;
+                .await?;
         }
 
         self.blockchain_write_handle
             .ready()
-            .await
-            .expect(PANIC_CRITICAL_SERVICE_ERROR)
+            .await?
             .call(BlockchainWriteRequest::FlushAltBlocks)
-            .await
-            .expect(PANIC_CRITICAL_SERVICE_ERROR);
+            .await?;
 
         info!("Successfully reversed reorg");
+        Ok(())
     }
 
     /// Pop blocks from the main chain, moving them to alt-blocks. This function will flush all other alt-blocks.
     ///
     /// This returns the [`ChainId`] of the blocks that were popped.
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// This function will panic if any internal service returns an unexpected error that we cannot
+    /// This function will return an [`Err`] if any internal service returns an unexpected error that we cannot
     /// recover from.
     #[instrument(name = "pop_blocks", skip(self), level = "info")]
-    async fn pop_blocks(&mut self, numb_blocks: usize) -> ChainId {
+    async fn pop_blocks(&mut self, numb_blocks: usize) -> Result<ChainId, tower::BoxError> {
         let BlockchainResponse::PopBlocks(old_main_chain_id) = self
             .blockchain_write_handle
             .ready()
-            .await
-            .expect(PANIC_CRITICAL_SERVICE_ERROR)
+            .await?
             .call(BlockchainWriteRequest::PopBlocks(numb_blocks))
-            .await
-            .expect(PANIC_CRITICAL_SERVICE_ERROR)
+            .await?
         else {
             unreachable!();
         };
 
         self.blockchain_context_service
             .ready()
-            .await
-            .expect(PANIC_CRITICAL_SERVICE_ERROR)
+            .await?
             .call(BlockChainContextRequest::PopBlocks { numb_blocks })
-            .await
-            .expect(PANIC_CRITICAL_SERVICE_ERROR);
+            .await?;
 
-        old_main_chain_id
+        Ok(old_main_chain_id)
     }
 
     /// Verify and add a list of [`AltBlockInformation`]s to the main-chain.
@@ -585,23 +600,19 @@ impl super::BlockchainManager {
     ///
     /// # Errors
     ///
-    /// This function will return an [`Err`] if the alt-blocks were invalid, in this case the re-org should
-    /// be aborted and the chain should be returned to its previous state.
-    ///
-    /// # Panics
-    ///
-    /// This function will panic if any internal service returns an unexpected error that we cannot
-    /// recover from.
+    /// This function will return an [`Err`] if any internal service returns an unexpected error,
+    /// or if the alt-blocks are invalid. In this case the re-org should be aborted and the chain
+    /// returned to its previous state.
     async fn verify_add_alt_blocks_to_main_chain(
         &mut self,
         alt_blocks: Vec<AltBlockInformation>,
-    ) -> Result<(), anyhow::Error> {
+    ) -> Result<(), BlockManagerError> {
         for mut alt_block in alt_blocks {
             let prepped_txs = alt_block
                 .txs
                 .drain(..)
-                .map(|tx| Ok(tx.try_into()?))
-                .collect::<Result<_, anyhow::Error>>()?;
+                .map(TryInto::try_into)
+                .collect::<Result<_, TxConversionError>>()?;
 
             let prepped_block = PreparedBlock::new_alt_block(alt_block)?;
 
@@ -615,7 +626,7 @@ impl super::BlockchainManager {
             .await?;
 
             self.add_valid_block_to_main_chain(verified_block, BlockSource::Reorg)
-                .await;
+                .await?;
         }
 
         Ok(())
@@ -626,15 +637,15 @@ impl super::BlockchainManager {
     /// This function will update the blockchain database and the context cache,
     /// and announce the block to peers if `source` is [`BlockSource::Incoming`].
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// This function will panic if any internal service returns an unexpected error that we cannot
+    /// This function will return an [`Err`] if any internal service returns an unexpected error that we cannot
     /// recover from.
     async fn add_valid_block_to_main_chain(
         &mut self,
         verified_block: VerifiedBlockInformation,
         source: BlockSource,
-    ) {
+    ) -> Result<(), tower::BoxError> {
         // FIXME: this is pretty inefficient, we should probably return the KI map created in the consensus crate.
         let spent_key_images = verified_block
             .txs
@@ -651,10 +662,10 @@ impl super::BlockchainManager {
             .then(|| Bytes::copy_from_slice(&verified_block.block_blob));
 
         self.add_valid_block_to_blockchain_cache(&verified_block)
-            .await;
+            .await?;
 
         self.add_valid_block_to_blockchain_database(verified_block)
-            .await;
+            .await?;
 
         if let Some(block_blob) = block_blob {
             let chain_height = self
@@ -667,24 +678,24 @@ impl super::BlockchainManager {
 
         self.txpool_manager_handle
             .new_block(spent_key_images)
-            .await
-            .expect(PANIC_CRITICAL_SERVICE_ERROR);
+            .await?;
+
+        Ok(())
     }
 
     /// Adds a [`VerifiedBlockInformation`] to the blockchain context cache.
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// This function will panic if any internal service returns an unexpected error that we cannot
+    /// This function will return an [`Err`] if any internal service returns an unexpected error that we cannot
     /// recover from.
     async fn add_valid_block_to_blockchain_cache(
         &mut self,
         verified_block: &VerifiedBlockInformation,
-    ) {
+    ) -> Result<(), tower::BoxError> {
         self.blockchain_context_service
             .ready()
-            .await
-            .expect(PANIC_CRITICAL_SERVICE_ERROR)
+            .await?
             .call(BlockChainContextRequest::Update(NewBlockData {
                 block_hash: verified_block.block_hash,
                 height: verified_block.height,
@@ -696,48 +707,46 @@ impl super::BlockchainManager {
                 cumulative_difficulty: verified_block.cumulative_difficulty,
                 numb_rct_outputs: rct_output_count(verified_block),
             }))
-            .await
-            .expect(PANIC_CRITICAL_SERVICE_ERROR);
+            .await?;
+        Ok(())
     }
 
     /// Writes a [`VerifiedBlockInformation`] to the blockchain database.
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// This function will panic if any internal service returns an unexpected error that we cannot
+    /// This function will return an [`Err`] if any internal service returns an unexpected error that we cannot
     /// recover from.
     async fn add_valid_block_to_blockchain_database(
         &mut self,
         verified_block: VerifiedBlockInformation,
-    ) {
+    ) -> Result<(), tower::BoxError> {
         self.blockchain_write_handle
             .ready()
-            .await
-            .expect(PANIC_CRITICAL_SERVICE_ERROR)
+            .await?
             .call(BlockchainWriteRequest::WriteBlock(verified_block))
-            .await
-            .expect(PANIC_CRITICAL_SERVICE_ERROR);
+            .await?;
+        Ok(())
     }
 
     /// Batch writes the [`VerifiedBlockInformation`]s to the database.
     ///
     /// The blocks must be sequential.
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// This function will panic if any internal service returns an unexpected error that we cannot
+    /// This function will return an [`Err`] if any internal service returns an unexpected error that we cannot
     /// recover from.
     async fn batch_add_valid_block_to_blockchain_database(
         &mut self,
         blocks: Vec<VerifiedBlockInformation>,
-    ) {
+    ) -> Result<(), tower::BoxError> {
         self.blockchain_write_handle
             .ready()
-            .await
-            .expect(PANIC_CRITICAL_SERVICE_ERROR)
+            .await?
             .call(BlockchainWriteRequest::BatchWriteBlocks(blocks))
-            .await
-            .expect(PANIC_CRITICAL_SERVICE_ERROR);
+            .await?;
+        Ok(())
     }
 }
 

--- a/binaries/cuprated/src/blockchain/manager/handler.rs
+++ b/binaries/cuprated/src/blockchain/manager/handler.rs
@@ -375,7 +375,11 @@ impl super::BlockchainManager {
                     return self.handle_incoming_block_batch_main_chain(batch).await;
                 }
                 // continue adding alt blocks.
-                Ok(AddAltBlock::NewlyCached(_) | AddAltBlock::AlreadyCached) => (),
+                Ok(
+                    AddAltBlock::NewlyCached(_)
+                    | AddAltBlock::AlreadyCached
+                    | AddAltBlock::AlreadyInMainChain,
+                ) => (),
             }
         }
 
@@ -413,7 +417,7 @@ impl super::BlockchainManager {
 
         match chain {
             Some((Chain::Alt(_), _)) => return Ok(AddAltBlock::AlreadyCached),
-            Some((Chain::Main, _)) => return Err(BlockValidationError::AlreadyInMainChain.into()),
+            Some((Chain::Main, _)) => return Ok(AddAltBlock::AlreadyInMainChain),
             None => (),
         }
 
@@ -754,6 +758,8 @@ impl super::BlockchainManager {
 enum AddAltBlock {
     /// We already had this alt-block cached.
     AlreadyCached,
+    /// The block already exists on the main chain.
+    AlreadyInMainChain,
     /// The alt-block was newly cached. Contains the block blob.
     NewlyCached(Bytes),
     /// The chain was reorged.

--- a/binaries/cuprated/src/blockchain/manager/handler.rs
+++ b/binaries/cuprated/src/blockchain/manager/handler.rs
@@ -18,7 +18,7 @@ use cuprate_consensus::{
         verify_prepped_main_chain_block, PreparedBlock,
     },
     transactions::new_tx_verification_data,
-    BlockChainContextRequest, BlockChainContextResponse, ExtendedConsensusError,
+    BlockChainContextRequest, BlockChainContextResponse,
 };
 use cuprate_consensus_context::{distribution::rct_output_count, BlockchainContext, NewBlockData};
 use cuprate_fast_sync::{block_to_verified_block_information, fast_sync_stop_height};

--- a/binaries/cuprated/src/blockchain/manager/handler.rs
+++ b/binaries/cuprated/src/blockchain/manager/handler.rs
@@ -11,14 +11,17 @@ use rayon::prelude::*;
 use tower::{Service, ServiceExt};
 use tracing::{info, instrument, warn, Span};
 
-use cuprate_blockchain::service::{BlockchainReadHandle, BlockchainWriteHandle};
+use cuprate_blockchain::{
+    service::{BlockchainReadHandle, BlockchainWriteHandle},
+    BlockchainError,
+};
 use cuprate_consensus::{
     block::{
         batch_prepare_main_chain_blocks, sanity_check_alt_block, verify_main_chain_block,
-        verify_prepped_main_chain_block, PreparedBlock,
+        verify_prepped_main_chain_block, BlockVerificationError, PreparedBlock,
     },
     transactions::new_tx_verification_data,
-    BlockChainContextRequest, BlockChainContextResponse,
+    BlockChainContextRequest, BlockChainContextResponse, ExtendedConsensusError,
 };
 use cuprate_consensus_context::{distribution::rct_output_count, BlockchainContext, NewBlockData};
 use cuprate_fast_sync::{block_to_verified_block_information, fast_sync_stop_height};
@@ -37,11 +40,8 @@ use cuprate_types::{
 
 use crate::{
     blockchain::{
-        manager::{
-            commands::{BlockchainManagerCommand, IncomingBlockOk},
-            BlockManagerError,
-        },
-        BlockValidationError,
+        manager::commands::{BlockchainManagerCommand, IncomingBlockOk},
+        IncomingBlockError,
     },
     monitor::FatalError,
 };
@@ -62,9 +62,9 @@ impl super::BlockchainManager {
                 prepped_txs,
                 response_tx,
             } => match self.handle_incoming_block(block, prepped_txs).await {
-                Err(BlockManagerError::Fatal(e)) => return Err(e),
+                Err(IncomingBlockError::Fatal(e)) => return Err(e),
                 res => {
-                    let _ = response_tx.send(res.map_err(Into::into));
+                    let _ = response_tx.send(res);
                 }
             },
             BlockchainManagerCommand::PopBlocks {
@@ -123,7 +123,7 @@ impl super::BlockchainManager {
         &mut self,
         block: Block,
         prepared_txs: HashMap<[u8; 32], TransactionVerificationData>,
-    ) -> Result<IncomingBlockOk, BlockManagerError> {
+    ) -> Result<IncomingBlockOk, IncomingBlockError> {
         if block.header.previous
             != self
                 .blockchain_context_service
@@ -252,16 +252,13 @@ impl super::BlockchainManager {
             self.blockchain_read_handle.clone(),
         )
         .await
-        .map_err(BlockManagerError::from)
         {
             Ok(v) => v,
-            Err(BlockManagerError::Fatal(e)) => return Err(e),
-            Err(BlockManagerError::Validation(e)) => {
-                let duration = match e {
-                    BlockValidationError::HardFork(_) => MEDIUM_BAN,
-                    BlockValidationError::Consensus(_) => LONG_BAN,
-                };
-                batch.peer_handle.ban_peer(duration);
+            Err(ExtendedConsensusError::FatalError(e)) => return Err(e),
+            Err(ExtendedConsensusError::ConsensusError(e)) => {
+                warn!("Failed to batch prepare blocks for verification: {e}, banning peer.");
+                // This is not a gossiped block, we don't need to check if PoW was verified.
+                batch.peer_handle.ban_peer(MEDIUM_BAN);
                 self.stop_current_block_downloader.notify_waiters();
                 return Ok(());
             }
@@ -278,35 +275,22 @@ impl super::BlockchainManager {
                 Some(&mut output_cache),
             )
             .await
-            .map_err(BlockManagerError::from)
             {
                 Ok(block) => block,
-                Err(BlockManagerError::Fatal(e)) => return Err(e),
-                Err(BlockManagerError::Validation(e)) => {
-                    let duration = match e {
-                        BlockValidationError::HardFork(e) => {
-                            warn!(
-                                "Failed to verify block: {}, error {} (block v{}, current v{}), banning peer.",
-                                hex::encode(hash),
-                                e,
-                                block_version,
-                                self.blockchain_context_service.blockchain_context().current_hf.as_u8()
-                            );
-                            MEDIUM_BAN
-                        }
-                        BlockValidationError::Consensus(e) => {
-                            warn!(
-                                "Failed to verify block: {}, error {}, banning peer.",
-                                hex::encode(hash),
-                                e
-                            );
-                            LONG_BAN
-                        }
-                    };
-                    batch.peer_handle.ban_peer(duration);
-                    self.stop_current_block_downloader.notify_waiters();
-                    return Ok(());
-                }
+                Err(e) => match e.into() {
+                    ExtendedConsensusError::FatalError(e) => return Err(e),
+                    ExtendedConsensusError::ConsensusError(e) => {
+                        warn!(
+                            "Failed to verify block: {}, error {}, banning peer.",
+                            hex::encode(hash),
+                            e
+                        );
+
+                        batch.peer_handle.ban_peer(MEDIUM_BAN);
+                        self.stop_current_block_downloader.notify_waiters();
+                        return Ok(());
+                    }
+                },
             };
 
             self.add_valid_block_to_main_chain(verified_block, BlockSource::BatchSync)
@@ -375,38 +359,20 @@ impl super::BlockchainManager {
                         let tx = new_tx_verification_data(tx)?;
                         Ok((tx.tx_hash, tx))
                     })
-                    .collect::<Result<_, BlockManagerError>>()?;
+                    .collect::<Result<_, ExtendedConsensusError>>()?;
 
                 let reorged = self.handle_incoming_alt_block(block, txs).await?;
 
-                Ok::<_, BlockManagerError>(reorged)
+                Ok::<_, ExtendedConsensusError>(reorged)
             }
             .await;
 
             match res {
-                Err(BlockManagerError::Fatal(e)) => return Err(e),
-                Err(BlockManagerError::Validation(e)) => {
-                    let duration = match e {
-                        BlockValidationError::HardFork(e) => {
-                            warn!(
-                                "Failed to verify block: {}, error {} (block v{}, current v{}), banning peer.",
-                                hex::encode(hash),
-                                e,
-                                block_version,
-                                self.blockchain_context_service.blockchain_context().current_hf.as_u8()
-                            );
-                            MEDIUM_BAN
-                        }
-                        BlockValidationError::Consensus(e) => {
-                            warn!(
-                                "Failed to verify block: {}, error {}, banning peer.",
-                                hex::encode(hash),
-                                e
-                            );
-                            LONG_BAN
-                        }
-                    };
-                    batch.peer_handle.ban_peer(duration);
+                Err(ExtendedConsensusError::FatalError(e)) => return Err(e),
+                Err(ExtendedConsensusError::ConsensusError(e)) => {
+                    warn!("Failed to verify alt block: {e}, banning peer.");
+
+                    batch.peer_handle.ban_peer(MEDIUM_BAN);
                     self.stop_current_block_downloader.notify_waiters();
                     return Ok(());
                 }
@@ -449,14 +415,16 @@ impl super::BlockchainManager {
         &mut self,
         block: Block,
         prepared_txs: HashMap<[u8; 32], TransactionVerificationData>,
-    ) -> Result<AddAltBlock, BlockManagerError> {
+    ) -> Result<AddAltBlock, BlockVerificationError> {
         // Check if a block already exists.
         let BlockchainResponse::FindBlock(chain) = self
             .blockchain_read_handle
             .ready()
-            .await?
+            .await
+            .map_err(BlockVerificationError::invalid_pow)?
             .call(BlockchainReadRequest::FindBlock(block.hash()))
-            .await?
+            .await
+            .map_err(BlockVerificationError::invalid_pow)?
         else {
             unreachable!();
         };
@@ -478,16 +446,20 @@ impl super::BlockchainManager {
                 .blockchain_context()
                 .cumulative_difficulty
         {
-            self.try_do_reorg(alt_block_info).await?;
+            self.try_do_reorg(alt_block_info)
+                .await
+                .map_err(BlockVerificationError::valid_pow)?;
             return Ok(AddAltBlock::Reorged);
         }
 
         let block_blob = Bytes::copy_from_slice(&alt_block_info.block_blob);
         self.blockchain_write_handle
             .ready()
-            .await?
+            .await
+            .map_err(fatal_block_verification_error)?
             .call(BlockchainWriteRequest::WriteAltBlock(alt_block_info))
-            .await?;
+            .await
+            .map_err(fatal_block_verification_error)?;
 
         Ok(AddAltBlock::NewlyCached(block_blob))
     }
@@ -507,7 +479,7 @@ impl super::BlockchainManager {
     async fn try_do_reorg(
         &mut self,
         top_alt_block: AltBlockInformation,
-    ) -> Result<(), BlockManagerError> {
+    ) -> Result<(), ExtendedConsensusError> {
         let reorg_lock = Arc::clone(&self.reorg_lock);
         let _guard = reorg_lock.write().await;
 
@@ -656,13 +628,14 @@ impl super::BlockchainManager {
     async fn verify_add_alt_blocks_to_main_chain(
         &mut self,
         alt_blocks: Vec<AltBlockInformation>,
-    ) -> Result<(), BlockManagerError> {
+    ) -> Result<(), ExtendedConsensusError> {
         for mut alt_block in alt_blocks {
             let prepped_txs = alt_block
                 .txs
                 .drain(..)
                 .map(TryInto::try_into)
-                .collect::<Result<_, TxConversionError>>()?;
+                .collect::<Result<_, TxConversionError>>()
+                .map_err(fatal_extended_consensus_error)?;
 
             let prepped_block = PreparedBlock::new_alt_block(alt_block)?;
 
@@ -861,4 +834,12 @@ pub fn alt_block_to_verified_block_information(
             + blockchain_ctx.next_difficulty,
         block: block.block,
     }
+}
+
+fn fatal_block_verification_error(e: impl Into<FatalError>) -> BlockVerificationError {
+    BlockVerificationError::valid_pow(e.into())
+}
+
+fn fatal_extended_consensus_error(e: impl Into<FatalError>) -> ExtendedConsensusError {
+    ExtendedConsensusError::FatalError(e.into())
 }

--- a/binaries/cuprated/src/blockchain/manager/handler.rs
+++ b/binaries/cuprated/src/blockchain/manager/handler.rs
@@ -11,10 +11,7 @@ use rayon::prelude::*;
 use tower::{Service, ServiceExt};
 use tracing::{info, instrument, warn, Span};
 
-use cuprate_blockchain::{
-    service::{BlockchainReadHandle, BlockchainWriteHandle},
-    BlockchainError,
-};
+use cuprate_blockchain::service::{BlockchainReadHandle, BlockchainWriteHandle};
 use cuprate_consensus::{
     block::{
         batch_prepare_main_chain_blocks, sanity_check_alt_block, verify_main_chain_block,
@@ -26,11 +23,7 @@ use cuprate_consensus::{
 use cuprate_consensus_context::{distribution::rct_output_count, BlockchainContext, NewBlockData};
 use cuprate_fast_sync::{block_to_verified_block_information, fast_sync_stop_height};
 use cuprate_helper::cast::usize_to_u64;
-use cuprate_p2p::{
-    block_downloader::BlockBatch,
-    constants::{LONG_BAN, MEDIUM_BAN},
-    BroadcastRequest,
-};
+use cuprate_p2p::{block_downloader::BlockBatch, constants::MEDIUM_BAN, BroadcastRequest};
 use cuprate_txpool::service::interface::TxpoolWriteRequest;
 use cuprate_types::{
     blockchain::{BlockchainReadRequest, BlockchainResponse, BlockchainWriteRequest},
@@ -266,7 +259,6 @@ impl super::BlockchainManager {
 
         for (block, txs) in prepped_blocks {
             let hash = block.block_hash;
-            let block_version = block.hf_version.as_u8();
             let verified_block = match verify_prepped_main_chain_block(
                 block,
                 txs,
@@ -349,7 +341,6 @@ impl super::BlockchainManager {
 
         while let Some((block, txs)) = blocks.next() {
             let hash = block.hash();
-            let block_version = block.header.hardfork_version;
 
             // async blocks work as try blocks.
             let res = async {
@@ -370,7 +361,11 @@ impl super::BlockchainManager {
             match res {
                 Err(ExtendedConsensusError::FatalError(e)) => return Err(e),
                 Err(ExtendedConsensusError::ConsensusError(e)) => {
-                    warn!("Failed to verify alt block: {e}, banning peer.");
+                    warn!(
+                        "Failed to verify alt block: {}, error {}, banning peer.",
+                        hex::encode(hash),
+                        e
+                    );
 
                     batch.peer_handle.ban_peer(MEDIUM_BAN);
                     self.stop_current_block_downloader.notify_waiters();
@@ -421,10 +416,10 @@ impl super::BlockchainManager {
             .blockchain_read_handle
             .ready()
             .await
-            .map_err(BlockVerificationError::invalid_pow)?
+            .map_err(BlockVerificationError::fatal)?
             .call(BlockchainReadRequest::FindBlock(block.hash()))
             .await
-            .map_err(BlockVerificationError::invalid_pow)?
+            .map_err(BlockVerificationError::fatal)?
         else {
             unreachable!();
         };
@@ -456,10 +451,10 @@ impl super::BlockchainManager {
         self.blockchain_write_handle
             .ready()
             .await
-            .map_err(fatal_block_verification_error)?
+            .map_err(|e| BlockVerificationError::fatal(e.into()))?
             .call(BlockchainWriteRequest::WriteAltBlock(alt_block_info))
             .await
-            .map_err(fatal_block_verification_error)?;
+            .map_err(|e| BlockVerificationError::fatal(e.into()))?;
 
         Ok(AddAltBlock::NewlyCached(block_blob))
     }
@@ -635,7 +630,7 @@ impl super::BlockchainManager {
                 .drain(..)
                 .map(TryInto::try_into)
                 .collect::<Result<_, TxConversionError>>()
-                .map_err(fatal_extended_consensus_error)?;
+                .map_err(|e| ExtendedConsensusError::FatalError(e.into()))?;
 
             let prepped_block = PreparedBlock::new_alt_block(alt_block)?;
 
@@ -834,12 +829,4 @@ pub fn alt_block_to_verified_block_information(
             + blockchain_ctx.next_difficulty,
         block: block.block,
     }
-}
-
-fn fatal_block_verification_error(e: impl Into<FatalError>) -> BlockVerificationError {
-    BlockVerificationError::valid_pow(e.into())
-}
-
-fn fatal_extended_consensus_error(e: impl Into<FatalError>) -> ExtendedConsensusError {
-    ExtendedConsensusError::FatalError(e.into())
 }

--- a/binaries/cuprated/src/blockchain/manager/handler.rs
+++ b/binaries/cuprated/src/blockchain/manager/handler.rs
@@ -35,9 +35,15 @@ use cuprate_types::{
     VerifiedBlockInformation, VerifiedTransactionInformation,
 };
 
-use crate::blockchain::{
-    manager::commands::{BlockchainManagerCommand, IncomingBlockOk},
-    BlockManagerError, BlockValidationError,
+use crate::{
+    blockchain::{
+        manager::{
+            commands::{BlockchainManagerCommand, IncomingBlockOk},
+            BlockManagerError,
+        },
+        BlockValidationError,
+    },
+    monitor::FatalError,
 };
 
 impl super::BlockchainManager {
@@ -49,14 +55,14 @@ impl super::BlockchainManager {
     pub async fn handle_command(
         &mut self,
         command: BlockchainManagerCommand,
-    ) -> Result<(), tower::BoxError> {
+    ) -> Result<(), FatalError> {
         match command {
             BlockchainManagerCommand::AddBlock {
                 block,
                 prepped_txs,
                 response_tx,
             } => match self.handle_incoming_block(block, prepped_txs).await {
-                Err(BlockManagerError::Internal(e)) => return Err(e),
+                Err(BlockManagerError::Fatal(e)) => return Err(e),
                 res => {
                     let _ = response_tx.send(res.map_err(Into::into));
                 }
@@ -193,7 +199,7 @@ impl super::BlockchainManager {
     pub async fn handle_incoming_block_batch(
         &mut self,
         batch: BlockBatch,
-    ) -> Result<(), tower::BoxError> {
+    ) -> Result<(), FatalError> {
         let (first_block, _) = batch
             .blocks
             .first()
@@ -230,7 +236,7 @@ impl super::BlockchainManager {
     async fn handle_incoming_block_batch_main_chain(
         &mut self,
         batch: BlockBatch,
-    ) -> Result<(), tower::BoxError> {
+    ) -> Result<(), FatalError> {
         let (last_block, _) = batch
             .blocks
             .last()
@@ -249,11 +255,11 @@ impl super::BlockchainManager {
         .map_err(BlockManagerError::from)
         {
             Ok(v) => v,
-            Err(BlockManagerError::Internal(e)) => return Err(e),
+            Err(BlockManagerError::Fatal(e)) => return Err(e),
             Err(BlockManagerError::Validation(e)) => {
                 let duration = match e {
                     BlockValidationError::HardFork(_) => MEDIUM_BAN,
-                    BlockValidationError::Other(_) => LONG_BAN,
+                    BlockValidationError::Consensus(_) => LONG_BAN,
                 };
                 batch.peer_handle.ban_peer(duration);
                 self.stop_current_block_downloader.notify_waiters();
@@ -275,7 +281,7 @@ impl super::BlockchainManager {
             .map_err(BlockManagerError::from)
             {
                 Ok(block) => block,
-                Err(BlockManagerError::Internal(e)) => return Err(e),
+                Err(BlockManagerError::Fatal(e)) => return Err(e),
                 Err(BlockManagerError::Validation(e)) => {
                     let duration = match e {
                         BlockValidationError::HardFork(e) => {
@@ -288,7 +294,7 @@ impl super::BlockchainManager {
                             );
                             MEDIUM_BAN
                         }
-                        BlockValidationError::Other(e) => {
+                        BlockValidationError::Consensus(e) => {
                             warn!(
                                 "Failed to verify block: {}, error {}, banning peer.",
                                 hex::encode(hash),
@@ -319,7 +325,7 @@ impl super::BlockchainManager {
     async fn handle_incoming_block_batch_fast_sync(
         &mut self,
         batch: BlockBatch,
-    ) -> Result<(), tower::BoxError> {
+    ) -> Result<(), FatalError> {
         let mut valid_blocks = Vec::with_capacity(batch.blocks.len());
         for (block, txs) in batch.blocks {
             let block = block_to_verified_block_information(
@@ -354,7 +360,7 @@ impl super::BlockchainManager {
     async fn handle_incoming_block_batch_alt_chain(
         &mut self,
         mut batch: BlockBatch,
-    ) -> Result<(), tower::BoxError> {
+    ) -> Result<(), FatalError> {
         let mut blocks = batch.blocks.into_iter();
 
         while let Some((block, txs)) = blocks.next() {
@@ -378,7 +384,7 @@ impl super::BlockchainManager {
             .await;
 
             match res {
-                Err(BlockManagerError::Internal(e)) => return Err(e),
+                Err(BlockManagerError::Fatal(e)) => return Err(e),
                 Err(BlockManagerError::Validation(e)) => {
                     let duration = match e {
                         BlockValidationError::HardFork(e) => {
@@ -391,7 +397,7 @@ impl super::BlockchainManager {
                             );
                             MEDIUM_BAN
                         }
-                        BlockValidationError::Other(e) => {
+                        BlockValidationError::Consensus(e) => {
                             warn!(
                                 "Failed to verify block: {}, error {}, banning peer.",
                                 hex::encode(hash),
@@ -562,7 +568,7 @@ impl super::BlockchainManager {
     /// This function will return an [`Err`] if any internal service returns an unexpected error that we cannot
     /// recover from.
     #[instrument(name = "reverse_reorg", skip_all, level = "info")]
-    async fn reverse_reorg(&mut self, old_main_chain_id: ChainId) -> Result<(), tower::BoxError> {
+    async fn reverse_reorg(&mut self, old_main_chain_id: ChainId) -> Result<(), FatalError> {
         warn!("Reorg failed, reverting to old chain.");
 
         let BlockchainResponse::AltBlocksInChain(mut blocks) = self
@@ -616,7 +622,7 @@ impl super::BlockchainManager {
     /// This function will return an [`Err`] if any internal service returns an unexpected error that we cannot
     /// recover from.
     #[instrument(name = "pop_blocks", skip(self), level = "info")]
-    async fn pop_blocks(&mut self, numb_blocks: usize) -> Result<ChainId, tower::BoxError> {
+    async fn pop_blocks(&mut self, numb_blocks: usize) -> Result<ChainId, FatalError> {
         let BlockchainResponse::PopBlocks(old_main_chain_id) = self
             .blockchain_write_handle
             .ready()
@@ -689,7 +695,7 @@ impl super::BlockchainManager {
         &mut self,
         verified_block: VerifiedBlockInformation,
         source: BlockSource,
-    ) -> Result<(), tower::BoxError> {
+    ) -> Result<(), FatalError> {
         // FIXME: this is pretty inefficient, we should probably return the KI map created in the consensus crate.
         let spent_key_images = verified_block
             .txs
@@ -736,7 +742,7 @@ impl super::BlockchainManager {
     async fn add_valid_block_to_blockchain_cache(
         &mut self,
         verified_block: &VerifiedBlockInformation,
-    ) -> Result<(), tower::BoxError> {
+    ) -> Result<(), FatalError> {
         self.blockchain_context_service
             .ready()
             .await?
@@ -764,7 +770,7 @@ impl super::BlockchainManager {
     async fn add_valid_block_to_blockchain_database(
         &mut self,
         verified_block: VerifiedBlockInformation,
-    ) -> Result<(), tower::BoxError> {
+    ) -> Result<(), FatalError> {
         self.blockchain_write_handle
             .ready()
             .await?
@@ -784,7 +790,7 @@ impl super::BlockchainManager {
     async fn batch_add_valid_block_to_blockchain_database(
         &mut self,
         blocks: Vec<VerifiedBlockInformation>,
-    ) -> Result<(), tower::BoxError> {
+    ) -> Result<(), FatalError> {
         self.blockchain_write_handle
             .ready()
             .await?

--- a/binaries/cuprated/src/blockchain/manager/handler.rs
+++ b/binaries/cuprated/src/blockchain/manager/handler.rs
@@ -98,11 +98,6 @@ impl super::BlockchainManager {
     /// the top of the main chain.
     ///
     /// Otherwise, this function will validate and add the block to the main chain.
-    ///
-    /// # Errors
-    ///
-    /// This function will return an [`Err`] if any internal service returns an unexpected error that we cannot
-    /// recover from.
     #[instrument(
         name = "incoming_block",
         skip_all,

--- a/binaries/cuprated/src/blockchain/manager/tests.rs
+++ b/binaries/cuprated/src/blockchain/manager/tests.rs
@@ -50,7 +50,8 @@ async fn mock_manager(data_dir: PathBuf) -> BlockchainManager {
         &mut blockchain_write_handle,
         Network::Mainnet,
     )
-    .await;
+    .await
+    .unwrap();
 
     let mut context_config = ContextConfig::main_net();
     context_config.difficulty_cfg.fixed_difficulty = Some(1);
@@ -129,7 +130,8 @@ async fn simple_reorg() {
             prepped_txs: HashMap::new(),
             response_tx: oneshot::channel().0,
         })
-        .await;
+        .await
+        .unwrap();
 
     manager_2
         .handle_command(BlockchainManagerCommand::AddBlock {
@@ -137,7 +139,8 @@ async fn simple_reorg() {
             prepped_txs: HashMap::new(),
             response_tx: oneshot::channel().0,
         })
-        .await;
+        .await
+        .unwrap();
 
     assert_eq!(
         manager_1.blockchain_context_service.blockchain_context(),
@@ -154,7 +157,8 @@ async fn simple_reorg() {
             prepped_txs: HashMap::new(),
             response_tx: oneshot::channel().0,
         })
-        .await;
+        .await
+        .unwrap();
 
     manager_2
         .handle_command(BlockchainManagerCommand::AddBlock {
@@ -162,7 +166,8 @@ async fn simple_reorg() {
             prepped_txs: HashMap::new(),
             response_tx: oneshot::channel().0,
         })
-        .await;
+        .await
+        .unwrap();
 
     let manager_1_context = manager_1
         .blockchain_context_service
@@ -181,7 +186,8 @@ async fn simple_reorg() {
             prepped_txs: HashMap::new(),
             response_tx: oneshot::channel().0,
         })
-        .await;
+        .await
+        .unwrap();
     // make sure this didn't change the context
     assert_eq!(
         &manager_1_context,
@@ -197,7 +203,8 @@ async fn simple_reorg() {
             prepped_txs: HashMap::new(),
             response_tx: oneshot::channel().0,
         })
-        .await;
+        .await
+        .unwrap();
 
     manager_2
         .handle_command(BlockchainManagerCommand::AddBlock {
@@ -205,7 +212,8 @@ async fn simple_reorg() {
             prepped_txs: HashMap::new(),
             response_tx: oneshot::channel().0,
         })
-        .await;
+        .await
+        .unwrap();
 
     // make sure manager 1 reorged.
     assert_eq!(
@@ -242,7 +250,8 @@ async fn simple_reorg_block_batch() {
             size: 0,
             peer_handle: handle.1.clone(),
         })
-        .await;
+        .await
+        .unwrap();
 
     manager_2
         .handle_incoming_block_batch(BlockBatch {
@@ -250,7 +259,8 @@ async fn simple_reorg_block_batch() {
             size: 0,
             peer_handle: handle.1.clone(),
         })
-        .await;
+        .await
+        .unwrap();
 
     assert_eq!(
         manager_1.blockchain_context_service.blockchain_context(),
@@ -267,7 +277,8 @@ async fn simple_reorg_block_batch() {
             size: 0,
             peer_handle: handle.1.clone(),
         })
-        .await;
+        .await
+        .unwrap();
 
     manager_2
         .handle_incoming_block_batch(BlockBatch {
@@ -275,7 +286,8 @@ async fn simple_reorg_block_batch() {
             size: 0,
             peer_handle: handle.1.clone(),
         })
-        .await;
+        .await
+        .unwrap();
 
     let manager_1_context = manager_1
         .blockchain_context_service
@@ -294,7 +306,8 @@ async fn simple_reorg_block_batch() {
             size: 0,
             peer_handle: handle.1.clone(),
         })
-        .await;
+        .await
+        .unwrap();
     // make sure this didn't change the context
     assert_eq!(
         &manager_1_context,
@@ -310,7 +323,8 @@ async fn simple_reorg_block_batch() {
             size: 0,
             peer_handle: handle.1.clone(),
         })
-        .await;
+        .await
+        .unwrap();
 
     manager_2
         .handle_incoming_block_batch(BlockBatch {
@@ -318,7 +332,8 @@ async fn simple_reorg_block_batch() {
             size: 0,
             peer_handle: handle.1.clone(),
         })
-        .await;
+        .await
+        .unwrap();
 
     // make sure manager 1 reorged.
     assert_eq!(
@@ -353,7 +368,8 @@ async fn recover_bad_reorg() {
             prepped_txs: HashMap::new(),
             response_tx: oneshot::channel().0,
         })
-        .await;
+        .await
+        .unwrap();
 
     let context_2 = manager_1
         .blockchain_context_service
@@ -368,7 +384,8 @@ async fn recover_bad_reorg() {
             prepped_txs: HashMap::new(),
             response_tx: oneshot::channel().0,
         })
-        .await;
+        .await
+        .unwrap();
 
     // Save this context for later to check the reorg gets reversed correctly.
     let context = manager_1
@@ -385,7 +402,8 @@ async fn recover_bad_reorg() {
             prepped_txs: HashMap::new(),
             response_tx: oneshot::channel().0,
         })
-        .await;
+        .await
+        .unwrap();
 
     // This tx is invalid and will make the reorg fail.
     let tx = Transaction::V2 {
@@ -418,7 +436,8 @@ async fn recover_bad_reorg() {
             prepped_txs: HashMap::from([(tx.tx_hash, tx)]),
             response_tx: oneshot::channel().0,
         })
-        .await;
+        .await
+        .unwrap();
 
     let mut block_3_alt = generate_block(manager_1.blockchain_context_service.blockchain_context());
     block_3_alt.header.previous = block_2_alt.hash();
@@ -434,7 +453,8 @@ async fn recover_bad_reorg() {
             prepped_txs: HashMap::new(),
             response_tx: oneshot::channel().0,
         })
-        .await;
+        .await
+        .unwrap();
 
     // make sure the reorg failed.
     assert_eq!(

--- a/binaries/cuprated/src/blockchain/syncer.rs
+++ b/binaries/cuprated/src/blockchain/syncer.rs
@@ -22,17 +22,7 @@ use cuprate_p2p::{
 use cuprate_p2p_core::{client::PeerSyncCallback, ClearNet, CoreSyncData, NetworkZone};
 
 use super::BlockchainManagerHandle;
-
-/// An error returned from the [`BlockchainSyncer`].
-#[derive(Debug, thiserror::Error)]
-pub enum SyncerError {
-    #[error("Incoming block channel closed.")]
-    IncomingBlockChannelClosed,
-    #[error("One of our services returned an error: {0}.")]
-    ServiceError(#[from] tower::BoxError),
-    #[error("Sync permit semaphore closed unexpectedly: {0}.")]
-    SemaphoreClosed(#[from] tokio::sync::AcquireError),
-}
+use crate::monitor::FatalError;
 
 #[derive(Debug, PartialEq)]
 enum SyncStatus {
@@ -83,7 +73,7 @@ impl BlockchainSyncer {
         stop_current_block_downloader: Arc<Notify>,
         block_downloader_config: BlockDownloaderConfig,
         shutdown_token: CancellationToken,
-    ) -> Result<(), SyncerError>
+    ) -> Result<(), FatalError>
     where
         CN: Service<
                 ChainSvcRequest<ClearNet>,
@@ -173,7 +163,7 @@ impl BlockchainSyncer {
                             if shutdown_token.is_cancelled() {
                                 return Ok(());
                             }
-                            return Err(SyncerError::IncomingBlockChannelClosed);
+                            return Err("Incoming block channel closed.".into());
                         }
                     }
                 }

--- a/binaries/cuprated/src/constants.rs
+++ b/binaries/cuprated/src/constants.rs
@@ -20,8 +20,8 @@ pub const PATCH_VERSION: &str = env!("CARGO_PKG_VERSION_PATCH");
 /// If a debug build, the suffix is `-debug`, else it is `-release`.
 pub const VERSION_BUILD: &str = formatcp!("{VERSION}-{}", cuprate_constants::build::BUILD);
 
-/// The panic message used when cuprated encounters a critical service error.
-pub const PANIC_CRITICAL_SERVICE_ERROR: &str =
+/// The message used when cuprated encounters a critical service error.
+pub const CRITICAL_SERVICE_ERROR: &str =
     "A service critical to Cuprate's function returned an unexpected error.";
 
 pub const DEFAULT_CONFIG_WARNING: &str = formatcp!(

--- a/binaries/cuprated/src/constants.rs
+++ b/binaries/cuprated/src/constants.rs
@@ -20,10 +20,6 @@ pub const PATCH_VERSION: &str = env!("CARGO_PKG_VERSION_PATCH");
 /// If a debug build, the suffix is `-debug`, else it is `-release`.
 pub const VERSION_BUILD: &str = formatcp!("{VERSION}-{}", cuprate_constants::build::BUILD);
 
-/// The message used when cuprated encounters a critical service error.
-pub const CRITICAL_SERVICE_ERROR: &str =
-    "A service critical to Cuprate's function returned an unexpected error.";
-
 pub const DEFAULT_CONFIG_WARNING: &str = formatcp!(
     "WARNING: no config file found, using default config.\
     \nThe default config may not be optimal for your setup, see the user book here: https://user.cuprate.org/.\

--- a/binaries/cuprated/src/lib.rs
+++ b/binaries/cuprated/src/lib.rs
@@ -122,7 +122,7 @@ pub struct Node {
 
 impl Drop for Node {
     fn drop(&mut self) {
-        self.task_executor.trigger_shutdown();
+        self.shutdown();
     }
 }
 
@@ -143,148 +143,158 @@ impl Node {
     /// or `target_max_memory` is unresolved.
     pub async fn launch(config: impl Into<Arc<Config>>) -> Result<Self, anyhow::Error> {
         let config: Arc<Config> = config.into();
+        let task_executor = TaskExecutor::new();
+        let shutdown_token = task_executor.cancellation_token();
 
-        // Initialize the database thread pool.
-        let db_thread_pool = Arc::new(
-            rayon::ThreadPoolBuilder::new()
-                .num_threads(config.storage.reader_threads)
-                .build()
-                .context("failed to build rayon database thread pool")?,
-        );
+        let node: Result<Self, anyhow::Error> = async move {
+            // Initialize the database thread pool.
+            let db_thread_pool = Arc::new(
+                rayon::ThreadPoolBuilder::new()
+                    .num_threads(config.storage.reader_threads)
+                    .build()
+                    .context("failed to build rayon database thread pool")?,
+            );
 
-        // Start the blockchain & tx-pool databases.
-        let fjall_db = fjall::Database::builder(config.fjall_directory())
-            .cache_size(config.fjall_cache_size())
-            .open()
-            .context(DATABASE_CORRUPT_MSG)?;
-
-        let (mut blockchain_read_handle, mut blockchain_write_handle, _) =
-            cuprate_blockchain::service::init_with_pool(
-                &config.blockchain_config(),
-                fjall_db.clone(),
-                Arc::clone(&db_thread_pool),
-            )
-            .context(DATABASE_CORRUPT_MSG)?;
-
-        let (txpool_read_handle, txpool_write_handle) =
-            cuprate_txpool::service::init_with_pool(fjall_db, db_thread_pool)
+            // Start the blockchain & tx-pool databases.
+            let fjall_db = fjall::Database::builder(config.fjall_directory())
+                .cache_size(config.fjall_cache_size())
+                .open()
                 .context(DATABASE_CORRUPT_MSG)?;
 
-        // TODO: Add an argument/option for keeping alt blocks between restart.
-        blockchain_write_handle
-            .ready()
-            .await?
-            .call(BlockchainWriteRequest::FlushAltBlocks)
+            let (mut blockchain_read_handle, mut blockchain_write_handle, _) =
+                cuprate_blockchain::service::init_with_pool(
+                    &config.blockchain_config(),
+                    fjall_db.clone(),
+                    Arc::clone(&db_thread_pool),
+                )
+                .context(DATABASE_CORRUPT_MSG)?;
+
+            let (txpool_read_handle, txpool_write_handle) =
+                cuprate_txpool::service::init_with_pool(fjall_db, db_thread_pool)
+                    .context(DATABASE_CORRUPT_MSG)?;
+
+            // TODO: Add an argument/option for keeping alt blocks between restart.
+            blockchain_write_handle
+                .ready()
+                .await?
+                .call(BlockchainWriteRequest::FlushAltBlocks)
+                .await?;
+
+            // Check add the genesis block to the blockchain.
+            blockchain::check_add_genesis(
+                &mut blockchain_read_handle,
+                &mut blockchain_write_handle,
+                config.network(),
+            )
             .await?;
 
-        // Check add the genesis block to the blockchain.
-        blockchain::check_add_genesis(
-            &mut blockchain_read_handle,
-            &mut blockchain_write_handle,
-            config.network(),
-        )
-        .await;
+            // Start the context service and the block/tx verifier.
+            let context_svc =
+                blockchain::init_consensus(blockchain_read_handle.clone(), config.context_config())
+                    .await
+                    .map_err(anyhow::Error::from_boxed)?;
 
-        // Start the context service and the block/tx verifier.
-        let context_svc =
-            blockchain::init_consensus(blockchain_read_handle.clone(), config.context_config())
-                .await
-                .map_err(anyhow::Error::from_boxed)?;
+            // Create the blockchain syncer handle and synced signal sender.
+            let (blockchain_syncer_handle, synced_tx) = BlockchainSyncerHandle::new();
 
-        // Create the blockchain syncer handle and synced signal sender.
-        let (blockchain_syncer_handle, synced_tx) = BlockchainSyncerHandle::new();
+            // Create the blockchain manager handle and command receiver.
+            let (blockchain_manager_handle, command_rx) = BlockchainManagerHandle::new();
 
-        // Create the blockchain manager handle and command receiver.
-        let (blockchain_manager_handle, command_rx) = BlockchainManagerHandle::new();
-
-        // Create the blockchain interface.
-        let blockchain_interface = BlockchainInterface::new(
-            blockchain_read_handle,
-            context_svc,
-            blockchain_manager_handle,
-            blockchain_syncer_handle,
-        );
-
-        // Create the launch context.
-        let launch_ctx = LaunchContext {
-            config,
-            reorg_lock: Arc::new(RwLock::new(())),
-            blockchain: blockchain_interface,
-            txpool_read: txpool_read_handle,
-            task_executor: TaskExecutor::new(),
-        };
-
-        // Bootstrap or configure Tor if enabled.
-        let tor_enabled = !launch_ctx.config.offline && launch_ctx.config.p2p.tor_net.enabled;
-        let tor_context = initialize_tor_if_enabled(&launch_ctx).await;
-
-        // Start clearnet P2P zone
-        let (clearnet_interface, clearnet_tx_handler_subscriber) =
-            p2p::initialize_clearnet_p2p(&launch_ctx, &tor_context).await;
-
-        // Create Tor router delivery channel.
-        let (tor_router_tx, tor_router_rx) = tor_enabled.then(oneshot::channel).unzip();
-
-        // Create the incoming tx handler service.
-        let tx_handler = IncomingTxHandler::init(
-            &launch_ctx,
-            clearnet_interface.clone(),
-            tor_router_rx,
-            txpool_write_handle,
-        )
-        .await;
-
-        // Send tx handler sender to clearnet zone, offline zones have no subscriber.
-        if let Some(subscriber) = clearnet_tx_handler_subscriber {
-            if subscriber.send(tx_handler.clone()).is_err() {
-                unreachable!()
-            }
-        }
-
-        // Tor interface channel - populated when Tor starts after sync.
-        let (tor_tx, tor_rx) = oneshot::channel();
-
-        // Initialize the blockchain manager.
-        blockchain::init_blockchain_manager(
-            &launch_ctx,
-            clearnet_interface.clone(),
-            blockchain_write_handle,
-            tx_handler.txpool_manager.clone(),
-            synced_tx,
-            command_rx,
-        )
-        .await?;
-
-        // Initialize the RPC server(s).
-        rpc::init_rpc_servers(&launch_ctx, tx_handler.clone());
-
-        // Start Tor P2P zone after sync completes.
-        if tor_enabled {
-            p2p::initialize_tor_p2p(
-                launch_ctx.clone(),
-                tor_context,
-                tx_handler,
-                tor_tx,
-                tor_router_tx,
+            // Create the blockchain interface.
+            let blockchain_interface = BlockchainInterface::new(
+                blockchain_read_handle,
+                context_svc,
+                blockchain_manager_handle,
+                blockchain_syncer_handle,
             );
+
+            // Create the launch context.
+            let launch_ctx = LaunchContext {
+                config,
+                reorg_lock: Arc::new(RwLock::new(())),
+                blockchain: blockchain_interface,
+                txpool_read: txpool_read_handle,
+                task_executor,
+            };
+
+            // Bootstrap or configure Tor if enabled.
+            let tor_enabled = !launch_ctx.config.offline && launch_ctx.config.p2p.tor_net.enabled;
+            let tor_context = initialize_tor_if_enabled(&launch_ctx).await;
+
+            // Start clearnet P2P zone
+            let (clearnet_interface, clearnet_tx_handler_subscriber) =
+                p2p::initialize_clearnet_p2p(&launch_ctx, &tor_context).await?;
+
+            // Create Tor router delivery channel.
+            let (tor_router_tx, tor_router_rx) = tor_enabled.then(oneshot::channel).unzip();
+
+            // Create the incoming tx handler service.
+            let tx_handler = IncomingTxHandler::init(
+                &launch_ctx,
+                clearnet_interface.clone(),
+                tor_router_rx,
+                txpool_write_handle.clone(),
+            )
+            .await?;
+
+            // Send tx handler sender to clearnet zone, offline zones have no subscriber.
+            if let Some(subscriber) = clearnet_tx_handler_subscriber {
+                if subscriber.send(tx_handler.clone()).is_err() {
+                    unreachable!()
+                }
+            }
+
+            // Tor interface channel - populated when Tor starts after sync.
+            let (tor_tx, tor_rx) = oneshot::channel();
+
+            // Initialize the blockchain manager.
+            blockchain::init_blockchain_manager(
+                &launch_ctx,
+                clearnet_interface.clone(),
+                blockchain_write_handle,
+                tx_handler.txpool_manager.clone(),
+                synced_tx,
+                command_rx,
+            )
+            .await?;
+
+            // Initialize the RPC server(s).
+            rpc::init_rpc_servers(&launch_ctx, tx_handler.clone())?;
+
+            // Start Tor P2P zone after sync completes.
+            if tor_enabled {
+                p2p::initialize_tor_p2p(
+                    launch_ctx.clone(),
+                    tor_context,
+                    tx_handler,
+                    tor_tx,
+                    tor_router_tx,
+                );
+            }
+
+            let LaunchContext {
+                blockchain,
+                txpool_read,
+                config,
+                task_executor,
+                ..
+            } = launch_ctx;
+
+            Ok(Self {
+                blockchain,
+                txpool: txpool_read,
+                clearnet: clearnet_interface,
+                tor: if tor_enabled { Some(tor_rx) } else { None },
+                config,
+                task_executor,
+            })
         }
+        .await;
 
-        let LaunchContext {
-            blockchain,
-            txpool_read,
-            config,
-            task_executor,
-            ..
-        } = launch_ctx;
-
-        Ok(Self {
-            blockchain,
-            txpool: txpool_read,
-            clearnet: clearnet_interface,
-            tor: if tor_enabled { Some(tor_rx) } else { None },
-            config,
-            task_executor,
-        })
+        if node.is_err() {
+            shutdown_token.cancel();
+        }
+        node
     }
 
     /// Trigger a graceful shutdown.

--- a/binaries/cuprated/src/lib.rs
+++ b/binaries/cuprated/src/lib.rs
@@ -144,7 +144,7 @@ impl Node {
     pub async fn launch(config: impl Into<Arc<Config>>) -> Result<Self, anyhow::Error> {
         let config: Arc<Config> = config.into();
         let task_executor = TaskExecutor::new();
-        let shutdown_token = task_executor.cancellation_token();
+        let launch_executor = task_executor.clone();
 
         let node: Result<Self, anyhow::Error> = async move {
             // Initialize the database thread pool.
@@ -292,7 +292,8 @@ impl Node {
         .await;
 
         if node.is_err() {
-            shutdown_token.cancel();
+            launch_executor.cancellation_token().cancel();
+            launch_executor.wait_for_shutdown().await;
         }
         node
     }

--- a/binaries/cuprated/src/lib.rs
+++ b/binaries/cuprated/src/lib.rs
@@ -144,7 +144,7 @@ impl Node {
     pub async fn launch(config: impl Into<Arc<Config>>) -> Result<Self, anyhow::Error> {
         let config: Arc<Config> = config.into();
         let task_executor = TaskExecutor::new();
-        let shutdown_token = task_executor.cancellation_token();
+        let launch_executor = task_executor.clone();
 
         let node: Result<Self, anyhow::Error> = async move {
             // Initialize the database thread pool.
@@ -291,8 +291,10 @@ impl Node {
         }
         .await;
 
-        if node.is_err() {
-            shutdown_token.cancel();
+        if let Err(e) = &node {
+            error!("Failed to launch node: {e:#}");
+            launch_executor.cancellation_token().cancel();
+            launch_executor.wait_for_shutdown().await;
         }
         node
     }

--- a/binaries/cuprated/src/lib.rs
+++ b/binaries/cuprated/src/lib.rs
@@ -233,7 +233,7 @@ impl Node {
                 &launch_ctx,
                 clearnet_interface.clone(),
                 tor_router_rx,
-                txpool_write_handle.clone(),
+                txpool_write_handle,
             )
             .await?;
 

--- a/binaries/cuprated/src/lib.rs
+++ b/binaries/cuprated/src/lib.rs
@@ -259,7 +259,7 @@ impl Node {
             .await?;
 
             // Initialize the RPC server(s).
-            rpc::init_rpc_servers(&launch_ctx, tx_handler.clone())?;
+            rpc::init_rpc_servers(&launch_ctx, tx_handler.clone()).await?;
 
             // Start Tor P2P zone after sync completes.
             if tor_enabled {

--- a/binaries/cuprated/src/logging.rs
+++ b/binaries/cuprated/src/logging.rs
@@ -5,13 +5,15 @@ use std::ops::BitAnd;
 use std::{
     fmt::{Display, Formatter},
     io::IsTerminal,
-    mem::forget,
     sync::OnceLock,
 };
 use tracing::{
     instrument::WithSubscriber, level_filters::LevelFilter, subscriber::Interest, Metadata,
 };
-use tracing_appender::{non_blocking::NonBlocking, rolling::Rotation};
+use tracing_appender::{
+    non_blocking::{NonBlocking, WorkerGuard},
+    rolling::Rotation,
+};
 use tracing_subscriber::{
     filter::Filtered,
     fmt::{
@@ -84,7 +86,7 @@ impl<S> Filter<S> for CupratedTracingFilter {
 }
 
 /// Initialize [`tracing`] for logging to stdout and to a file.
-pub fn init_logging(config: &Config) {
+pub fn init_logging(config: &Config) -> WorkerGuard {
     // initialize the stdout filter, set `STDOUT_FILTER_HANDLE` and create the layer.
     let (stdout_filter, stdout_handle) = ReloadLayer::new(CupratedTracingFilter {
         level: config.tracing.stdout.level,
@@ -107,9 +109,6 @@ pub fn init_logging(config: &Config) {
             .unwrap(),
     );
 
-    // TODO: drop this when we shutdown.
-    forget(guard);
-
     // initialize the appender filter, set `FILE_WRITER_FILTER_HANDLE` and create the layer.
     let (appender_filter, appender_handle) = ReloadLayer::new(CupratedTracingFilter {
         level: appender_config.level,
@@ -127,6 +126,8 @@ pub fn init_logging(config: &Config) {
         .with(appender_layer)
         .with(stdout_layer)
         .init();
+
+    guard
 }
 
 /// Modify the stdout [`CupratedTracingFilter`].

--- a/binaries/cuprated/src/main.rs
+++ b/binaries/cuprated/src/main.rs
@@ -84,7 +84,7 @@ fn main() {
     rt.block_on(async move {
         // Start the node.
         let Ok(node) = cuprated::Node::launch(config).await else {
-            std::process::exit(1)
+            return;
         };
 
         let task_executor = node.task_executor.clone();

--- a/binaries/cuprated/src/main.rs
+++ b/binaries/cuprated/src/main.rs
@@ -81,15 +81,10 @@ fn main() {
 
     let rt = init_tokio_rt(&config);
 
-    #[expect(clippy::significant_drop_tightening)]
     rt.block_on(async move {
         // Start the node.
-        let node = match cuprated::Node::launch(config).await {
-            Ok(node) => node,
-            Err(e) => {
-                tracing::error!("Failed to launch node: {e:#}");
-                std::process::exit(1);
-            }
+        let Ok(node) = cuprated::Node::launch(config).await else {
+            std::process::exit(1)
         };
 
         let task_executor = node.task_executor.clone();

--- a/binaries/cuprated/src/main.rs
+++ b/binaries/cuprated/src/main.rs
@@ -67,7 +67,7 @@ fn main() {
     let mut config = load_config(&args);
 
     // Initialize logging.
-    cuprated::logging::init_logging(&config);
+    let _log_guard = cuprated::logging::init_logging(&config);
 
     // Resolve available memory.
     resolve_max_memory(&mut config);

--- a/binaries/cuprated/src/monitor.rs
+++ b/binaries/cuprated/src/monitor.rs
@@ -1,10 +1,13 @@
 //! Task spawning and shutdown coordination.
 
-use std::future::Future;
+use std::{future::Future, panic::AssertUnwindSafe};
 
+use futures::FutureExt;
 use tokio::task::JoinHandle;
 use tokio_util::{sync::CancellationToken, task::TaskTracker};
-use tracing::info;
+use tracing::{error, info};
+
+use crate::constants::CRITICAL_SERVICE_ERROR;
 
 /// A handle for task spawning and shutdown coordination.
 #[derive(Clone, Default)]
@@ -28,6 +31,38 @@ impl TaskExecutor {
         self.tracker.spawn(future)
     }
 
+    /// Spawn a tracked task that triggers shutdown if the future returns
+    /// early or panics.
+    pub fn spawn_critical<F, E>(&self, name: &'static str, future: F) -> JoinHandle<()>
+    where
+        F: Future<Output = Result<(), E>> + Send + 'static,
+        E: Into<anyhow::Error> + Send + 'static,
+    {
+        let executor = self.clone();
+        self.tracker
+            .spawn(AssertUnwindSafe(future).catch_unwind().map(move |result| {
+                match result {
+                    Ok(Ok(())) => {
+                        if executor.token.is_cancelled() {
+                            // Node is shutting down, so an early exit is expected
+                            return;
+                        }
+                        error!(
+                            subsystem = name,
+                            "critical task exited before shutdown was requested"
+                        );
+                    }
+                    Ok(Err(e)) => error!(subsystem = name, "{:#}", e.into()),
+                    Err(payload) => error!(
+                        subsystem = name,
+                        err = panic_message(&payload),
+                        "{CRITICAL_SERVICE_ERROR}",
+                    ),
+                }
+                executor.trigger_shutdown();
+            }))
+    }
+
     /// Get a clone of the cancellation token.
     pub fn cancellation_token(&self) -> CancellationToken {
         self.token.clone()
@@ -47,4 +82,13 @@ impl TaskExecutor {
         self.tracker.close();
         self.tracker.wait().await;
     }
+}
+
+/// Extracts a printable message from a `catch_unwind` panic payload.
+fn panic_message(payload: &(dyn std::any::Any + Send)) -> &str {
+    payload
+        .downcast_ref::<String>()
+        .map(String::as_str)
+        .or_else(|| payload.downcast_ref::<&'static str>().copied())
+        .unwrap_or("<no panic message>")
 }

--- a/binaries/cuprated/src/monitor.rs
+++ b/binaries/cuprated/src/monitor.rs
@@ -5,7 +5,7 @@ use std::{future::Future, panic::AssertUnwindSafe};
 use futures::FutureExt;
 use tokio::task::JoinHandle;
 use tokio_util::{sync::CancellationToken, task::TaskTracker};
-use tracing::{error, info};
+use tracing::{debug, error, info};
 
 use crate::constants::CRITICAL_SERVICE_ERROR;
 
@@ -42,17 +42,22 @@ impl TaskExecutor {
         self.tracker
             .spawn(AssertUnwindSafe(future).catch_unwind().map(move |result| {
                 match result {
-                    Ok(Ok(())) => {
+                    Ok(res) => {
                         if executor.token.is_cancelled() {
-                            // Node is shutting down, so an early exit is expected
+                            // Node is shutting down, so an early exit or error is expected
+                            if let Err(e) = res {
+                                debug!(subsystem = name, "{:#}", e.into());
+                            }
                             return;
                         }
-                        error!(
-                            subsystem = name,
-                            "critical task exited before shutdown was requested"
-                        );
+                        match res {
+                            Ok(()) => error!(
+                                subsystem = name,
+                                "critical task exited before shutdown was requested"
+                            ),
+                            Err(e) => error!(subsystem = name, "{:#}", e.into()),
+                        }
                     }
-                    Ok(Err(e)) => error!(subsystem = name, "{:#}", e.into()),
                     Err(payload) => error!(
                         subsystem = name,
                         err = panic_message(&payload),

--- a/binaries/cuprated/src/monitor.rs
+++ b/binaries/cuprated/src/monitor.rs
@@ -1,13 +1,11 @@
 //! Task spawning and shutdown coordination.
 
-use std::{future::Future, panic::AssertUnwindSafe};
+use std::future::Future;
 
 use futures::FutureExt;
 use tokio::task::JoinHandle;
 use tokio_util::{sync::CancellationToken, task::TaskTracker};
 use tracing::{debug, error, info};
-
-use crate::constants::CRITICAL_SERVICE_ERROR;
 
 /// An unexpected node-side failure that should trigger a shutdown.
 pub type FatalError = tower::BoxError;

--- a/binaries/cuprated/src/monitor.rs
+++ b/binaries/cuprated/src/monitor.rs
@@ -9,6 +9,9 @@ use tracing::{debug, error, info};
 
 use crate::constants::CRITICAL_SERVICE_ERROR;
 
+/// An unexpected node-side failure that should trigger a shutdown.
+pub type FatalError = tower::BoxError;
+
 /// A handle for task spawning and shutdown coordination.
 #[derive(Clone, Default)]
 pub struct TaskExecutor {
@@ -33,10 +36,9 @@ impl TaskExecutor {
 
     /// Spawn a tracked task that triggers shutdown if the future returns
     /// early or panics.
-    pub fn spawn_critical<F, E>(&self, name: &'static str, future: F) -> JoinHandle<()>
+    pub fn spawn_critical<F>(&self, name: &'static str, future: F) -> JoinHandle<()>
     where
-        F: Future<Output = Result<(), E>> + Send + 'static,
-        E: Into<anyhow::Error> + Send + 'static,
+        F: Future<Output = Result<(), FatalError>> + Send + 'static,
     {
         let executor = self.clone();
         self.tracker
@@ -46,7 +48,7 @@ impl TaskExecutor {
                         if executor.token.is_cancelled() {
                             // Node is shutting down, so an early exit or error is expected
                             if let Err(e) = res {
-                                debug!(subsystem = name, "{:#}", e.into());
+                                debug!(subsystem = name, "{:#}", anyhow::Error::from_boxed(e));
                             }
                             return;
                         }
@@ -55,7 +57,9 @@ impl TaskExecutor {
                                 subsystem = name,
                                 "critical task exited before shutdown was requested"
                             ),
-                            Err(e) => error!(subsystem = name, "{:#}", e.into()),
+                            Err(e) => {
+                                error!(subsystem = name, "{:#}", anyhow::Error::from_boxed(e));
+                            }
                         }
                     }
                     Err(payload) => error!(

--- a/binaries/cuprated/src/monitor.rs
+++ b/binaries/cuprated/src/monitor.rs
@@ -34,42 +34,32 @@ impl TaskExecutor {
         self.tracker.spawn(future)
     }
 
-    /// Spawn a tracked task that triggers shutdown if the future returns
-    /// early or panics.
+    /// Spawn a tracked task that triggers shutdown if the future returns early.
     pub fn spawn_critical<F>(&self, name: &'static str, future: F) -> JoinHandle<()>
     where
         F: Future<Output = Result<(), FatalError>> + Send + 'static,
     {
         let executor = self.clone();
-        self.tracker
-            .spawn(AssertUnwindSafe(future).catch_unwind().map(move |result| {
-                match result {
-                    Ok(res) => {
-                        if executor.token.is_cancelled() {
-                            // Node is shutting down, so an early exit or error is expected
-                            if let Err(e) = res {
-                                debug!(subsystem = name, "{:#}", anyhow::Error::from_boxed(e));
-                            }
-                            return;
-                        }
-                        match res {
-                            Ok(()) => error!(
-                                subsystem = name,
-                                "critical task exited before shutdown was requested"
-                            ),
-                            Err(e) => {
-                                error!(subsystem = name, "{:#}", anyhow::Error::from_boxed(e));
-                            }
-                        }
-                    }
-                    Err(payload) => error!(
-                        subsystem = name,
-                        err = panic_message(&payload),
-                        "{CRITICAL_SERVICE_ERROR}",
-                    ),
+        self.tracker.spawn(future.map(move |result| {
+            if executor.token.is_cancelled() {
+                // Node is shutting down, so an early exit or error is expected
+                if let Err(e) = result {
+                    debug!(subsystem = name, "{:#}", anyhow::Error::from_boxed(e));
                 }
-                executor.trigger_shutdown();
-            }))
+                return;
+            }
+            match result {
+                Ok(()) => error!(
+                    subsystem = name,
+                    "critical task exited before shutdown was requested"
+                ),
+                Err(e) => {
+                    error!(subsystem = name, "{:#}", anyhow::Error::from_boxed(e));
+                }
+            }
+
+            executor.trigger_shutdown();
+        }))
     }
 
     /// Get a clone of the cancellation token.
@@ -91,13 +81,4 @@ impl TaskExecutor {
         self.tracker.close();
         self.tracker.wait().await;
     }
-}
-
-/// Extracts a printable message from a `catch_unwind` panic payload.
-fn panic_message(payload: &(dyn std::any::Any + Send)) -> &str {
-    payload
-        .downcast_ref::<String>()
-        .map(String::as_str)
-        .or_else(|| payload.downcast_ref::<&'static str>().copied())
-        .unwrap_or("<no panic message>")
 }

--- a/binaries/cuprated/src/p2p.rs
+++ b/binaries/cuprated/src/p2p.rs
@@ -133,8 +133,7 @@ pub async fn initialize_clearnet_p2p(
     anyhow::Error,
 > {
     let config = launch_ctx.config.as_ref();
-    let blockchain = &launch_ctx.blockchain;
-    let peer_sync_callback = blockchain.peer_sync_callback();
+    let peer_sync_callback = launch_ctx.blockchain.peer_sync_callback();
 
     if config.offline {
         let (interface, _) = start_zone_p2p::<ClearNet, Tcp>(
@@ -159,7 +158,7 @@ pub async fn initialize_clearnet_p2p(
             TorMode::Arti => {
                 tracing::info!("Anonymizing clearnet connections through Arti.");
                 start_zone_p2p::<ClearNet, Arti>(
-                    blockchain,
+                    &launch_ctx.blockchain,
                     launch_ctx.txpool_read.clone(),
                     config.clearnet_p2p_config(),
                     transport_clearnet_arti_config(tor_ctx)?,

--- a/binaries/cuprated/src/p2p.rs
+++ b/binaries/cuprated/src/p2p.rs
@@ -25,7 +25,6 @@ use cuprate_types::blockchain::BlockchainWriteRequest;
 
 use crate::{
     blockchain::BlockchainInterface,
-    constants::PANIC_CRITICAL_SERVICE_ERROR,
     tor::{transport_clearnet_daemon_config, transport_daemon_config, TorContext, TorMode},
     txpool::{self, IncomingTxHandler},
     LaunchContext,
@@ -126,10 +125,13 @@ impl NetworkInterfaces {
 pub async fn initialize_clearnet_p2p(
     launch_ctx: &LaunchContext,
     tor_ctx: &TorContext,
-) -> (
-    NetworkInterface<ClearNet>,
-    Option<Sender<IncomingTxHandler>>,
-) {
+) -> Result<
+    (
+        NetworkInterface<ClearNet>,
+        Option<Sender<IncomingTxHandler>>,
+    ),
+    anyhow::Error,
+> {
     let config = launch_ctx.config.as_ref();
     let blockchain = &launch_ctx.blockchain;
     let peer_sync_callback = blockchain.peer_sync_callback();
@@ -146,9 +148,9 @@ pub async fn initialize_clearnet_p2p(
             Some(peer_sync_callback),
         )
         .await
-        .unwrap();
+        .map_err(anyhow::Error::from_boxed)?;
 
-        return (interface, None);
+        return Ok((interface, None));
     }
 
     let (interface, tx_handler_tx) = match &config.p2p.clear_net.proxy {
@@ -160,47 +162,50 @@ pub async fn initialize_clearnet_p2p(
                     blockchain,
                     launch_ctx.txpool_read.clone(),
                     config.clearnet_p2p_config(),
-                    transport_clearnet_arti_config(tor_ctx),
+                    transport_clearnet_arti_config(tor_ctx)?,
                     Some(peer_sync_callback),
                 )
                 .await
-                .unwrap()
             }
-            TorMode::Daemon => start_zone_p2p::<ClearNet, Socks>(
+            TorMode::Daemon => {
+                start_zone_p2p::<ClearNet, Socks>(
+                    &launch_ctx.blockchain,
+                    launch_ctx.txpool_read.clone(),
+                    config.clearnet_p2p_config(),
+                    transport_clearnet_daemon_config(config),
+                    Some(peer_sync_callback),
+                )
+                .await
+            }
+            TorMode::Auto => unreachable!("Auto mode should be resolved before this point"),
+        },
+        ProxySettings::Disabled => {
+            start_zone_p2p::<ClearNet, Tcp>(
                 &launch_ctx.blockchain,
                 launch_ctx.txpool_read.clone(),
                 config.clearnet_p2p_config(),
-                transport_clearnet_daemon_config(config),
+                config.p2p.clear_net.tcp_transport_config(config.network),
                 Some(peer_sync_callback),
             )
             .await
-            .unwrap(),
-            TorMode::Auto => unreachable!("Auto mode should be resolved before this point"),
-        },
-        ProxySettings::Disabled => start_zone_p2p::<ClearNet, Tcp>(
-            blockchain,
-            launch_ctx.txpool_read.clone(),
-            config.clearnet_p2p_config(),
-            config.p2p.clear_net.tcp_transport_config(config.network),
-            Some(peer_sync_callback),
-        )
-        .await
-        .unwrap(),
-        ProxySettings::Socks(socks_config) => start_zone_p2p::<ClearNet, Socks>(
-            blockchain,
-            launch_ctx.txpool_read.clone(),
-            config.clearnet_p2p_config(),
-            TransportConfig {
-                client_config: socks_config.clone(),
-                server_config: None,
-            },
-            Some(peer_sync_callback),
-        )
-        .await
-        .unwrap(),
-    };
+        }
+        ProxySettings::Socks(socks_config) => {
+            start_zone_p2p::<ClearNet, Socks>(
+                &launch_ctx.blockchain,
+                launch_ctx.txpool_read.clone(),
+                config.clearnet_p2p_config(),
+                TransportConfig {
+                    client_config: socks_config.clone(),
+                    server_config: None,
+                },
+                Some(peer_sync_callback),
+            )
+            .await
+        }
+    }
+    .map_err(anyhow::Error::from_boxed)?;
 
-    (interface, Some(tx_handler_tx))
+    Ok((interface, Some(tx_handler_tx)))
 }
 
 /// Initialize the Tor P2P network zone after the node has synced with the network.
@@ -233,27 +238,36 @@ pub fn initialize_tor_p2p(
         tracing::info!("Starting Tor P2P zone.");
 
         let config = launch_ctx.config.as_ref();
-        let (tor_interface, tor_tx_handler_tx) = match tor_context.mode {
-            TorMode::Daemon => start_zone_p2p::<Tor, Daemon>(
-                &launch_ctx.blockchain,
-                launch_ctx.txpool_read.clone(),
-                config.tor_p2p_config(&tor_context),
-                transport_daemon_config(config),
-                None,
-            )
-            .await
-            .unwrap(),
-            #[cfg(feature = "arti")]
-            TorMode::Arti => start_zone_p2p::<Tor, Arti>(
-                &launch_ctx.blockchain,
-                launch_ctx.txpool_read.clone(),
-                config.tor_p2p_config(&tor_context),
-                transport_arti_config(config, tor_context),
-                None,
-            )
-            .await
-            .unwrap(),
-            TorMode::Auto => unreachable!("Auto mode should be resolved before this point"),
+        let Ok((tor_interface, tor_tx_handler_tx)) = async {
+            match tor_context.mode {
+                TorMode::Daemon => {
+                    start_zone_p2p::<Tor, Daemon>(
+                        &launch_ctx.blockchain,
+                        launch_ctx.txpool_read.clone(),
+                        config.tor_p2p_config(&tor_context),
+                        transport_daemon_config(config),
+                        None,
+                    )
+                    .await
+                }
+                #[cfg(feature = "arti")]
+                TorMode::Arti => {
+                    start_zone_p2p::<Tor, Arti>(
+                        &launch_ctx.blockchain,
+                        launch_ctx.txpool_read.clone(),
+                        config.tor_p2p_config(&tor_context),
+                        transport_arti_config(config, tor_context)?,
+                        None,
+                    )
+                    .await
+                }
+                TorMode::Auto => unreachable!("Auto mode should be resolved before this point"),
+            }
+        }
+        .await
+        .map_err(anyhow::Error::from_boxed)
+        .inspect_err(|e| tracing::error!("Failed to start Tor P2P zone: {e:#}")) else {
+            return;
         };
 
         // Publish the Tor interface for consumers

--- a/binaries/cuprated/src/p2p/request_handler.rs
+++ b/binaries/cuprated/src/p2p/request_handler.rs
@@ -46,8 +46,7 @@ use cuprate_wire::protocol::{
 };
 
 use crate::{
-    blockchain::interface::{BlockchainManagerHandle, IncomingBlockError},
-    constants::PANIC_CRITICAL_SERVICE_ERROR,
+    blockchain::{interface::BlockchainManagerHandle, IncomingBlockError},
     p2p::CrossNetworkInternalPeerId,
     txpool::{IncomingTxError, IncomingTxHandler, IncomingTxs},
 };
@@ -431,8 +430,7 @@ where
 
     let res = incoming_tx_handler
         .ready()
-        .await
-        .expect(PANIC_CRITICAL_SERVICE_ERROR)
+        .await?
         .call(IncomingTxs {
             txs,
             state,

--- a/binaries/cuprated/src/p2p/request_handler.rs
+++ b/binaries/cuprated/src/p2p/request_handler.rs
@@ -29,7 +29,7 @@ use cuprate_helper::{
     map::{combine_low_high_bits_to_u128, split_u128_into_low_high_bits},
 };
 use cuprate_p2p::constants::{
-    MAX_BLOCKS_IDS_IN_CHAIN_ENTRY, MAX_BLOCK_BATCH_LEN, MAX_TRANSACTION_BLOB_SIZE, MEDIUM_BAN,
+    LONG_BAN, MAX_BLOCKS_IDS_IN_CHAIN_ENTRY, MAX_BLOCK_BATCH_LEN, MAX_TRANSACTION_BLOB_SIZE,
 };
 use cuprate_p2p_core::{
     client::{InternalPeerID, PeerInformation},
@@ -354,6 +354,7 @@ async fn new_fluffy_block<A: NetZoneAddress>(
         return Ok(ProtocolResponse::NA);
     }
 
+    let block_hash = block.hash();
     let res = blockchain_manager
         .handle_incoming_block(
             block,
@@ -380,7 +381,21 @@ async fn new_fluffy_block<A: NetZoneAddress>(
             // Manager has exited (likely shutdown); drop silently.
             Ok(ProtocolResponse::NA)
         }
-        Err(e) => Err(e.into()),
+        Err(IncomingBlockError::Internal(e)) => {
+            tracing::error!("Failed to handle incoming block: {e}");
+            Ok(ProtocolResponse::NA)
+        }
+        Err(e) => {
+            if matches!(e, IncomingBlockError::Validation(_)) {
+                tracing::warn!(
+                    "Failed to verify block: {}, error {}, banning peer.",
+                    hex::encode(block_hash),
+                    e
+                );
+                peer_information.handle.ban_peer(LONG_BAN);
+            }
+            Err(e.into())
+        }
     }
 }
 
@@ -441,6 +456,10 @@ where
 
     match res {
         Ok(()) => Ok(ProtocolResponse::NA),
+        Err(IncomingTxError::Internal(e)) => {
+            tracing::error!("Failed to handle incoming txs: {e}");
+            Ok(ProtocolResponse::NA)
+        }
         Err(e) => Err(e.into()),
     }
 }

--- a/binaries/cuprated/src/p2p/request_handler.rs
+++ b/binaries/cuprated/src/p2p/request_handler.rs
@@ -30,6 +30,7 @@ use cuprate_helper::{
 };
 use cuprate_p2p::constants::{
     LONG_BAN, MAX_BLOCKS_IDS_IN_CHAIN_ENTRY, MAX_BLOCK_BATCH_LEN, MAX_TRANSACTION_BLOB_SIZE,
+    MEDIUM_BAN,
 };
 use cuprate_p2p_core::{
     client::{InternalPeerID, PeerInformation},
@@ -46,7 +47,7 @@ use cuprate_wire::protocol::{
 };
 
 use crate::{
-    blockchain::{interface::BlockchainManagerHandle, IncomingBlockError},
+    blockchain::{interface::BlockchainManagerHandle, BlockValidationError, IncomingBlockError},
     p2p::CrossNetworkInternalPeerId,
     txpool::{IncomingTxError, IncomingTxHandler, IncomingTxs},
 };
@@ -355,6 +356,7 @@ async fn new_fluffy_block<A: NetZoneAddress>(
     }
 
     let block_hash = block.hash();
+    let block_version = block.header.hardfork_version;
     let res = blockchain_manager
         .handle_incoming_block(
             block,
@@ -381,21 +383,33 @@ async fn new_fluffy_block<A: NetZoneAddress>(
             // Manager has exited (likely shutdown); drop silently.
             Ok(ProtocolResponse::NA)
         }
-        Err(IncomingBlockError::Internal(e)) => {
-            tracing::error!("Failed to handle incoming block: {e}");
-            Ok(ProtocolResponse::NA)
-        }
-        Err(e) => {
-            if matches!(e, IncomingBlockError::Validation(_)) {
+        Err(IncomingBlockError::Validation(e)) => match e {
+            BlockValidationError::HardFork(e) => {
+                tracing::warn!(
+                    "Failed to verify block: {}, error {} (block v{}, current v{}), banning peer.",
+                    hex::encode(block_hash),
+                    e,
+                    block_version,
+                    context.current_hf.as_u8()
+                );
+                peer_information.handle.ban_peer(MEDIUM_BAN);
+                Err(e.into())
+            }
+            BlockValidationError::Other(e) => {
                 tracing::warn!(
                     "Failed to verify block: {}, error {}, banning peer.",
                     hex::encode(block_hash),
                     e
                 );
                 peer_information.handle.ban_peer(LONG_BAN);
+                Err(e.into())
             }
-            Err(e.into())
+        },
+        Err(IncomingBlockError::Internal(e)) => {
+            tracing::error!("Failed to handle incoming block: {e}");
+            Err(anyhow::Error::from_boxed(e))
         }
+        Err(e) => Err(e.into()),
     }
 }
 
@@ -458,7 +472,7 @@ where
         Ok(()) => Ok(ProtocolResponse::NA),
         Err(IncomingTxError::Internal(e)) => {
             tracing::error!("Failed to handle incoming txs: {e}");
-            Ok(ProtocolResponse::NA)
+            Err(anyhow::Error::from_boxed(e))
         }
         Err(e) => Err(e.into()),
     }

--- a/binaries/cuprated/src/p2p/request_handler.rs
+++ b/binaries/cuprated/src/p2p/request_handler.rs
@@ -47,7 +47,7 @@ use cuprate_wire::protocol::{
 };
 
 use crate::{
-    blockchain::{interface::BlockchainManagerHandle, BlockValidationError, IncomingBlockError},
+    blockchain::{interface::BlockchainManagerHandle, IncomingBlockError},
     p2p::CrossNetworkInternalPeerId,
     txpool::{IncomingTxError, IncomingTxHandler, IncomingTxs},
 };
@@ -379,32 +379,20 @@ async fn new_fluffy_block<A: NetZoneAddress>(
             // Block's parent was unknown, could be syncing?
             Ok(ProtocolResponse::NA)
         }
-        Err(IncomingBlockError::ChannelClosed) => {
-            // Manager has exited (likely shutdown); drop silently.
-            Ok(ProtocolResponse::NA)
-        }
-        Err(IncomingBlockError::Validation(e)) => match e {
-            BlockValidationError::HardFork(e) => {
-                tracing::warn!(
-                    "Failed to verify block: {}, error {} (block v{}, current v{}), banning peer.",
-                    hex::encode(block_hash),
-                    e,
-                    block_version,
-                    context.current_hf.as_u8()
-                );
-                peer_information.handle.ban_peer(MEDIUM_BAN);
-                Err(e.into())
-            }
-            BlockValidationError::Consensus(e) => {
+        Err(IncomingBlockError::Validation { pow_valid, inner }) => {
+            if pow_valid {
+                tracing::warn!("Peer sent invalid block but PoW was valid. Error: {inner}");
+                Ok(ProtocolResponse::NA)
+            } else {
                 tracing::warn!(
                     "Failed to verify block: {}, error {}, banning peer.",
                     hex::encode(block_hash),
-                    e
+                    inner
                 );
-                peer_information.handle.ban_peer(LONG_BAN);
-                Err(e.into())
+                peer_information.handle.ban_peer(MEDIUM_BAN);
+                Err(inner.into())
             }
-        },
+        }
         Err(IncomingBlockError::Fatal(e)) => {
             tracing::error!("Failed to handle incoming block: {e}");
             Err(anyhow::Error::from_boxed(e))

--- a/binaries/cuprated/src/p2p/request_handler.rs
+++ b/binaries/cuprated/src/p2p/request_handler.rs
@@ -395,7 +395,7 @@ async fn new_fluffy_block<A: NetZoneAddress>(
                 peer_information.handle.ban_peer(MEDIUM_BAN);
                 Err(e.into())
             }
-            BlockValidationError::Other(e) => {
+            BlockValidationError::Consensus(e) => {
                 tracing::warn!(
                     "Failed to verify block: {}, error {}, banning peer.",
                     hex::encode(block_hash),
@@ -405,7 +405,7 @@ async fn new_fluffy_block<A: NetZoneAddress>(
                 Err(e.into())
             }
         },
-        Err(IncomingBlockError::Internal(e)) => {
+        Err(IncomingBlockError::Fatal(e)) => {
             tracing::error!("Failed to handle incoming block: {e}");
             Err(anyhow::Error::from_boxed(e))
         }
@@ -470,9 +470,13 @@ where
 
     match res {
         Ok(()) => Ok(ProtocolResponse::NA),
-        Err(IncomingTxError::Internal(e)) => {
+        Err(IncomingTxError::Fatal(e)) => {
             tracing::error!("Failed to handle incoming txs: {e}");
             Err(anyhow::Error::from_boxed(e))
+        }
+        Err(IncomingTxError::ChannelClosed) => {
+            // Manager has exited (likely shutdown); drop silently.
+            Ok(ProtocolResponse::NA)
         }
         Err(e) => Err(e.into()),
     }

--- a/binaries/cuprated/src/p2p/request_handler.rs
+++ b/binaries/cuprated/src/p2p/request_handler.rs
@@ -29,8 +29,7 @@ use cuprate_helper::{
     map::{combine_low_high_bits_to_u128, split_u128_into_low_high_bits},
 };
 use cuprate_p2p::constants::{
-    LONG_BAN, MAX_BLOCKS_IDS_IN_CHAIN_ENTRY, MAX_BLOCK_BATCH_LEN, MAX_TRANSACTION_BLOB_SIZE,
-    MEDIUM_BAN,
+    MAX_BLOCKS_IDS_IN_CHAIN_ENTRY, MAX_BLOCK_BATCH_LEN, MAX_TRANSACTION_BLOB_SIZE, MEDIUM_BAN,
 };
 use cuprate_p2p_core::{
     client::{InternalPeerID, PeerInformation},
@@ -356,7 +355,6 @@ async fn new_fluffy_block<A: NetZoneAddress>(
     }
 
     let block_hash = block.hash();
-    let block_version = block.header.hardfork_version;
     let res = blockchain_manager
         .handle_incoming_block(
             block,
@@ -381,7 +379,11 @@ async fn new_fluffy_block<A: NetZoneAddress>(
         }
         Err(IncomingBlockError::Validation { pow_valid, inner }) => {
             if pow_valid {
-                tracing::warn!("Peer sent invalid block but PoW was valid. Error: {inner}");
+                tracing::warn!(
+                    "Peer sent invalid block but PoW was valid: {}, error {}",
+                    hex::encode(block_hash),
+                    inner
+                );
                 Ok(ProtocolResponse::NA)
             } else {
                 tracing::warn!(
@@ -396,6 +398,10 @@ async fn new_fluffy_block<A: NetZoneAddress>(
         Err(IncomingBlockError::Fatal(e)) => {
             tracing::error!("Failed to handle incoming block: {e}");
             Err(anyhow::Error::from_boxed(e))
+        }
+        Err(IncomingBlockError::ChannelClosed) => {
+            // Manager has exited (likely shutdown); drop silently.
+            Ok(ProtocolResponse::NA)
         }
         Err(e) => Err(e.into()),
     }

--- a/binaries/cuprated/src/p2p/request_handler.rs
+++ b/binaries/cuprated/src/p2p/request_handler.rs
@@ -354,7 +354,6 @@ async fn new_fluffy_block<A: NetZoneAddress>(
         return Ok(ProtocolResponse::NA);
     }
 
-    let block_hash = block.hash();
     let res = blockchain_manager
         .handle_incoming_block(
             block,
@@ -379,18 +378,10 @@ async fn new_fluffy_block<A: NetZoneAddress>(
         }
         Err(IncomingBlockError::Validation { pow_valid, inner }) => {
             if pow_valid {
-                tracing::warn!(
-                    "Peer sent invalid block but PoW was valid: {}, error {}",
-                    hex::encode(block_hash),
-                    inner
-                );
+                tracing::warn!("Peer sent invalid block but PoW was valid: {inner}");
                 Ok(ProtocolResponse::NA)
             } else {
-                tracing::warn!(
-                    "Failed to verify block: {}, error {}, banning peer.",
-                    hex::encode(block_hash),
-                    inner
-                );
+                tracing::warn!("Failed to verify block: {inner}, banning peer.");
                 peer_information.handle.ban_peer(MEDIUM_BAN);
                 Err(inner.into())
             }

--- a/binaries/cuprated/src/rpc/server.rs
+++ b/binaries/cuprated/src/rpc/server.rs
@@ -10,7 +10,7 @@ use tokio::net::TcpListener;
 use tokio_util::sync::CancellationToken;
 use tower::limit::rate::RateLimitLayer;
 use tower_http::limit::RequestBodyLimitLayer;
-use tracing::{info, warn};
+use tracing::{error, info, warn};
 
 use cuprate_rpc_interface::RouterBuilder;
 
@@ -23,12 +23,14 @@ use crate::{
 
 /// Initialize the RPC server(s).
 ///
-/// # Panics
-/// This function will panic if:
-/// - the server(s) could not be started
-/// - unrestricted RPC is started on non-local
-///   address without override option
-pub fn init_rpc_servers(launch_ctx: &LaunchContext, tx_handler: IncomingTxHandler) {
+/// # Errors
+///
+/// This function will return an [`Err`] if unrestricted RPC is started on a
+/// non-local address without the override option.
+pub fn init_rpc_servers(
+    launch_ctx: &LaunchContext,
+    tx_handler: IncomingTxHandler,
+) -> Result<(), Error> {
     let config = &launch_ctx.config.rpc;
     for ((enable, addr, port, request_byte_limit), restricted) in [
         (
@@ -65,7 +67,7 @@ pub fn init_rpc_servers(launch_ctx: &LaunchContext, tx_handler: IncomingTxHandle
                     "Starting unrestricted RPC on non-local address, this is dangerous!"
                 );
             } else {
-                panic!("Refusing to start unrestricted RPC on a non-local address ({addr})");
+                anyhow::bail!("Refusing to start unrestricted RPC on a non-local address ({addr})");
             }
         }
 
@@ -73,7 +75,7 @@ pub fn init_rpc_servers(launch_ctx: &LaunchContext, tx_handler: IncomingTxHandle
 
         let shutdown_token = launch_ctx.task_executor.cancellation_token();
         launch_ctx.task_executor.spawn(async move {
-            run_rpc_server(
+            if let Err(e) = run_rpc_server(
                 rpc_handler,
                 restricted,
                 SocketAddr::new(addr, port),
@@ -81,10 +83,13 @@ pub fn init_rpc_servers(launch_ctx: &LaunchContext, tx_handler: IncomingTxHandle
                 shutdown_token,
             )
             .await
-            .unwrap();
-            info!(restricted, "RPC server shut down.");
+            {
+                error!(restricted, "Failed to start RPC server: {e:#}");
+            }
         });
     }
+
+    Ok(())
 }
 
 /// This initializes and runs an RPC server.
@@ -152,5 +157,6 @@ async fn run_rpc_server(
         .with_graceful_shutdown(shutdown_token.cancelled_owned())
         .await?;
 
+    info!(restricted, "RPC server shut down.");
     Ok(())
 }

--- a/binaries/cuprated/src/rpc/server.rs
+++ b/binaries/cuprated/src/rpc/server.rs
@@ -45,12 +45,14 @@ const RPC_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Initialize the RPC server(s).
 ///
-/// # Panics
-/// This function will panic if:
-/// - the server(s) could not be started
-/// - unrestricted RPC is started on non-local
-///   address without override option
-pub fn init_rpc_servers(launch_ctx: &LaunchContext, tx_handler: IncomingTxHandler) {
+/// # Errors
+///
+/// This function will return an [`Err`] if unrestricted RPC is started on a
+/// non-local address without the override option.
+pub fn init_rpc_servers(
+    launch_ctx: &LaunchContext,
+    tx_handler: IncomingTxHandler,
+) -> Result<(), Error> {
     let config = &launch_ctx.config.rpc;
     for ((enable, addr, port, request_byte_limit), restricted) in [
         (
@@ -87,7 +89,7 @@ pub fn init_rpc_servers(launch_ctx: &LaunchContext, tx_handler: IncomingTxHandle
                     "Starting unrestricted RPC on non-local address, this is dangerous!"
                 );
             } else {
-                panic!("Refusing to start unrestricted RPC on a non-local address ({addr})");
+                anyhow::bail!("Refusing to start unrestricted RPC on a non-local address ({addr})");
             }
         }
 
@@ -135,6 +137,8 @@ pub fn init_rpc_servers(launch_ctx: &LaunchContext, tx_handler: IncomingTxHandle
             info!(restricted, "RPC server shut down.");
         });
     }
+
+    Ok(())
 }
 
 /// Initialize the Axum router of the RPC server.

--- a/binaries/cuprated/src/rpc/server.rs
+++ b/binaries/cuprated/src/rpc/server.rs
@@ -12,7 +12,7 @@ use std::{
     time::Duration,
 };
 
-use anyhow::Error;
+use anyhow::{Context, Error};
 use axum::Router;
 use hyper::{body::Incoming, server::conn::http1, Request};
 use hyper_util::{
@@ -27,7 +27,7 @@ use tokio::{
 use tokio_util::{sync::CancellationToken, time::FutureExt};
 use tower::{limit::rate::RateLimitLayer, Service};
 use tower_http::{limit::RequestBodyLimitLayer, timeout::RequestBodyDeadlineLayer};
-use tracing::{debug, error, info, warn};
+use tracing::{debug, info, warn};
 
 use cuprate_helper::net::ip_is_local;
 use cuprate_rpc_interface::RouterBuilder;
@@ -48,8 +48,9 @@ const RPC_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
 /// # Errors
 ///
 /// This function will return an [`Err`] if unrestricted RPC is started on a
-/// non-local address without the override option.
-pub fn init_rpc_servers(
+/// non-local address without the override option, or if an RPC listener cannot
+/// be bound.
+pub async fn init_rpc_servers(
     launch_ctx: &LaunchContext,
     tx_handler: IncomingTxHandler,
 ) -> Result<(), Error> {
@@ -109,30 +110,27 @@ pub fn init_rpc_servers(
 
         // Initialize RPC handler service.
         let rpc_handler = CupratedRpcHandler::new(restricted, tx_handler.clone(), launch_ctx);
+        let address = SocketAddr::new(addr, port);
+        let listener = TcpListener::bind(address)
+            .await
+            .with_context(|| format!("failed to bind RPC listener on {address}"))?;
 
         // Initialize Axum RPC router.
         let rpc_router = init_rpc_router(rpc_handler, request_byte_limit, rpc_body_read_timeout);
 
         // Build the RPC server.
-        let rpc_server = RpcServer::new(
-            SocketAddr::new(addr, port),
-            rpc_send_timeout,
-            rpc_header_read_timeout,
-            rpc_router,
-        );
+        let rpc_server = RpcServer::new(rpc_send_timeout, rpc_header_read_timeout, rpc_router);
 
         info!(
             restricted,
-            address = %addr,
+            address = %address,
             "Starting RPC server"
         );
 
         // Launch RPC server.
         let shutdown_token = launch_ctx.task_executor.cancellation_token();
         launch_ctx.task_executor.spawn(async move {
-            if let Err(e) = rpc_server.run(shutdown_token).await {
-                error!(restricted, "RPC server error: {e:#}");
-            }
+            rpc_server.run(listener, shutdown_token).await;
 
             info!(restricted, "RPC server shut down.");
         });
@@ -193,7 +191,6 @@ fn init_rpc_router(
 struct RpcServer {
     /// The RPC Axum router.
     rpc: Router,
-    listening_address: SocketAddr,
     // Socket timeouts
     send_timeout: Duration,
     header_read_timeout: Duration,
@@ -202,27 +199,17 @@ struct RpcServer {
 
 impl RpcServer {
     /// Build a new RPC server.
-    fn new(
-        listening_address: SocketAddr,
-        send_timeout: Duration,
-        header_read_timeout: Duration,
-        rpc: Router,
-    ) -> Self {
+    fn new(send_timeout: Duration, header_read_timeout: Duration, rpc: Router) -> Self {
         Self {
             rpc,
-            listening_address,
             send_timeout,
             header_read_timeout,
             rpc_tasks: JoinSet::new(),
         }
     }
 
-    /// Consume this server and start serving to incoming connections.
-    /// This method only returns errors is unable to listen on its address:port.
-    async fn run(mut self, shutdown_token: CancellationToken) -> Result<(), Error> {
-        // Start the listener.
-        let listener = TcpListener::bind(self.listening_address).await?;
-
+    /// Consume this server and start serving connections incoming on `listener`.
+    async fn run(mut self, listener: TcpListener, shutdown_token: CancellationToken) {
         loop {
             tokio::select! {
                 res = listener.accept() => {
@@ -261,8 +248,6 @@ impl RpcServer {
         {
             warn!("RPC tasks survived shutdown signal for more than {} seconds... Dropping connections anyway.", RPC_SHUTDOWN_TIMEOUT.as_secs());
         }
-
-        Ok(())
     }
 
     fn serve(

--- a/binaries/cuprated/src/rpc/server.rs
+++ b/binaries/cuprated/src/rpc/server.rs
@@ -26,8 +26,9 @@ use crate::{
 /// # Errors
 ///
 /// This function will return an [`Err`] if unrestricted RPC is started on a
-/// non-local address without the override option.
-pub fn init_rpc_servers(
+/// non-local address without the override option, or if an RPC listener cannot
+/// be bound.
+pub async fn init_rpc_servers(
     launch_ctx: &LaunchContext,
     tx_handler: IncomingTxHandler,
 ) -> Result<(), Error> {
@@ -72,13 +73,16 @@ pub fn init_rpc_servers(
         }
 
         let rpc_handler = CupratedRpcHandler::new(restricted, tx_handler.clone(), launch_ctx);
+        let address = SocketAddr::new(addr, port);
+        let listener = TcpListener::bind(address).await?;
 
         let shutdown_token = launch_ctx.task_executor.cancellation_token();
         launch_ctx.task_executor.spawn(async move {
             if let Err(e) = run_rpc_server(
                 rpc_handler,
                 restricted,
-                SocketAddr::new(addr, port),
+                address,
+                listener,
                 request_byte_limit,
                 shutdown_token,
             )
@@ -99,6 +103,7 @@ async fn run_rpc_server(
     rpc_handler: CupratedRpcHandler,
     restricted: bool,
     address: SocketAddr,
+    listener: TcpListener,
     request_byte_limit: usize,
     shutdown_token: CancellationToken,
 ) -> Result<(), Error> {
@@ -152,7 +157,6 @@ async fn run_rpc_server(
     // Start the server.
     //
     // TODO: impl custom server code, don't use axum.
-    let listener = TcpListener::bind(address).await?;
     axum::serve(listener, router)
         .with_graceful_shutdown(shutdown_token.cancelled_owned())
         .await?;

--- a/binaries/cuprated/src/rpc/service/tx_handler.rs
+++ b/binaries/cuprated/src/rpc/service/tx_handler.rs
@@ -5,7 +5,9 @@ use tower::{Service, ServiceExt};
 
 use cuprate_types::TxRelayChecks;
 
-use crate::txpool::{IncomingTxError, IncomingTxHandler, IncomingTxs, RelayRuleError};
+use crate::txpool::{
+    IncomingTxError, IncomingTxHandler, IncomingTxs, RelayRuleError, TxValidationError,
+};
 
 pub async fn handle_incoming_txs(
     tx_handler: &mut IncomingTxHandler,
@@ -20,10 +22,11 @@ pub async fn handle_incoming_txs(
 
     Ok(match resp {
         Ok(()) => TxRelayChecks::empty(),
-        Err(e) => match e {
-            IncomingTxError::Consensus(ExtendedConsensusError::ConErr(
-                ConsensusError::Transaction(e),
-            )) => match e {
+        Err(IncomingTxError::Internal(e)) => return Err(anyhow!(e)),
+        Err(IncomingTxError::Validation(e)) => match e {
+            TxValidationError::Consensus(ExtendedConsensusError::ConErr(
+                ConsensusError::Transaction(ref tx_err),
+            )) => match tx_err {
                 TransactionError::TooBig => TxRelayChecks::TOO_BIG,
                 TransactionError::KeyImageSpent => TxRelayChecks::DOUBLE_SPEND,
 
@@ -49,21 +52,21 @@ pub async fn handle_incoming_txs(
                 | TransactionError::RingMemberNotFoundOrInvalid
                 | TransactionError::RingSignatureIncorrect
                 | TransactionError::TransactionVersionInvalid
-                | TransactionError::RingCTError(_) => return Err(anyhow!("unreachable")),
+                | TransactionError::RingCTError(_) => return Err(anyhow!(e)),
             },
-            IncomingTxError::Parse(_) | IncomingTxError::Consensus(_) => {
-                return Err(anyhow!("unreachable"))
+            TxValidationError::Parse(_) | TxValidationError::Consensus(_) => {
+                return Err(anyhow!(e))
             }
-            IncomingTxError::RelayRule(RelayRuleError::NonZeroTimelock) => {
+            TxValidationError::RelayRule(RelayRuleError::NonZeroTimelock) => {
                 TxRelayChecks::NONZERO_UNLOCK_TIME
             }
-            IncomingTxError::RelayRule(RelayRuleError::ExtraFieldTooLarge) => {
+            TxValidationError::RelayRule(RelayRuleError::ExtraFieldTooLarge) => {
                 TxRelayChecks::TX_EXTRA_TOO_BIG
             }
-            IncomingTxError::RelayRule(RelayRuleError::FeeBelowMinimum) => {
+            TxValidationError::RelayRule(RelayRuleError::FeeBelowMinimum) => {
                 TxRelayChecks::FEE_TOO_LOW
             }
-            IncomingTxError::DuplicateTransaction => TxRelayChecks::DOUBLE_SPEND,
+            TxValidationError::DuplicateTransaction => TxRelayChecks::DOUBLE_SPEND,
         },
     })
 }

--- a/binaries/cuprated/src/rpc/service/tx_handler.rs
+++ b/binaries/cuprated/src/rpc/service/tx_handler.rs
@@ -13,16 +13,10 @@ pub async fn handle_incoming_txs(
     tx_handler: &mut IncomingTxHandler,
     incoming_txs: IncomingTxs,
 ) -> Result<TxRelayChecks, Error> {
-    let resp = tx_handler
-        .ready()
-        .await
-        .map_err(|e| anyhow!(e))?
-        .call(incoming_txs)
-        .await;
+    let resp = tx_handler.ready().await?.call(incoming_txs).await;
 
     Ok(match resp {
         Ok(()) => TxRelayChecks::empty(),
-        Err(IncomingTxError::Internal(e)) => return Err(anyhow!(e)),
         Err(IncomingTxError::Validation(e)) => match e {
             TxValidationError::Consensus(ExtendedConsensusError::ConErr(
                 ConsensusError::Transaction(ref tx_err),
@@ -68,5 +62,6 @@ pub async fn handle_incoming_txs(
             }
             TxValidationError::DuplicateTransaction => TxRelayChecks::DOUBLE_SPEND,
         },
+        Err(e) => return Err(anyhow!(e)),
     })
 }

--- a/binaries/cuprated/src/rpc/service/tx_handler.rs
+++ b/binaries/cuprated/src/rpc/service/tx_handler.rs
@@ -1,67 +1,57 @@
-use anyhow::{anyhow, Error};
-use cuprate_consensus::ExtendedConsensusError;
 use cuprate_consensus_rules::{transactions::TransactionError, ConsensusError};
 use tower::{Service, ServiceExt};
 
 use cuprate_types::TxRelayChecks;
 
-use crate::txpool::{
-    IncomingTxError, IncomingTxHandler, IncomingTxs, RelayRuleError, TxValidationError,
-};
+use crate::txpool::{IncomingTxError, IncomingTxHandler, IncomingTxs, RelayRuleError};
 
 pub async fn handle_incoming_txs(
     tx_handler: &mut IncomingTxHandler,
     incoming_txs: IncomingTxs,
-) -> Result<TxRelayChecks, Error> {
+) -> Result<TxRelayChecks, IncomingTxError> {
     let resp = tx_handler.ready().await?.call(incoming_txs).await;
 
     Ok(match resp {
         Ok(()) => TxRelayChecks::empty(),
-        Err(IncomingTxError::Validation(e)) => match e {
-            TxValidationError::Consensus(ExtendedConsensusError::ConErr(
-                ConsensusError::Transaction(ref tx_err),
-            )) => match tx_err {
-                TransactionError::TooBig => TxRelayChecks::TOO_BIG,
-                TransactionError::KeyImageSpent => TxRelayChecks::DOUBLE_SPEND,
+        Err(IncomingTxError::Consensus(ConsensusError::Transaction(tx_err))) => match &tx_err {
+            TransactionError::TooBig => TxRelayChecks::TOO_BIG,
+            TransactionError::KeyImageSpent => TxRelayChecks::DOUBLE_SPEND,
 
-                TransactionError::OutputNotValidPoint
-                | TransactionError::OutputTypeInvalid
-                | TransactionError::ZeroOutputForV1
-                | TransactionError::NonZeroOutputForV2
-                | TransactionError::OutputsOverflow
-                | TransactionError::OutputsTooHigh => TxRelayChecks::INVALID_OUTPUT,
+            TransactionError::OutputNotValidPoint
+            | TransactionError::OutputTypeInvalid
+            | TransactionError::ZeroOutputForV1
+            | TransactionError::NonZeroOutputForV2
+            | TransactionError::OutputsOverflow
+            | TransactionError::OutputsTooHigh => TxRelayChecks::INVALID_OUTPUT,
 
-                TransactionError::MoreThanOneMixableInputWithUnmixable
-                | TransactionError::InvalidNumberOfOutputs
-                | TransactionError::InputDoesNotHaveExpectedNumbDecoys
-                | TransactionError::IncorrectInputType
-                | TransactionError::InputsAreNotOrdered
-                | TransactionError::InputsOverflow
-                | TransactionError::NoInputs => TxRelayChecks::INVALID_INPUT,
+            TransactionError::MoreThanOneMixableInputWithUnmixable
+            | TransactionError::InvalidNumberOfOutputs
+            | TransactionError::InputDoesNotHaveExpectedNumbDecoys
+            | TransactionError::IncorrectInputType
+            | TransactionError::InputsAreNotOrdered
+            | TransactionError::InputsOverflow
+            | TransactionError::NoInputs => TxRelayChecks::INVALID_INPUT,
 
-                TransactionError::KeyImageIsNotInPrimeSubGroup
-                | TransactionError::AmountNotDecomposed
-                | TransactionError::DuplicateRingMember
-                | TransactionError::OneOrMoreRingMembersLocked
-                | TransactionError::RingMemberNotFoundOrInvalid
-                | TransactionError::RingSignatureIncorrect
-                | TransactionError::TransactionVersionInvalid
-                | TransactionError::RingCTError(_) => return Err(anyhow!(e)),
-            },
-            TxValidationError::Parse(_) | TxValidationError::Consensus(_) => {
-                return Err(anyhow!(e))
+            TransactionError::KeyImageIsNotInPrimeSubGroup
+            | TransactionError::AmountNotDecomposed
+            | TransactionError::DuplicateRingMember
+            | TransactionError::OneOrMoreRingMembersLocked
+            | TransactionError::RingMemberNotFoundOrInvalid
+            | TransactionError::RingSignatureIncorrect
+            | TransactionError::TransactionVersionInvalid
+            | TransactionError::BatchVerificationFailed
+            | TransactionError::RingCTError(_) => {
+                return Err(IncomingTxError::Consensus(ConsensusError::Transaction(
+                    tx_err,
+                )))
             }
-            TxValidationError::RelayRule(RelayRuleError::NonZeroTimelock) => {
-                TxRelayChecks::NONZERO_UNLOCK_TIME
-            }
-            TxValidationError::RelayRule(RelayRuleError::ExtraFieldTooLarge) => {
-                TxRelayChecks::TX_EXTRA_TOO_BIG
-            }
-            TxValidationError::RelayRule(RelayRuleError::FeeBelowMinimum) => {
-                TxRelayChecks::FEE_TOO_LOW
-            }
-            TxValidationError::DuplicateTransaction => TxRelayChecks::DOUBLE_SPEND,
         },
-        Err(e) => return Err(anyhow!(e)),
+        Err(IncomingTxError::RelayRule(e)) => match e {
+            RelayRuleError::NonZeroTimelock => TxRelayChecks::NONZERO_UNLOCK_TIME,
+            RelayRuleError::ExtraFieldTooLarge => TxRelayChecks::TX_EXTRA_TOO_BIG,
+            RelayRuleError::FeeBelowMinimum => TxRelayChecks::FEE_TOO_LOW,
+        },
+        Err(IncomingTxError::DuplicateTransaction) => TxRelayChecks::DOUBLE_SPEND,
+        Err(e) => return Err(e),
     })
 }

--- a/binaries/cuprated/src/rpc/service/txpool.rs
+++ b/binaries/cuprated/src/rpc/service/txpool.rs
@@ -30,11 +30,9 @@ use cuprate_types::{
 pub async fn backlog(txpool_read: &mut TxpoolReadHandle) -> Result<Vec<TxEntry>, Error> {
     let TxpoolReadResponse::Backlog(tx_entries) = txpool_read
         .ready()
-        .await
-        .map_err(|e| anyhow!(e))?
+        .await?
         .call(TxpoolReadRequest::Backlog)
-        .await
-        .map_err(|e| anyhow!(e))?
+        .await?
     else {
         unreachable!();
     };
@@ -49,13 +47,11 @@ pub async fn size(
 ) -> Result<u64, Error> {
     let TxpoolReadResponse::Size(size) = txpool_read
         .ready()
-        .await
-        .map_err(|e| anyhow!(e))?
+        .await?
         .call(TxpoolReadRequest::Size {
             include_sensitive_txs,
         })
-        .await
-        .map_err(|e| anyhow!(e))?
+        .await?
     else {
         unreachable!();
     };
@@ -71,15 +67,13 @@ pub async fn tx_blobs_by_hash(
 ) -> Result<Vec<PoolTxInfo>, Error> {
     let TxpoolReadResponse::TxsByHash(txs) = txpool_read
         .ready()
-        .await
-        .map_err(|e| anyhow!(e))?
+        .await?
         .call(TxpoolReadRequest::TxsByHash {
             tx_hashes: tx_hashes.to_vec(),
             // TODO: allow sending private txs on restricted.
             include_sensitive_txs: false,
         })
-        .await
-        .map_err(|e| anyhow!(e))?
+        .await?
     else {
         unreachable!()
     };
@@ -134,15 +128,13 @@ pub async fn pool_info(
 ) -> Result<PoolInfo, Error> {
     let TxpoolReadResponse::PoolInfo(pool_info) = txpool_read
         .ready()
-        .await
-        .map_err(|e| anyhow!(e))?
+        .await?
         .call(TxpoolReadRequest::PoolInfo {
             include_sensitive_txs,
             max_tx_count,
             start_time,
         })
-        .await
-        .map_err(|e| anyhow!(e))?
+        .await?
     else {
         unreachable!();
     };
@@ -158,14 +150,12 @@ pub async fn txs_by_hash(
 ) -> Result<Vec<TxInPool>, Error> {
     let TxpoolReadResponse::TxsByHash(txs_in_pool) = txpool_read
         .ready()
-        .await
-        .map_err(|e| anyhow!(e))?
+        .await?
         .call(TxpoolReadRequest::TxsByHash {
             tx_hashes,
             include_sensitive_txs,
         })
-        .await
-        .map_err(|e| anyhow!(e))?
+        .await?
     else {
         unreachable!();
     };
@@ -181,14 +171,12 @@ pub async fn key_images_spent(
 ) -> Result<bool, Error> {
     let TxpoolReadResponse::KeyImagesSpent(status) = txpool_read
         .ready()
-        .await
-        .map_err(|e| anyhow!(e))?
+        .await?
         .call(TxpoolReadRequest::KeyImagesSpent {
             key_images,
             include_sensitive_txs,
         })
-        .await
-        .map_err(|e| anyhow!(e))?
+        .await?
     else {
         unreachable!();
     };
@@ -204,14 +192,12 @@ pub async fn key_images_spent_vec(
 ) -> Result<Vec<bool>, Error> {
     let TxpoolReadResponse::KeyImagesSpentVec(status) = txpool_read
         .ready()
-        .await
-        .map_err(|e| anyhow!(e))?
+        .await?
         .call(TxpoolReadRequest::KeyImagesSpentVec {
             key_images,
             include_sensitive_txs,
         })
-        .await
-        .map_err(|e| anyhow!(e))?
+        .await?
     else {
         unreachable!();
     };
@@ -229,13 +215,11 @@ pub async fn pool(
         spent_key_images,
     } = txpool_read
         .ready()
-        .await
-        .map_err(|e| anyhow!(e))?
+        .await?
         .call(TxpoolReadRequest::Pool {
             include_sensitive_txs,
         })
-        .await
-        .map_err(|e| anyhow!(e))?
+        .await?
     else {
         unreachable!();
     };
@@ -253,13 +237,11 @@ pub async fn pool_stats(
 ) -> Result<TxpoolStats, Error> {
     let TxpoolReadResponse::PoolStats(txpool_stats) = txpool_read
         .ready()
-        .await
-        .map_err(|e| anyhow!(e))?
+        .await?
         .call(TxpoolReadRequest::PoolStats {
             include_sensitive_txs,
         })
-        .await
-        .map_err(|e| anyhow!(e))?
+        .await?
     else {
         unreachable!();
     };
@@ -274,13 +256,11 @@ pub async fn all_hashes(
 ) -> Result<Vec<[u8; 32]>, Error> {
     let TxpoolReadResponse::AllHashes(hashes) = txpool_read
         .ready()
-        .await
-        .map_err(|e| anyhow!(e))?
+        .await?
         .call(TxpoolReadRequest::AllHashes {
             include_sensitive_txs,
         })
-        .await
-        .map_err(|e| anyhow!(e))?
+        .await?
     else {
         unreachable!();
     };
@@ -295,11 +275,9 @@ pub async fn txs_for_block(
 ) -> Result<(HashMap<[u8; 32], TransactionVerificationData>, Vec<usize>), Error> {
     let TxpoolReadResponse::TxsForBlock { txs, missing } = txpool_read
         .ready()
-        .await
-        .map_err(|e| anyhow!(e))?
+        .await?
         .call(TxpoolReadRequest::TxsForBlock(tx_hashes))
-        .await
-        .map_err(|e| anyhow!(e))?
+        .await?
     else {
         unreachable!();
     };

--- a/binaries/cuprated/src/tor.rs
+++ b/binaries/cuprated/src/tor.rs
@@ -172,47 +172,54 @@ fn initialize_arti_onion_service(client_config: &TorClientConfig, config: &Confi
 //---------------------------------------------------------------------------------------------------- Transport configuration
 
 #[cfg(feature = "arti")]
-pub fn transport_arti_config(config: &Config, ctx: TorContext) -> TransportConfig<Tor, Arti> {
+pub fn transport_arti_config(
+    config: &Config,
+    ctx: TorContext,
+) -> Result<TransportConfig<Tor, Arti>, anyhow::Error> {
     // Extracting
     let (Some(bootstrapped_client), Some(client_config)) =
         (ctx.bootstrapped_client, ctx.arti_client_config)
     else {
-        panic!("Arti client should be initialized");
+        anyhow::bail!("Arti client should be initialized");
     };
 
-    let server_config = config.p2p.tor_net.inbound_onion.then(|| {
+    let server_config = if config.p2p.tor_net.inbound_onion {
         let Some(onion_svc) = ctx.arti_onion_service else {
-            panic!("inbound onion enabled, but no onion service initialized!");
+            anyhow::bail!("inbound onion enabled, but no onion service initialized!");
         };
 
-        ArtiServerConfig::new(
+        Some(ArtiServerConfig::new(
             onion_svc,
             p2p_port(config.p2p.tor_net.p2p_port, config.network),
             &bootstrapped_client,
             &client_config,
-        )
-    });
+        ))
+    } else {
+        None
+    };
 
-    TransportConfig::<Tor, Arti> {
+    Ok(TransportConfig::<Tor, Arti> {
         client_config: ArtiClientConfig {
             client: bootstrapped_client,
         },
         server_config,
-    }
+    })
 }
 
 #[cfg(feature = "arti")]
-pub fn transport_clearnet_arti_config(ctx: &TorContext) -> TransportConfig<ClearNet, Arti> {
+pub fn transport_clearnet_arti_config(
+    ctx: &TorContext,
+) -> Result<TransportConfig<ClearNet, Arti>, anyhow::Error> {
     let Some(bootstrapped_client) = &ctx.bootstrapped_client else {
-        panic!("Arti enabled but no TorClient initialized!");
+        anyhow::bail!("Arti enabled but no TorClient initialized!");
     };
 
-    TransportConfig::<ClearNet, Arti> {
+    Ok(TransportConfig::<ClearNet, Arti> {
         client_config: ArtiClientConfig {
             client: Arc::clone(bootstrapped_client),
         },
         server_config: None,
-    }
+    })
 }
 
 pub fn transport_daemon_config(config: &Config) -> TransportConfig<Tor, Daemon> {

--- a/binaries/cuprated/src/txpool.rs
+++ b/binaries/cuprated/src/txpool.rs
@@ -7,11 +7,13 @@ use cuprate_p2p_core::ClearNet;
 use cuprate_txpool::service::{TxpoolReadHandle, TxpoolWriteHandle};
 
 mod dandelion;
+mod error;
 mod incoming_tx;
 mod manager;
 mod relay_rules;
 mod txs_being_handled;
 
-pub use incoming_tx::{IncomingTxError, IncomingTxHandler, IncomingTxs};
+pub use error::{IncomingTxError, TxValidationError};
+pub use incoming_tx::{IncomingTxHandler, IncomingTxs};
 pub use manager::{PoolInfoSinceResponse, TxpoolManagerCommand, TxpoolManagerHandle};
 pub use relay_rules::RelayRuleError;

--- a/binaries/cuprated/src/txpool.rs
+++ b/binaries/cuprated/src/txpool.rs
@@ -13,7 +13,7 @@ mod manager;
 mod relay_rules;
 mod txs_being_handled;
 
-pub use error::{IncomingTxError, TxValidationError};
+pub use error::IncomingTxError;
 pub use incoming_tx::{IncomingTxHandler, IncomingTxs};
 pub use manager::{PoolInfoSinceResponse, TxpoolManagerCommand, TxpoolManagerHandle};
 pub use relay_rules::RelayRuleError;

--- a/binaries/cuprated/src/txpool/dandelion.rs
+++ b/binaries/cuprated/src/txpool/dandelion.rs
@@ -125,12 +125,15 @@ impl Service<DandelionRouteReq<DandelionTx, CrossNetworkInternalPeerId>> for Mai
     }
 }
 
-/// Starts the dandelion pool manager task and returns a handle to send txs to broadcast.
+/// Starts the dandelion pool manager and returns its service and task handles.
 pub fn start_dandelion_pool_manager(
     router: MainDandelionRouter,
     txpool_read_handle: TxpoolReadHandle,
     promote_tx: mpsc::UnboundedSender<[u8; 32]>,
-) -> DandelionPoolService<DandelionTx, TxId, CrossNetworkInternalPeerId> {
+) -> (
+    DandelionPoolService<DandelionTx, TxId, CrossNetworkInternalPeerId>,
+    tokio::task::JoinHandle<()>,
+) {
     cuprate_dandelion_tower::pool::start_dandelion_pool_manager(
         // TODO: make this constant configurable?
         32,

--- a/binaries/cuprated/src/txpool/error.rs
+++ b/binaries/cuprated/src/txpool/error.rs
@@ -2,7 +2,6 @@
 
 use cuprate_consensus::ExtendedConsensusError;
 use cuprate_consensus_rules::ConsensusError;
-use cuprate_txpool::TxPoolError;
 
 use crate::txpool::relay_rules::RelayRuleError;
 
@@ -40,10 +39,14 @@ pub enum IncomingTxError {
 
 impl From<ExtendedConsensusError> for IncomingTxError {
     fn from(e: ExtendedConsensusError) -> Self {
-        if let ExtendedConsensusError::DBErr(e) = e {
-            return Self::Internal(e);
+        match e {
+            ExtendedConsensusError::DBErr(e) => Self::Internal(e),
+
+            ExtendedConsensusError::ConErr(_)
+            | ExtendedConsensusError::TxsIncludedWithBlockIncorrect
+            | ExtendedConsensusError::OneOrMoreBatchVerificationStatementsInvalid
+            | ExtendedConsensusError::NoBlocksToVerify => TxValidationError::Consensus(e).into(),
         }
-        TxValidationError::Consensus(e).into()
     }
 }
 
@@ -62,11 +65,5 @@ impl From<std::io::Error> for IncomingTxError {
 impl From<RelayRuleError> for IncomingTxError {
     fn from(e: RelayRuleError) -> Self {
         TxValidationError::from(e).into()
-    }
-}
-
-impl From<TxPoolError> for IncomingTxError {
-    fn from(e: TxPoolError) -> Self {
-        Self::Internal(e.into())
     }
 }

--- a/binaries/cuprated/src/txpool/error.rs
+++ b/binaries/cuprated/src/txpool/error.rs
@@ -1,0 +1,72 @@
+//! Error types for incoming transaction handling.
+
+use cuprate_consensus::ExtendedConsensusError;
+use cuprate_consensus_rules::ConsensusError;
+use cuprate_txpool::TxPoolError;
+
+use crate::txpool::relay_rules::RelayRuleError;
+
+/// A validation failure - the tx should be dropped.
+#[derive(Debug, thiserror::Error)]
+pub enum TxValidationError {
+    /// The transaction could not be parsed.
+    #[error("Error parsing tx: {0}")]
+    Parse(#[from] std::io::Error),
+
+    /// The transaction violated a consensus rule.
+    #[error(transparent)]
+    Consensus(ExtendedConsensusError),
+
+    /// A duplicate transaction appeared in the incoming batch.
+    #[error("Duplicate tx in message.")]
+    DuplicateTransaction,
+
+    /// A relay rule was broken.
+    #[error("Relay rule was broken: {0}")]
+    RelayRule(#[from] RelayRuleError),
+}
+
+/// An error returned while handling an incoming transaction.
+#[derive(Debug, thiserror::Error)]
+pub enum IncomingTxError {
+    /// The tx was rejected by validation; drop it.
+    #[error(transparent)]
+    Validation(#[from] TxValidationError),
+
+    /// An inner tower service returned an error.
+    #[error(transparent)]
+    Internal(#[from] tower::BoxError),
+}
+
+impl From<ExtendedConsensusError> for IncomingTxError {
+    fn from(e: ExtendedConsensusError) -> Self {
+        if let ExtendedConsensusError::DBErr(e) = e {
+            return Self::Internal(e);
+        }
+        TxValidationError::Consensus(e).into()
+    }
+}
+
+impl From<ConsensusError> for IncomingTxError {
+    fn from(e: ConsensusError) -> Self {
+        TxValidationError::Consensus(e.into()).into()
+    }
+}
+
+impl From<std::io::Error> for IncomingTxError {
+    fn from(e: std::io::Error) -> Self {
+        TxValidationError::from(e).into()
+    }
+}
+
+impl From<RelayRuleError> for IncomingTxError {
+    fn from(e: RelayRuleError) -> Self {
+        TxValidationError::from(e).into()
+    }
+}
+
+impl From<TxPoolError> for IncomingTxError {
+    fn from(e: TxPoolError) -> Self {
+        Self::Internal(e.into())
+    }
+}

--- a/binaries/cuprated/src/txpool/error.rs
+++ b/binaries/cuprated/src/txpool/error.rs
@@ -38,8 +38,8 @@ pub enum IncomingTxError {
 impl From<ExtendedConsensusError> for IncomingTxError {
     fn from(e: ExtendedConsensusError) -> Self {
         match e {
-            ExtendedConsensusError::DBErr(e) => Self::Fatal(e),
-            ExtendedConsensusError::ConErr(e) => Self::Consensus(e),
+            ExtendedConsensusError::FatalError(e) => Self::Fatal(e),
+            ExtendedConsensusError::ConsensusError(e) => Self::Consensus(e),
         }
     }
 }

--- a/binaries/cuprated/src/txpool/error.rs
+++ b/binaries/cuprated/src/txpool/error.rs
@@ -2,6 +2,8 @@
 
 use cuprate_consensus::ExtendedConsensusError;
 use cuprate_consensus_rules::ConsensusError;
+use cuprate_dandelion_tower::pool::DandelionPoolShutDown;
+use cuprate_txpool::TxPoolError;
 
 use crate::{monitor::FatalError, txpool::relay_rules::RelayRuleError};
 
@@ -45,5 +47,17 @@ impl From<ExtendedConsensusError> for IncomingTxError {
 impl From<ConsensusError> for IncomingTxError {
     fn from(e: ConsensusError) -> Self {
         Self::Consensus(e)
+    }
+}
+
+impl From<TxPoolError> for IncomingTxError {
+    fn from(e: TxPoolError) -> Self {
+        Self::Fatal(e.into())
+    }
+}
+
+impl From<DandelionPoolShutDown> for IncomingTxError {
+    fn from(e: DandelionPoolShutDown) -> Self {
+        Self::Fatal(e.into())
     }
 }

--- a/binaries/cuprated/src/txpool/error.rs
+++ b/binaries/cuprated/src/txpool/error.rs
@@ -3,7 +3,7 @@
 use cuprate_consensus::ExtendedConsensusError;
 use cuprate_consensus_rules::ConsensusError;
 
-use crate::txpool::relay_rules::RelayRuleError;
+use crate::{monitor::FatalError, txpool::relay_rules::RelayRuleError};
 
 /// A validation failure - the tx should be dropped.
 #[derive(Debug, thiserror::Error)]
@@ -32,15 +32,19 @@ pub enum IncomingTxError {
     #[error(transparent)]
     Validation(#[from] TxValidationError),
 
-    /// An inner tower service returned an error.
+    /// We cannot recover; shut the node down.
     #[error(transparent)]
-    Internal(#[from] tower::BoxError),
+    Fatal(#[from] FatalError),
+
+    /// The tx-pool manager command channel is closed.
+    #[error("The tx-pool manager command channel is closed.")]
+    ChannelClosed,
 }
 
 impl From<ExtendedConsensusError> for IncomingTxError {
     fn from(e: ExtendedConsensusError) -> Self {
         match e {
-            ExtendedConsensusError::DBErr(e) => Self::Internal(e),
+            ExtendedConsensusError::DBErr(e) => Self::Fatal(e),
 
             ExtendedConsensusError::ConErr(_)
             | ExtendedConsensusError::TxsIncludedWithBlockIncorrect

--- a/binaries/cuprated/src/txpool/error.rs
+++ b/binaries/cuprated/src/txpool/error.rs
@@ -5,16 +5,16 @@ use cuprate_consensus_rules::ConsensusError;
 
 use crate::{monitor::FatalError, txpool::relay_rules::RelayRuleError};
 
-/// A validation failure - the tx should be dropped.
+/// An error returned while handling an incoming transaction.
 #[derive(Debug, thiserror::Error)]
-pub enum TxValidationError {
+pub enum IncomingTxError {
     /// The transaction could not be parsed.
     #[error("Error parsing tx: {0}")]
     Parse(#[from] std::io::Error),
 
     /// The transaction violated a consensus rule.
     #[error(transparent)]
-    Consensus(ExtendedConsensusError),
+    Consensus(ConsensusError),
 
     /// A duplicate transaction appeared in the incoming batch.
     #[error("Duplicate tx in message.")]
@@ -23,14 +23,6 @@ pub enum TxValidationError {
     /// A relay rule was broken.
     #[error("Relay rule was broken: {0}")]
     RelayRule(#[from] RelayRuleError),
-}
-
-/// An error returned while handling an incoming transaction.
-#[derive(Debug, thiserror::Error)]
-pub enum IncomingTxError {
-    /// The tx was rejected by validation; drop it.
-    #[error(transparent)]
-    Validation(#[from] TxValidationError),
 
     /// We cannot recover; shut the node down.
     #[error(transparent)]
@@ -45,29 +37,13 @@ impl From<ExtendedConsensusError> for IncomingTxError {
     fn from(e: ExtendedConsensusError) -> Self {
         match e {
             ExtendedConsensusError::DBErr(e) => Self::Fatal(e),
-
-            ExtendedConsensusError::ConErr(_)
-            | ExtendedConsensusError::TxsIncludedWithBlockIncorrect
-            | ExtendedConsensusError::OneOrMoreBatchVerificationStatementsInvalid
-            | ExtendedConsensusError::NoBlocksToVerify => TxValidationError::Consensus(e).into(),
+            ExtendedConsensusError::ConErr(e) => Self::Consensus(e),
         }
     }
 }
 
 impl From<ConsensusError> for IncomingTxError {
     fn from(e: ConsensusError) -> Self {
-        TxValidationError::Consensus(e.into()).into()
-    }
-}
-
-impl From<std::io::Error> for IncomingTxError {
-    fn from(e: std::io::Error) -> Self {
-        TxValidationError::from(e).into()
-    }
-}
-
-impl From<RelayRuleError> for IncomingTxError {
-    fn from(e: RelayRuleError) -> Self {
-        TxValidationError::from(e).into()
+        Self::Consensus(e)
     }
 }

--- a/binaries/cuprated/src/txpool/incoming_tx.rs
+++ b/binaries/cuprated/src/txpool/incoming_tx.rs
@@ -15,7 +15,6 @@ use cuprate_blockchain::service::BlockchainReadHandle;
 use cuprate_consensus::{
     transactions::{new_tx_verification_data, start_tx_verification, PrepTransactions},
     BlockChainContextRequest, BlockChainContextResponse, BlockchainContextService,
-    ExtendedConsensusError,
 };
 use cuprate_dandelion_tower::{
     pool::{DandelionPoolService, IncomingTxBuilder},
@@ -31,37 +30,24 @@ use cuprate_txpool::{
         },
         TxpoolReadHandle, TxpoolWriteHandle,
     },
-    transaction_blob_hash,
+    transaction_blob_hash, TxPoolError,
 };
 use cuprate_types::TransactionVerificationData;
 
 use crate::{
     blockchain::ConsensusBlockchainReadHandle,
-    constants::PANIC_CRITICAL_SERVICE_ERROR,
     p2p::CrossNetworkInternalPeerId,
     txpool::{
         dandelion::{
             self, AnonTxService, ConcreteDandelionRouter, DiffuseService, MainDandelionRouter,
         },
         manager::{start_txpool_manager, TxpoolManagerCommand, TxpoolManagerHandle},
-        relay_rules::{check_tx_relay_rules, RelayRuleError},
+        relay_rules::check_tx_relay_rules,
         txs_being_handled::{TxsBeingHandled, TxsBeingHandledLocally},
+        IncomingTxError, TxValidationError,
     },
     LaunchContext,
 };
-
-/// An error that can happen handling an incoming tx.
-#[derive(Debug, thiserror::Error)]
-pub enum IncomingTxError {
-    #[error("Error parsing tx: {0}")]
-    Parse(std::io::Error),
-    #[error(transparent)]
-    Consensus(ExtendedConsensusError),
-    #[error("Duplicate tx in message")]
-    DuplicateTransaction,
-    #[error("Relay rule was broken: {0}")]
-    RelayRule(RelayRuleError),
-}
 
 /// Incoming transactions.
 pub struct IncomingTxs {
@@ -115,7 +101,7 @@ impl IncomingTxHandler {
         clear_net: NetworkInterface<ClearNet>,
         tor_net_rx: Option<oneshot::Receiver<NetworkInterface<Tor>>>,
         txpool_write_handle: TxpoolWriteHandle,
-    ) -> Self {
+    ) -> anyhow::Result<Self> {
         let txpool_config = launch_ctx.config.storage.txpool.clone();
 
         let diffuse_service = DiffuseService {
@@ -142,9 +128,9 @@ impl IncomingTxHandler {
             txpool_config,
             launch_ctx.task_executor.clone(),
         )
-        .await;
+        .await?;
 
-        Self {
+        Ok(Self {
             txs_being_handled: TxsBeingHandled::new(),
             blockchain_context_cache: launch_ctx.blockchain.context_svc(),
             dandelion_pool_manager,
@@ -155,7 +141,7 @@ impl IncomingTxHandler {
                 BoxError::from,
             ),
             reorg_lock: Arc::clone(&launch_ctx.reorg_lock),
-        }
+        })
     }
 }
 
@@ -209,8 +195,7 @@ async fn handle_incoming_txs(
 
     let txs = start_tx_verification()
         .append_prepped_txs(txs)
-        .prepare()
-        .map_err(|e| IncomingTxError::Consensus(e.into()))?
+        .prepare()?
         .full(
             context.chain_height,
             context.top_hash,
@@ -220,8 +205,7 @@ async fn handle_incoming_txs(
             None,
         )
         .verify()
-        .await
-        .map_err(IncomingTxError::Consensus)?;
+        .await?;
 
     for tx in txs {
         // TODO: this could be a DoS, if someone spams us with txs that violate these rules?
@@ -232,7 +216,7 @@ async fn handle_incoming_txs(
                 continue;
             }
 
-            return Err(IncomingTxError::RelayRule(e));
+            return Err(TxValidationError::RelayRule(e).into());
         }
 
         tracing::debug!(
@@ -299,7 +283,9 @@ async fn prepare_incoming_txs(
             // If a duplicate is in here the incoming tx batch contained the same tx twice.
             if !tx_blob_hashes.insert(tx_blob_hash) {
                 tracing::debug!("peer sent duplicate tx in batch, ignoring batch.");
-                return Some(Err(IncomingTxError::DuplicateTransaction));
+                return Some(Err(IncomingTxError::Validation(
+                    TxValidationError::DuplicateTransaction,
+                )));
             }
 
             // If a duplicate is here it is being handled in another batch.
@@ -318,11 +304,9 @@ async fn prepare_incoming_txs(
         stem_pool_hashes,
     } = txpool_read_handle
         .ready()
-        .await
-        .expect(PANIC_CRITICAL_SERVICE_ERROR)
+        .await?
         .call(TxpoolReadRequest::FilterKnownTxBlobHashes(tx_blob_hashes))
-        .await
-        .expect(PANIC_CRITICAL_SERVICE_ERROR)
+        .await?
     else {
         unreachable!()
     };
@@ -339,10 +323,9 @@ async fn prepare_incoming_txs(
                 }
             })
             .map(|bytes| {
-                let tx = Transaction::read(&mut bytes.as_ref()).map_err(IncomingTxError::Parse)?;
+                let tx = Transaction::read(&mut bytes.as_ref())?;
 
-                let tx = new_tx_verification_data(tx)
-                    .map_err(|e| IncomingTxError::Consensus(e.into()))?;
+                let tx = new_tx_verification_data(tx)?;
 
                 Ok(tx)
             })
@@ -364,15 +347,25 @@ async fn rerelay_stem_tx(
         CrossNetworkInternalPeerId,
     >,
 ) {
-    let Ok(TxpoolReadResponse::TxBlob { tx_blob, .. }) = txpool_read_handle
-        .ready()
-        .await
-        .expect(PANIC_CRITICAL_SERVICE_ERROR)
-        .call(TxpoolReadRequest::TxBlob(*tx_hash))
-        .await
-    else {
-        // The tx could have been dropped from the pool.
-        return;
+    let svc = match txpool_read_handle.ready().await {
+        Ok(svc) => svc,
+        Err(e) => {
+            tracing::warn!("Failed to acquire txpool read service for stem re-relay: {e}");
+            return;
+        }
+    };
+    let tx_blob = match svc.call(TxpoolReadRequest::TxBlob(*tx_hash)).await {
+        Ok(TxpoolReadResponse::TxBlob { tx_blob, .. }) => tx_blob,
+        Ok(_) => unreachable!(),
+        Err(TxPoolError::NotFound) => {
+            // The tx was dropped from the pool
+            return;
+        }
+        Err(e) => {
+            // The service returned an error
+            tracing::warn!("Failed to fetch stem tx for re-relay: {e}");
+            return;
+        }
     };
 
     let incoming_tx =
@@ -384,11 +377,15 @@ async fn rerelay_stem_tx(
         .build()
         .unwrap();
 
-    dandelion_pool_manager
-        .ready()
-        .await
-        .expect(PANIC_CRITICAL_SERVICE_ERROR)
-        .call(incoming_tx)
-        .await
-        .expect(PANIC_CRITICAL_SERVICE_ERROR);
+    if let Err(e) = async {
+        dandelion_pool_manager
+            .ready()
+            .await?
+            .call(incoming_tx)
+            .await
+    }
+    .await
+    {
+        tracing::warn!("Dandelion pool manager failed for stem re-relay: {e}");
+    }
 }

--- a/binaries/cuprated/src/txpool/incoming_tx.rs
+++ b/binaries/cuprated/src/txpool/incoming_tx.rs
@@ -113,11 +113,26 @@ impl IncomingTxHandler {
 
         let (promote_tx, promote_rx) = mpsc::unbounded_channel();
 
-        let dandelion_pool_manager = dandelion::start_dandelion_pool_manager(
-            dandelion_router,
-            launch_ctx.txpool_read.clone(),
-            promote_tx,
-        );
+        let (dandelion_pool_manager, mut dandelion_pool_task) =
+            dandelion::start_dandelion_pool_manager(
+                dandelion_router,
+                launch_ctx.txpool_read.clone(),
+                promote_tx,
+            );
+
+        let shutdown = launch_ctx.task_executor.cancellation_token();
+        launch_ctx
+            .task_executor
+            .spawn_critical("dandelion pool manager", async move {
+                tokio::select! {
+                    result = &mut dandelion_pool_task => result.map_err(anyhow::Error::from),
+                    () = shutdown.cancelled() => {
+                        dandelion_pool_task.abort();
+                        drop(dandelion_pool_task.await);
+                        Ok(())
+                    }
+                }
+            });
 
         let txpool_manager = start_txpool_manager(
             txpool_write_handle,
@@ -245,7 +260,7 @@ async fn handle_incoming_txs(
             &mut txpool_read_handle,
             &mut dandelion_pool_manager,
         )
-        .await;
+        .await?;
     }
 
     Ok(())
@@ -304,9 +319,11 @@ async fn prepare_incoming_txs(
         stem_pool_hashes,
     } = txpool_read_handle
         .ready()
-        .await?
+        .await
+        .expect("Txpool read service is always ready.")
         .call(TxpoolReadRequest::FilterKnownTxBlobHashes(tx_blob_hashes))
-        .await?
+        .await
+        .map_err(|e| IncomingTxError::Internal(e.into()))?
     else {
         unreachable!()
     };
@@ -346,26 +363,21 @@ async fn rerelay_stem_tx(
         TxId,
         CrossNetworkInternalPeerId,
     >,
-) {
-    let svc = match txpool_read_handle.ready().await {
-        Ok(svc) => svc,
-        Err(e) => {
-            tracing::warn!("Failed to acquire txpool read service for stem re-relay: {e}");
-            return;
-        }
-    };
-    let tx_blob = match svc.call(TxpoolReadRequest::TxBlob(*tx_hash)).await {
+) -> Result<(), IncomingTxError> {
+    let tx_blob = match txpool_read_handle
+        .ready()
+        .await
+        .expect("Txpool read service is always ready.")
+        .call(TxpoolReadRequest::TxBlob(*tx_hash))
+        .await
+    {
         Ok(TxpoolReadResponse::TxBlob { tx_blob, .. }) => tx_blob,
         Ok(_) => unreachable!(),
         Err(TxPoolError::NotFound) => {
             // The tx was dropped from the pool
-            return;
+            return Ok(());
         }
-        Err(e) => {
-            // The service returned an error
-            tracing::warn!("Failed to fetch stem tx for re-relay: {e}");
-            return;
-        }
+        Err(TxPoolError::Fjall(e)) => return Err(IncomingTxError::Internal(e.into())),
     };
 
     let incoming_tx =
@@ -377,7 +389,7 @@ async fn rerelay_stem_tx(
         .build()
         .unwrap();
 
-    if let Err(e) = async {
+    async {
         dandelion_pool_manager
             .ready()
             .await?
@@ -385,7 +397,5 @@ async fn rerelay_stem_tx(
             .await
     }
     .await
-    {
-        tracing::warn!("Dandelion pool manager failed for stem re-relay: {e}");
-    }
+    .map_err(|e| IncomingTxError::Internal(e.into()))
 }

--- a/binaries/cuprated/src/txpool/incoming_tx.rs
+++ b/binaries/cuprated/src/txpool/incoming_tx.rs
@@ -317,11 +317,9 @@ async fn prepare_incoming_txs(
         stem_pool_hashes,
     } = txpool_read_handle
         .ready()
-        .await
-        .expect("Txpool read service is always ready.")
+        .await?
         .call(TxpoolReadRequest::FilterKnownTxBlobHashes(tx_blob_hashes))
-        .await
-        .map_err(|e| IncomingTxError::Fatal(e.into()))?
+        .await?
     else {
         unreachable!()
     };
@@ -364,8 +362,7 @@ async fn rerelay_stem_tx(
 ) -> Result<(), IncomingTxError> {
     let tx_blob = match txpool_read_handle
         .ready()
-        .await
-        .expect("Txpool read service is always ready.")
+        .await?
         .call(TxpoolReadRequest::TxBlob(*tx_hash))
         .await
     {
@@ -375,7 +372,7 @@ async fn rerelay_stem_tx(
             // The tx was dropped from the pool
             return Ok(());
         }
-        Err(TxPoolError::Fjall(e)) => return Err(IncomingTxError::Fatal(e.into())),
+        Err(e) => return Err(e.into()),
     };
 
     let incoming_tx =
@@ -387,13 +384,11 @@ async fn rerelay_stem_tx(
         .build()
         .unwrap();
 
-    async {
-        dandelion_pool_manager
-            .ready()
-            .await?
-            .call(incoming_tx)
-            .await
-    }
-    .await
-    .map_err(|e| IncomingTxError::Fatal(e.into()))
+    dandelion_pool_manager
+        .ready()
+        .await?
+        .call(incoming_tx)
+        .await?;
+
+    Ok(())
 }

--- a/binaries/cuprated/src/txpool/incoming_tx.rs
+++ b/binaries/cuprated/src/txpool/incoming_tx.rs
@@ -143,7 +143,8 @@ impl IncomingTxHandler {
             txpool_config,
             launch_ctx.task_executor.clone(),
         )
-        .await?;
+        .await
+        .map_err(anyhow::Error::from_boxed)?;
 
         Ok(Self {
             txs_being_handled: TxsBeingHandled::new(),

--- a/binaries/cuprated/src/txpool/incoming_tx.rs
+++ b/binaries/cuprated/src/txpool/incoming_tx.rs
@@ -125,7 +125,7 @@ impl IncomingTxHandler {
             .task_executor
             .spawn_critical("dandelion pool manager", async move {
                 tokio::select! {
-                    result = &mut dandelion_pool_task => result.map_err(anyhow::Error::from),
+                    result = &mut dandelion_pool_task => result.map_err(Into::into),
                     () = shutdown.cancelled() => {
                         dandelion_pool_task.abort();
                         drop(dandelion_pool_task.await);
@@ -247,8 +247,7 @@ async fn handle_incoming_txs(
             .await
             .is_err()
         {
-            tracing::warn!("The txpool manager has been stopped, dropping incoming txs");
-            return Ok(());
+            return Err(IncomingTxError::ChannelClosed);
         }
     }
 
@@ -323,7 +322,7 @@ async fn prepare_incoming_txs(
         .expect("Txpool read service is always ready.")
         .call(TxpoolReadRequest::FilterKnownTxBlobHashes(tx_blob_hashes))
         .await
-        .map_err(|e| IncomingTxError::Internal(e.into()))?
+        .map_err(|e| IncomingTxError::Fatal(e.into()))?
     else {
         unreachable!()
     };
@@ -377,7 +376,7 @@ async fn rerelay_stem_tx(
             // The tx was dropped from the pool
             return Ok(());
         }
-        Err(TxPoolError::Fjall(e)) => return Err(IncomingTxError::Internal(e.into())),
+        Err(TxPoolError::Fjall(e)) => return Err(IncomingTxError::Fatal(e.into())),
     };
 
     let incoming_tx =
@@ -397,5 +396,5 @@ async fn rerelay_stem_tx(
             .await
     }
     .await
-    .map_err(|e| IncomingTxError::Internal(e.into()))
+    .map_err(|e| IncomingTxError::Fatal(e.into()))
 }

--- a/binaries/cuprated/src/txpool/incoming_tx.rs
+++ b/binaries/cuprated/src/txpool/incoming_tx.rs
@@ -44,7 +44,7 @@ use crate::{
         manager::{start_txpool_manager, TxpoolManagerCommand, TxpoolManagerHandle},
         relay_rules::check_tx_relay_rules,
         txs_being_handled::{TxsBeingHandled, TxsBeingHandledLocally},
-        IncomingTxError, TxValidationError,
+        IncomingTxError,
     },
     LaunchContext,
 };
@@ -231,7 +231,7 @@ async fn handle_incoming_txs(
                 continue;
             }
 
-            return Err(TxValidationError::RelayRule(e).into());
+            return Err(IncomingTxError::RelayRule(e));
         }
 
         tracing::debug!(
@@ -297,9 +297,7 @@ async fn prepare_incoming_txs(
             // If a duplicate is in here the incoming tx batch contained the same tx twice.
             if !tx_blob_hashes.insert(tx_blob_hash) {
                 tracing::debug!("peer sent duplicate tx in batch, ignoring batch.");
-                return Some(Err(IncomingTxError::Validation(
-                    TxValidationError::DuplicateTransaction,
-                )));
+                return Some(Err(IncomingTxError::DuplicateTransaction));
             }
 
             // If a duplicate is here it is being handled in another batch.

--- a/binaries/cuprated/src/txpool/manager.rs
+++ b/binaries/cuprated/src/txpool/manager.rs
@@ -430,7 +430,7 @@ impl TxpoolManager {
         &mut self,
         tx: TransactionVerificationData,
         state: TxState<CrossNetworkInternalPeerId>,
-    ) -> Result<(), TxPoolError> {
+    ) -> anyhow::Result<()> {
         tracing::debug!("handling new tx");
 
         let incoming_tx =
@@ -467,17 +467,11 @@ impl TxpoolManager {
             .build()
             .unwrap();
 
-        if let Err(e) = async {
-            self.dandelion_pool_manager
-                .ready()
-                .await?
-                .call(incoming_tx)
-                .await
-        }
-        .await
-        {
-            tracing::warn!("Dandelion pool manager failed for incoming tx: {e}");
-        }
+        self.dandelion_pool_manager
+            .ready()
+            .await?
+            .call(incoming_tx)
+            .await?;
 
         Ok(())
     }
@@ -564,7 +558,7 @@ impl TxpoolManager {
         mut command_rx: mpsc::Receiver<TxpoolManagerCommand>,
         mut block_rx: mpsc::Receiver<(Vec<[u8; 32]>, oneshot::Sender<()>)>,
         shutdown_token: CancellationToken,
-    ) -> Result<(), TxPoolError> {
+    ) -> anyhow::Result<()> {
         loop {
             tokio::select! {
                 biased;

--- a/binaries/cuprated/src/txpool/manager.rs
+++ b/binaries/cuprated/src/txpool/manager.rs
@@ -20,15 +20,19 @@ use cuprate_dandelion_tower::{
 };
 use cuprate_helper::time::current_unix_timestamp;
 use cuprate_p2p_core::ClearNet;
-use cuprate_txpool::service::{
-    interface::{TxpoolReadRequest, TxpoolReadResponse, TxpoolWriteRequest, TxpoolWriteResponse},
-    TxpoolReadHandle, TxpoolWriteHandle,
+use cuprate_txpool::{
+    service::{
+        interface::{
+            TxpoolReadRequest, TxpoolReadResponse, TxpoolWriteRequest, TxpoolWriteResponse,
+        },
+        TxpoolReadHandle, TxpoolWriteHandle,
+    },
+    TxPoolError,
 };
 use cuprate_types::TransactionVerificationData;
 
 use crate::{
     config::TxpoolConfig,
-    constants::PANIC_CRITICAL_SERVICE_ERROR,
     monitor::TaskExecutor,
     p2p::{CrossNetworkInternalPeerId, NetworkInterfaces},
     txpool::{
@@ -46,9 +50,9 @@ const MAX_RECENTLY_REMOVED_TXS: usize = 5000;
 
 /// Starts the transaction pool manager service.
 ///
-/// # Panics
+/// # Errors
 ///
-/// This function may panic if any inner service has an unrecoverable error.
+/// This function will return an [`Err`] if any inner service has an unrecoverable error.
 pub async fn start_txpool_manager(
     mut txpool_write_handle: TxpoolWriteHandle,
     mut txpool_read_handle: TxpoolReadHandle,
@@ -57,14 +61,12 @@ pub async fn start_txpool_manager(
     dandelion_pool_manager: DandelionPoolService<DandelionTx, TxId, CrossNetworkInternalPeerId>,
     config: TxpoolConfig,
     task_executor: TaskExecutor,
-) -> TxpoolManagerHandle {
+) -> anyhow::Result<TxpoolManagerHandle> {
     let TxpoolReadResponse::Backlog(backlog) = txpool_read_handle
         .ready()
-        .await
-        .expect(PANIC_CRITICAL_SERVICE_ERROR)
+        .await?
         .call(TxpoolReadRequest::Backlog)
-        .await
-        .expect(PANIC_CRITICAL_SERVICE_ERROR)
+        .await?
     else {
         unreachable!()
     };
@@ -121,19 +123,22 @@ pub async fn start_txpool_manager(
     tracing::info!(stem_txs = stem_txs.len(), "promoting stem txs");
 
     for tx in stem_txs {
-        manager.promote_tx(tx).await;
+        manager.promote_tx(tx).await?;
     }
 
     let (command_tx, command_rx) = mpsc::channel(INCOMING_TX_QUEUE_SIZE);
     let (spent_kis_tx, spent_kis_rx) = mpsc::channel(1);
 
     let shutdown_token = task_executor.cancellation_token();
-    task_executor.spawn(manager.run(command_rx, spent_kis_rx, shutdown_token));
+    task_executor.spawn_critical(
+        "txpool manager",
+        manager.run(command_rx, spent_kis_rx, shutdown_token),
+    );
 
-    TxpoolManagerHandle {
+    Ok(TxpoolManagerHandle {
         command_tx,
         spent_kis_tx,
-    }
+    })
 }
 
 /// Commands sent to the [`TxpoolManager`] via [`TxpoolManagerHandle`].
@@ -212,13 +217,15 @@ impl TxpoolManagerHandle {
     }
 
     /// Tell the tx-pool about spent key images in an incoming block.
-    pub async fn new_block(&mut self, spent_key_images: Vec<[u8; 32]>) -> anyhow::Result<()> {
+    pub async fn new_block(
+        &mut self,
+        spent_key_images: Vec<[u8; 32]>,
+    ) -> Result<(), tower::BoxError> {
         let (tx, rx) = oneshot::channel();
 
         drop(self.spent_kis_tx.send((spent_key_images, tx)).await);
 
-        rx.await
-            .map_err(|_| anyhow::anyhow!("txpool manager stopped"))
+        rx.await.map_err(|_| "txpool manager stopped".into())
     }
 }
 
@@ -284,8 +291,20 @@ impl TxpoolManager {
     ///
     /// This function will panic if the tx is not in the tx-pool manager.
     #[instrument(level = "debug", skip_all, fields(tx_id = hex::encode(tx)))]
-    async fn remove_tx_from_pool(&mut self, tx: [u8; 32], remove_from_db: bool) {
+    async fn remove_tx_from_pool(
+        &mut self,
+        tx: [u8; 32],
+        remove_from_db: bool,
+    ) -> Result<(), TxPoolError> {
         tracing::debug!("removing tx from pool");
+
+        if remove_from_db {
+            self.txpool_write_handle
+                .ready()
+                .await?
+                .call(TxpoolWriteRequest::RemoveTransaction(tx))
+                .await?;
+        }
 
         let tx_info = self.current_txs.swap_remove(&tx).unwrap();
 
@@ -307,15 +326,7 @@ impl TxpoolManager {
             }
         }
 
-        if remove_from_db {
-            self.txpool_write_handle
-                .ready()
-                .await
-                .expect(PANIC_CRITICAL_SERVICE_ERROR)
-                .call(TxpoolWriteRequest::RemoveTransaction(tx))
-                .await
-                .expect(PANIC_CRITICAL_SERVICE_ERROR);
-        }
+        Ok(())
     }
 
     /// Re-relay a tx to the network.
@@ -324,20 +335,15 @@ impl TxpoolManager {
     ///
     /// This function will panic if the tx is not in the tx-pool.
     #[instrument(level = "debug", skip_all, fields(tx_id = hex::encode(tx)))]
-    async fn rerelay_tx(&mut self, tx: [u8; 32]) {
+    async fn rerelay_tx(&mut self, tx: [u8; 32]) -> Result<(), TxPoolError> {
         tracing::debug!("re-relaying tx to network");
 
-        let TxpoolReadResponse::TxBlob {
-            tx_blob,
-            state_stem: _,
-        } = self
+        let TxpoolReadResponse::TxBlob { tx_blob, .. } = self
             .txpool_read_handle
             .ready()
-            .await
-            .expect(PANIC_CRITICAL_SERVICE_ERROR)
+            .await?
             .call(TxpoolReadRequest::TxBlob(tx))
-            .await
-            .expect(PANIC_CRITICAL_SERVICE_ERROR)
+            .await?
         else {
             unreachable!()
         };
@@ -345,16 +351,18 @@ impl TxpoolManager {
         self.diffuse_service
             .call(DiffuseRequest(DandelionTx(Bytes::from(tx_blob))))
             .await
-            .expect(PANIC_CRITICAL_SERVICE_ERROR);
+            .expect("Diffuse service should not return an error");
+
+        Ok(())
     }
 
     /// Handles a transaction timeout, be either rebroadcasting or dropping the tx from the pool.
     /// If a rebroadcast happens, this function will handle adding another timeout to the queue.
     #[instrument(level = "debug", skip_all, fields(tx_id = hex::encode(tx)))]
-    async fn handle_tx_timeout(&mut self, tx: [u8; 32]) {
+    async fn handle_tx_timeout(&mut self, tx: [u8; 32]) -> Result<(), TxPoolError> {
         let Some(tx_info) = self.current_txs.get(&tx) else {
             tracing::warn!("tx timed out, but tx not in pool");
-            return;
+            return Ok(());
         };
 
         let time_in_pool = current_unix_timestamp() - tx_info.received_at;
@@ -363,15 +371,15 @@ impl TxpoolManager {
         // slightly off.
         if time_in_pool + 10 > self.config.maximum_age_secs {
             tracing::warn!("tx has been in pool too long, removing from pool");
-            self.remove_tx_from_pool(tx, true).await;
-            return;
+            self.remove_tx_from_pool(tx, true).await?;
+            return Ok(());
         }
 
         let received_at = tx_info.received_at;
 
         tracing::debug!(time_in_pool, "tx timed out, resending to network");
 
-        self.rerelay_tx(tx).await;
+        self.rerelay_tx(tx).await?;
 
         let tx_info = self.current_txs.get_mut(&tx).unwrap();
 
@@ -382,6 +390,8 @@ impl TxpoolManager {
             self.tx_timeouts
                 .insert(tx, Duration::from_secs(next_timeout)),
         );
+
+        Ok(())
     }
 
     /// Adds a tx to the tx-pool manager.
@@ -420,7 +430,7 @@ impl TxpoolManager {
         &mut self,
         tx: TransactionVerificationData,
         state: TxState<CrossNetworkInternalPeerId>,
-    ) {
+    ) -> Result<(), TxPoolError> {
         tracing::debug!("handling new tx");
 
         let incoming_tx =
@@ -431,14 +441,12 @@ impl TxpoolManager {
         let TxpoolWriteResponse::AddTransaction(double_spend) = self
             .txpool_write_handle
             .ready()
-            .await
-            .expect(PANIC_CRITICAL_SERVICE_ERROR)
+            .await?
             .call(TxpoolWriteRequest::AddTransaction {
                 tx: Box::new(tx),
                 state_stem: state.is_stem_stage(),
             })
-            .await
-            .expect(PANIC_CRITICAL_SERVICE_ERROR)
+            .await?
         else {
             unreachable!()
         };
@@ -448,7 +456,7 @@ impl TxpoolManager {
                 double_spent = hex::encode(tx_hash),
                 "transaction is a double spend, ignoring"
             );
-            return;
+            return Ok(());
         }
 
         self.track_tx(tx_hash, tx_weight, tx_fee, state.is_stem_stage());
@@ -459,31 +467,43 @@ impl TxpoolManager {
             .build()
             .unwrap();
 
-        self.dandelion_pool_manager
-            .ready()
-            .await
-            .expect(PANIC_CRITICAL_SERVICE_ERROR)
-            .call(incoming_tx)
-            .await
-            .expect(PANIC_CRITICAL_SERVICE_ERROR);
+        if let Err(e) = async {
+            self.dandelion_pool_manager
+                .ready()
+                .await?
+                .call(incoming_tx)
+                .await
+        }
+        .await
+        {
+            tracing::warn!("Dandelion pool manager failed for incoming tx: {e}");
+        }
+
+        Ok(())
     }
 
     /// Promote a tx to the public pool.
     #[instrument(level = "debug", skip_all, fields(tx_id = hex::encode(tx)))]
-    async fn promote_tx(&mut self, tx: [u8; 32]) {
+    async fn promote_tx(&mut self, tx: [u8; 32]) -> Result<(), TxPoolError> {
         let Some(tx_info) = self.current_txs.get_mut(&tx) else {
             tracing::debug!("not promoting tx, tx not in pool");
-            return;
+            return Ok(());
         };
 
         if !tx_info.private {
             tracing::trace!("not promoting tx, tx is already public");
-            return;
+            return Ok(());
         }
-        tx_info.private = false;
 
         tracing::debug!("promoting tx");
 
+        self.txpool_write_handle
+            .ready()
+            .await?
+            .call(TxpoolWriteRequest::Promote(tx))
+            .await?;
+
+        tx_info.private = false;
         // It's now in the public pool, pretend we just saw it.
         tx_info.received_at = current_unix_timestamp();
         self.public_pool_timestamps
@@ -497,13 +517,7 @@ impl TxpoolManager {
                 .insert(tx, Duration::from_secs(next_timeout)),
         );
 
-        self.txpool_write_handle
-            .ready()
-            .await
-            .expect(PANIC_CRITICAL_SERVICE_ERROR)
-            .call(TxpoolWriteRequest::Promote(tx))
-            .await
-            .expect(PANIC_CRITICAL_SERVICE_ERROR);
+        Ok(())
     }
 
     /// Returns the hashes of all public-pool transactions that entered the public pool at or
@@ -526,33 +540,31 @@ impl TxpoolManager {
 
     /// Handles removing all transactions that have been included/double spent in an incoming block.
     #[instrument(level = "debug", skip_all)]
-    async fn new_block(&mut self, spent_key_images: Vec<[u8; 32]>) {
+    async fn new_block(&mut self, spent_key_images: Vec<[u8; 32]>) -> Result<(), TxPoolError> {
         tracing::debug!("handling new block");
 
         let TxpoolWriteResponse::NewBlock(removed_txs) = self
             .txpool_write_handle
             .ready()
-            .await
-            .expect(PANIC_CRITICAL_SERVICE_ERROR)
+            .await?
             .call(TxpoolWriteRequest::NewBlock { spent_key_images })
-            .await
-            .expect(PANIC_CRITICAL_SERVICE_ERROR)
+            .await?
         else {
             unreachable!()
         };
 
         for tx in removed_txs {
-            self.remove_tx_from_pool(tx, false).await;
+            self.remove_tx_from_pool(tx, false).await?;
         }
+        Ok(())
     }
 
-    #[expect(clippy::let_underscore_must_use)]
     async fn run(
         mut self,
         mut command_rx: mpsc::Receiver<TxpoolManagerCommand>,
         mut block_rx: mpsc::Receiver<(Vec<[u8; 32]>, oneshot::Sender<()>)>,
         shutdown_token: CancellationToken,
-    ) {
+    ) -> Result<(), TxPoolError> {
         loop {
             tokio::select! {
                 biased;
@@ -560,16 +572,16 @@ impl TxpoolManager {
                     break;
                 }
                 Some((spent_kis, tx)) = block_rx.recv() => {
-                    self.new_block(spent_kis).await;
+                    self.new_block(spent_kis).await?;
                     let _ = tx.send(());
                 }
                 Some(tx) = self.tx_timeouts.next() => {
-                    self.handle_tx_timeout(tx.into_inner()).await;
+                    self.handle_tx_timeout(tx.into_inner()).await?;
                 }
                 Some(command) = command_rx.recv() => {
                     match command {
                         TxpoolManagerCommand::IncomingTx(tx, state) => {
-                            self.handle_incoming_tx(tx, state).await;
+                            self.handle_incoming_tx(tx, state).await?;
                         }
                         TxpoolManagerCommand::PoolInfoSince { since, response_tx } => {
                             // If `since` is 0 the requester wants the full pool. If `since` is older than `removed_txs_start_time`,
@@ -595,12 +607,13 @@ impl TxpoolManager {
                     }
                 }
                 Some(tx) = self.promote_tx_channel.recv() => {
-                    self.promote_tx(tx).await;
+                    self.promote_tx(tx).await?;
                 }
             }
         }
 
         tracing::info!("Txpool manager shut down.");
+        Ok(())
     }
 }
 

--- a/binaries/cuprated/src/txpool/manager.rs
+++ b/binaries/cuprated/src/txpool/manager.rs
@@ -20,14 +20,9 @@ use cuprate_dandelion_tower::{
 };
 use cuprate_helper::time::current_unix_timestamp;
 use cuprate_p2p_core::ClearNet;
-use cuprate_txpool::{
-    service::{
-        interface::{
-            TxpoolReadRequest, TxpoolReadResponse, TxpoolWriteRequest, TxpoolWriteResponse,
-        },
-        TxpoolReadHandle, TxpoolWriteHandle,
-    },
-    TxPoolError,
+use cuprate_txpool::service::{
+    interface::{TxpoolReadRequest, TxpoolReadResponse, TxpoolWriteRequest, TxpoolWriteResponse},
+    TxpoolReadHandle, TxpoolWriteHandle,
 };
 use cuprate_types::TransactionVerificationData;
 
@@ -61,7 +56,7 @@ pub async fn start_txpool_manager(
     dandelion_pool_manager: DandelionPoolService<DandelionTx, TxId, CrossNetworkInternalPeerId>,
     config: TxpoolConfig,
     task_executor: TaskExecutor,
-) -> anyhow::Result<TxpoolManagerHandle> {
+) -> Result<TxpoolManagerHandle, FatalError> {
     let TxpoolReadResponse::Backlog(backlog) = txpool_read_handle
         .ready()
         .await?
@@ -292,7 +287,7 @@ impl TxpoolManager {
         &mut self,
         tx: [u8; 32],
         remove_from_db: bool,
-    ) -> Result<(), TxPoolError> {
+    ) -> Result<(), FatalError> {
         tracing::debug!("removing tx from pool");
 
         if remove_from_db {
@@ -332,7 +327,7 @@ impl TxpoolManager {
     ///
     /// This function will panic if the tx is not in the tx-pool.
     #[instrument(level = "debug", skip_all, fields(tx_id = hex::encode(tx)))]
-    async fn rerelay_tx(&mut self, tx: [u8; 32]) -> Result<(), TxPoolError> {
+    async fn rerelay_tx(&mut self, tx: [u8; 32]) -> Result<(), FatalError> {
         tracing::debug!("re-relaying tx to network");
 
         let TxpoolReadResponse::TxBlob { tx_blob, .. } = self
@@ -347,8 +342,7 @@ impl TxpoolManager {
 
         self.diffuse_service
             .call(DiffuseRequest(DandelionTx(Bytes::from(tx_blob))))
-            .await
-            .expect("Diffuse service should not return an error");
+            .await?;
 
         Ok(())
     }
@@ -356,7 +350,7 @@ impl TxpoolManager {
     /// Handles a transaction timeout, be either rebroadcasting or dropping the tx from the pool.
     /// If a rebroadcast happens, this function will handle adding another timeout to the queue.
     #[instrument(level = "debug", skip_all, fields(tx_id = hex::encode(tx)))]
-    async fn handle_tx_timeout(&mut self, tx: [u8; 32]) -> Result<(), TxPoolError> {
+    async fn handle_tx_timeout(&mut self, tx: [u8; 32]) -> Result<(), FatalError> {
         let Some(tx_info) = self.current_txs.get(&tx) else {
             tracing::warn!("tx timed out, but tx not in pool");
             return Ok(());
@@ -427,7 +421,7 @@ impl TxpoolManager {
         &mut self,
         tx: TransactionVerificationData,
         state: TxState<CrossNetworkInternalPeerId>,
-    ) -> anyhow::Result<()> {
+    ) -> Result<(), FatalError> {
         tracing::debug!("handling new tx");
 
         let incoming_tx =
@@ -475,7 +469,7 @@ impl TxpoolManager {
 
     /// Promote a tx to the public pool.
     #[instrument(level = "debug", skip_all, fields(tx_id = hex::encode(tx)))]
-    async fn promote_tx(&mut self, tx: [u8; 32]) -> Result<(), TxPoolError> {
+    async fn promote_tx(&mut self, tx: [u8; 32]) -> Result<(), FatalError> {
         let Some(tx_info) = self.current_txs.get_mut(&tx) else {
             tracing::debug!("not promoting tx, tx not in pool");
             return Ok(());
@@ -531,7 +525,7 @@ impl TxpoolManager {
 
     /// Handles removing all transactions that have been included/double spent in an incoming block.
     #[instrument(level = "debug", skip_all)]
-    async fn new_block(&mut self, spent_key_images: Vec<[u8; 32]>) -> Result<(), TxPoolError> {
+    async fn new_block(&mut self, spent_key_images: Vec<[u8; 32]>) -> Result<(), FatalError> {
         tracing::debug!("handling new block");
 
         let TxpoolWriteResponse::NewBlock(removed_txs) = self

--- a/binaries/cuprated/src/txpool/manager.rs
+++ b/binaries/cuprated/src/txpool/manager.rs
@@ -33,7 +33,7 @@ use cuprate_types::TransactionVerificationData;
 
 use crate::{
     config::TxpoolConfig,
-    monitor::TaskExecutor,
+    monitor::{FatalError, TaskExecutor},
     p2p::{CrossNetworkInternalPeerId, NetworkInterfaces},
     txpool::{
         dandelion::DiffuseService,
@@ -217,10 +217,7 @@ impl TxpoolManagerHandle {
     }
 
     /// Tell the tx-pool about spent key images in an incoming block.
-    pub async fn new_block(
-        &mut self,
-        spent_key_images: Vec<[u8; 32]>,
-    ) -> Result<(), tower::BoxError> {
+    pub async fn new_block(&mut self, spent_key_images: Vec<[u8; 32]>) -> Result<(), FatalError> {
         let (tx, rx) = oneshot::channel();
 
         drop(self.spent_kis_tx.send((spent_key_images, tx)).await);
@@ -558,7 +555,7 @@ impl TxpoolManager {
         mut command_rx: mpsc::Receiver<TxpoolManagerCommand>,
         mut block_rx: mpsc::Receiver<(Vec<[u8; 32]>, oneshot::Sender<()>)>,
         shutdown_token: CancellationToken,
-    ) -> anyhow::Result<()> {
+    ) -> Result<(), FatalError> {
         loop {
             tokio::select! {
                 biased;

--- a/consensus/context/Cargo.toml
+++ b/consensus/context/Cargo.toml
@@ -16,7 +16,6 @@ tokio = { workspace = true, features = ["rt-multi-thread", "macros"]}
 tokio-util = { workspace = true }
 tower = { workspace = true, features = ["util"] }
 tracing = { workspace = true, features = ["std", "attributes"] }
-thiserror = { workspace = true }
 
 monero-oxide = { workspace = true, features = ["std"] }
 randomx-rs = { workspace = true }

--- a/consensus/context/src/alt_chains.rs
+++ b/consensus/context/src/alt_chains.rs
@@ -2,7 +2,6 @@ use std::{collections::HashMap, sync::Arc};
 
 use tower::ServiceExt;
 
-use cuprate_consensus_rules::{blocks::BlockError, ConsensusError};
 use cuprate_types::{
     blockchain::{BlockchainReadRequest, BlockchainResponse},
     Chain, ChainId,
@@ -88,15 +87,17 @@ impl AltChainMap {
         self.alt_cache_map.insert(alt_cache.top_hash, alt_cache);
     }
 
-    /// Attempts to take an [`AltChainContextCache`] from the map, returning [`None`] if no cache is
-    /// present.
+    /// Attempts to take an [`AltChainContextCache`] from the map, building it from the database if no
+    /// cache is present.
+    ///
+    /// Returns [`None`] if `prev_id` is not a block we know about.
     pub(crate) async fn get_alt_chain_context<D: Database>(
         &mut self,
         prev_id: [u8; 32],
         database: D,
-    ) -> Result<Box<AltChainContextCache>, ContextCacheError> {
+    ) -> Result<Option<Box<AltChainContextCache>>, ContextCacheError> {
         if let Some(cache) = self.alt_cache_map.remove(&prev_id) {
-            return Ok(cache);
+            return Ok(Some(cache));
         }
 
         // find the block with hash == prev_id.
@@ -109,10 +110,10 @@ impl AltChainMap {
 
         let Some((parent_chain, top_height)) = res else {
             // Couldn't find prev_id
-            return Err(ConsensusError::Block(BlockError::PreviousIDIncorrect).into());
+            return Ok(None);
         };
 
-        Ok(Box::new(AltChainContextCache {
+        Ok(Some(Box::new(AltChainContextCache {
             weight_cache: None,
             difficulty_cache: None,
             cached_rx_vm: None,
@@ -120,7 +121,7 @@ impl AltChainMap {
             top_hash: prev_id,
             chain_id: None,
             parent_chain,
-        }))
+        })))
     }
 }
 
@@ -129,7 +130,7 @@ pub(crate) async fn get_alt_chain_difficulty_cache<D: Database + Clone>(
     prev_id: [u8; 32],
     main_chain_difficulty_cache: &DifficultyCache,
     mut database: D,
-) -> Result<DifficultyCache, ContextCacheError> {
+) -> Result<Option<DifficultyCache>, ContextCacheError> {
     // find the block with hash == prev_id.
     let BlockchainResponse::FindBlock(res) = database
         .ready()
@@ -142,10 +143,10 @@ pub(crate) async fn get_alt_chain_difficulty_cache<D: Database + Clone>(
 
     let Some((chain, top_height)) = res else {
         // Can't find prev_id
-        return Err(ConsensusError::Block(BlockError::PreviousIDIncorrect).into());
+        return Ok(None);
     };
 
-    Ok(match chain {
+    Ok(Some(match chain {
         Chain::Main => {
             // prev_id is in main chain, we can use the fast path and clone the main chain cache.
             let mut difficulty_cache = main_chain_difficulty_cache.clone();
@@ -168,7 +169,7 @@ pub(crate) async fn get_alt_chain_difficulty_cache<D: Database + Clone>(
             )
             .await?
         }
-    })
+    }))
 }
 
 /// Builds a [`BlockWeightsCache`] for an alt chain.
@@ -176,7 +177,7 @@ pub(crate) async fn get_alt_chain_weight_cache<D: Database + Clone>(
     prev_id: [u8; 32],
     main_chain_weight_cache: &BlockWeightsCache,
     mut database: D,
-) -> Result<BlockWeightsCache, ContextCacheError> {
+) -> Result<Option<BlockWeightsCache>, ContextCacheError> {
     // find the block with hash == prev_id.
     let BlockchainResponse::FindBlock(res) = database
         .ready()
@@ -189,10 +190,10 @@ pub(crate) async fn get_alt_chain_weight_cache<D: Database + Clone>(
 
     let Some((chain, top_height)) = res else {
         // Can't find prev_id
-        return Err(ConsensusError::Block(BlockError::PreviousIDIncorrect).into());
+        return Ok(None);
     };
 
-    Ok(match chain {
+    Ok(Some(match chain {
         Chain::Main => {
             // prev_id is in main chain, we can use the fast path and clone the main chain cache.
             let mut weight_cache = main_chain_weight_cache.clone();
@@ -212,5 +213,5 @@ pub(crate) async fn get_alt_chain_weight_cache<D: Database + Clone>(
             )
             .await?
         }
-    })
+    }))
 }

--- a/consensus/context/src/lib.rs
+++ b/consensus/context/src/lib.rs
@@ -27,7 +27,7 @@ use tower::Service;
 
 use cuprate_consensus_rules::{
     blocks::{ContextToVerifyBlock, PENALTY_FREE_ZONE_5},
-    current_unix_timestamp, ConsensusError, HardFork,
+    current_unix_timestamp, HardFork,
 };
 
 pub mod difficulty;
@@ -383,16 +383,22 @@ pub enum BlockChainContextResponse {
     AltChains(Vec<ChainInfo>),
 
     /// An alt chain context cache.
-    AltChainContextCache(Box<AltChainContextCache>),
+    ///
+    /// [`None`] if the requested `prev_id` is unknown.
+    AltChainContextCache(Option<Box<AltChainContextCache>>),
 
     /// A difficulty cache for an alt chain.
-    AltChainDifficultyCache(DifficultyCache),
+    ///
+    /// [`None`] if the requested `prev_id` is unknown.
+    AltChainDifficultyCache(Option<DifficultyCache>),
 
     /// A randomX VM for an alt chain.
     AltChainRxVM(Arc<RandomXVm>),
 
-    /// A weight cache for an alt chain
-    AltChainWeightCache(BlockWeightsCache),
+    /// A weight cache for an alt chain.
+    ///
+    /// [`None`] if the requested `prev_id` is unknown.
+    AltChainWeightCache(Option<BlockWeightsCache>),
 }
 
 /// The blockchain context service.
@@ -446,15 +452,7 @@ impl Service<BlockChainContextRequest> for BlockchainContextService {
     }
 }
 
-#[derive(Debug, thiserror::Error)]
-pub enum ContextCacheError {
-    /// A consensus error.
-    #[error("{0}")]
-    ConErr(#[from] ConsensusError),
-    /// A database error.
-    #[error("Database error: {0}")]
-    DBErr(#[from] tower::BoxError),
-}
+pub type ContextCacheError = tower::BoxError;
 
 use __private::Database;
 

--- a/consensus/rules/src/blocks.rs
+++ b/consensus/rules/src/blocks.rs
@@ -38,6 +38,12 @@ pub enum BlockError {
     TimeStampInvalid,
     #[error("The block contains a duplicate transaction.")]
     DuplicateTransaction,
+    #[error("The transactions passed in with the block are incorrect.")]
+    TxsIncludedWithBlockIncorrect,
+    #[error("Block batch verification failed.")]
+    BatchVerificationFailed,
+    #[error("No blocks to verify.")]
+    NoBlocksToVerify,
     #[error("Hard-fork error: {0}")]
     HardForkError(#[from] HardForkError),
     #[error("Miner transaction error: {0}")]

--- a/consensus/rules/src/transactions.rs
+++ b/consensus/rules/src/transactions.rs
@@ -76,6 +76,8 @@ pub enum TransactionError {
     //-------------------------------------------------------- RingCT
     #[error("RingCT Error: {0}.")]
     RingCTError(#[from] RingCTError),
+    #[error("Transaction batch verification failed.")]
+    BatchVerificationFailed,
 }
 
 //----------------------------------------------------------------------------------------------------------- OUTPUTS

--- a/consensus/src/block.rs
+++ b/consensus/src/block.rs
@@ -69,6 +69,14 @@ impl BlockVerificationError {
             inner: inner.into(),
         }
     }
+
+    /// Create a fatal error from a service failure.
+    pub fn fatal(inner: tower::BoxError) -> Self {
+        Self {
+            pow_valid: false,
+            inner: ExtendedConsensusError::FatalError(inner),
+        }
+    }
 }
 
 impl From<BlockVerificationError> for ExtendedConsensusError {
@@ -257,10 +265,10 @@ where
         let BlockChainContextResponse::RxVms(rx_vms) = context_svc
             .ready()
             .await
-            .map_err(BlockVerificationError::invalid_pow)?
+            .map_err(BlockVerificationError::fatal)?
             .call(BlockChainContextRequest::CurrentRxVms)
             .await
-            .map_err(BlockVerificationError::invalid_pow)?
+            .map_err(BlockVerificationError::fatal)?
         else {
             panic!("Blockchain context service returned wrong response!");
         };

--- a/consensus/src/block.rs
+++ b/consensus/src/block.rs
@@ -265,13 +265,15 @@ where
         .map_err(ConsensusError::Block)?;
 
     if prepped_block.block.transactions.len() != txs.len() {
-        return Err(ExtendedConsensusError::TxsIncludedWithBlockIncorrect);
+        return Err(ConsensusError::Block(BlockError::TxsIncludedWithBlockIncorrect).into());
     }
 
     if !prepped_block.block.transactions.is_empty() {
         for (expected_tx_hash, tx) in prepped_block.block.transactions.iter().zip(txs.iter()) {
             if expected_tx_hash != &tx.tx_hash {
-                return Err(ExtendedConsensusError::TxsIncludedWithBlockIncorrect);
+                return Err(
+                    ConsensusError::Block(BlockError::TxsIncludedWithBlockIncorrect).into(),
+                );
             }
         }
 

--- a/consensus/src/block.rs
+++ b/consensus/src/block.rs
@@ -39,6 +39,44 @@ pub use alt_block::sanity_check_alt_block;
 pub use batch_prepare::{batch_prepare_main_chain_blocks, BatchPrepareCache};
 use free::pull_ordered_transactions;
 
+/// An error encountered while verifying a block.
+///
+/// [`Self::pow_valid`] records whether the block's proof-of-work was successfully verified before
+/// the error occurred.
+#[derive(Debug, thiserror::Error)]
+#[error("{inner}")]
+pub struct BlockVerificationError {
+    /// Whether the block's proof-of-work was successfully verified.
+    pub pow_valid: bool,
+    /// The underlying error.
+    #[source]
+    pub inner: ExtendedConsensusError,
+}
+
+impl BlockVerificationError {
+    /// Create an error that occurred after the block's proof-of-work was verified.
+    pub fn valid_pow(inner: impl Into<ExtendedConsensusError>) -> Self {
+        Self {
+            pow_valid: true,
+            inner: inner.into(),
+        }
+    }
+
+    /// Create an error that occurred before the block's proof-of-work was verified.
+    pub fn invalid_pow(inner: impl Into<ExtendedConsensusError>) -> Self {
+        Self {
+            pow_valid: false,
+            inner: inner.into(),
+        }
+    }
+}
+
+impl From<BlockVerificationError> for ExtendedConsensusError {
+    fn from(inner: BlockVerificationError) -> Self {
+        inner.inner
+    }
+}
+
 /// A pre-prepared block with all data needed to verify it, except the block's proof of work.
 #[derive(Debug)]
 pub struct PreparedBlockExPow {
@@ -198,7 +236,7 @@ pub async fn verify_main_chain_block<D>(
     txs: HashMap<[u8; 32], TransactionVerificationData>,
     context_svc: &mut BlockchainContextService,
     database: D,
-) -> Result<VerifiedBlockInformation, ExtendedConsensusError>
+) -> Result<VerifiedBlockInformation, BlockVerificationError>
 where
     D: Database + Clone + Send + 'static,
 {
@@ -218,9 +256,11 @@ where
     } else {
         let BlockChainContextResponse::RxVms(rx_vms) = context_svc
             .ready()
-            .await?
+            .await
+            .map_err(BlockVerificationError::invalid_pow)?
             .call(BlockChainContextRequest::CurrentRxVms)
-            .await?
+            .await
+            .map_err(BlockVerificationError::invalid_pow)?
         else {
             panic!("Blockchain context service returned wrong response!");
         };
@@ -235,13 +275,16 @@ where
             rx_vms.get(&randomx_seed_height(height)).map(AsRef::as_ref),
         )
     })
-    .await?;
+    .await
+    .map_err(BlockVerificationError::invalid_pow)?;
 
     check_block_pow(&prepped_block.pow_hash, context.next_difficulty)
-        .map_err(ConsensusError::Block)?;
+        .map_err(ConsensusError::Block)
+        .map_err(BlockVerificationError::invalid_pow)?;
 
     // Check that the txs included are what we need and that there are not any extra.
-    let ordered_txs = pull_ordered_transactions(&prepped_block.block, txs)?;
+    let ordered_txs = pull_ordered_transactions(&prepped_block.block, txs)
+        .map_err(BlockVerificationError::valid_pow)?;
 
     verify_prepped_main_chain_block(prepped_block, ordered_txs, context_svc, database, None).await
 }
@@ -253,7 +296,7 @@ pub async fn verify_prepped_main_chain_block<D>(
     context_svc: &mut BlockchainContextService,
     database: D,
     batch_prep_cache: Option<&mut BatchPrepareCache>,
-) -> Result<VerifiedBlockInformation, ExtendedConsensusError>
+) -> Result<VerifiedBlockInformation, BlockVerificationError>
 where
     D: Database + Clone + Send + 'static,
 {
@@ -262,24 +305,28 @@ where
     tracing::debug!("verifying block: {}", hex::encode(prepped_block.block_hash));
 
     check_block_pow(&prepped_block.pow_hash, context.next_difficulty)
-        .map_err(ConsensusError::Block)?;
+        .map_err(ConsensusError::Block)
+        .map_err(BlockVerificationError::invalid_pow)?;
 
     if prepped_block.block.transactions.len() != txs.len() {
-        return Err(ConsensusError::Block(BlockError::TxsIncludedWithBlockIncorrect).into());
+        return Err(BlockVerificationError::valid_pow(ConsensusError::Block(
+            BlockError::TxsIncludedWithBlockIncorrect,
+        )));
     }
 
     if !prepped_block.block.transactions.is_empty() {
         for (expected_tx_hash, tx) in prepped_block.block.transactions.iter().zip(txs.iter()) {
             if expected_tx_hash != &tx.tx_hash {
-                return Err(
-                    ConsensusError::Block(BlockError::TxsIncludedWithBlockIncorrect).into(),
-                );
+                return Err(BlockVerificationError::valid_pow(ConsensusError::Block(
+                    BlockError::TxsIncludedWithBlockIncorrect,
+                )));
             }
         }
 
         let temp = start_tx_verification()
             .append_prepped_txs(mem::take(&mut txs))
-            .prepare()?
+            .prepare()
+            .map_err(BlockVerificationError::valid_pow)?
             .full(
                 context.chain_height,
                 context.top_hash,
@@ -289,7 +336,8 @@ where
                 batch_prep_cache.as_deref(),
             )
             .verify()
-            .await?;
+            .await
+            .map_err(BlockVerificationError::valid_pow)?;
 
         txs = temp;
     }
@@ -306,7 +354,8 @@ where
         prepped_block.block_blob.len(),
         &context.context_to_verify_block,
     )
-    .map_err(ConsensusError::Block)?;
+    .map_err(ConsensusError::Block)
+    .map_err(BlockVerificationError::valid_pow)?;
 
     let block = VerifiedBlockInformation {
         block_hash: prepped_block.block_hash,

--- a/consensus/src/block/alt_block.rs
+++ b/consensus/src/block/alt_block.rs
@@ -54,13 +54,13 @@ where
     let BlockChainContextResponse::AltChainContextCache(alt_context_cache) = context_svc
         .ready()
         .await
-        .map_err(BlockVerificationError::invalid_pow)?
+        .map_err(BlockVerificationError::fatal)?
         .call(BlockChainContextRequest::AltChainContextCache {
             prev_id: block.header.previous,
             _token: AltChainRequestToken,
         })
         .await
-        .map_err(BlockVerificationError::invalid_pow)?
+        .map_err(BlockVerificationError::fatal)?
     else {
         panic!("Context service returned wrong response!");
     };
@@ -209,7 +209,7 @@ where
             _token: AltChainRequestToken,
         })
         .await
-        .map_err(BlockVerificationError::valid_pow)?;
+        .map_err(BlockVerificationError::fatal)?;
 
     Ok(block_info)
 }

--- a/consensus/src/block/alt_block.rs
+++ b/consensus/src/block/alt_block.rs
@@ -27,7 +27,7 @@ use cuprate_types::{
 };
 
 use crate::{
-    block::{free::pull_ordered_transactions, PreparedBlock},
+    block::{free::pull_ordered_transactions, BlockVerificationError, PreparedBlock},
     BlockChainContextRequest, BlockChainContextResponse, ExtendedConsensusError,
 };
 
@@ -40,7 +40,7 @@ pub async fn sanity_check_alt_block<C>(
     block: Block,
     txs: HashMap<[u8; 32], TransactionVerificationData>,
     mut context_svc: C,
-) -> Result<AltBlockInformation, ExtendedConsensusError>
+) -> Result<AltBlockInformation, BlockVerificationError>
 where
     C: Service<
             BlockChainContextRequest,
@@ -53,33 +53,35 @@ where
     // Fetch the alt-chains context cache.
     let BlockChainContextResponse::AltChainContextCache(alt_context_cache) = context_svc
         .ready()
-        .await?
+        .await
+        .map_err(BlockVerificationError::invalid_pow)?
         .call(BlockChainContextRequest::AltChainContextCache {
             prev_id: block.header.previous,
             _token: AltChainRequestToken,
         })
-        .await?
+        .await
+        .map_err(BlockVerificationError::invalid_pow)?
     else {
         panic!("Context service returned wrong response!");
     };
 
     let Some(mut alt_context_cache) = alt_context_cache else {
-        return Err(ConsensusError::Block(BlockError::PreviousIDIncorrect).into());
+        return Err(BlockVerificationError::invalid_pow(ConsensusError::Block(
+            BlockError::PreviousIDIncorrect,
+        )));
     };
 
     // Check if the block's miner input is formed correctly.
     let [Input::Gen(height)] = &block.miner_transaction().prefix().inputs[..] else {
-        return Err(ConsensusError::Block(BlockError::MinerTxError(
-            MinerTxError::InputNotOfTypeGen,
-        ))
-        .into());
+        return Err(BlockVerificationError::invalid_pow(ConsensusError::Block(
+            BlockError::MinerTxError(MinerTxError::InputNotOfTypeGen),
+        )));
     };
 
     if *height != alt_context_cache.chain_height {
-        return Err(ConsensusError::Block(BlockError::MinerTxError(
-            MinerTxError::InputsHeightIncorrect,
-        ))
-        .into());
+        return Err(BlockVerificationError::invalid_pow(ConsensusError::Block(
+            BlockError::MinerTxError(MinerTxError::InputsHeightIncorrect),
+        )));
     }
 
     // prep the alt block.
@@ -91,9 +93,12 @@ where
             &mut alt_context_cache,
             &mut context_svc,
         )
-        .await?;
+        .await
+        .map_err(BlockVerificationError::invalid_pow)?;
 
-        rayon_spawn_async(move || PreparedBlock::new(block, rx_vm.as_deref())).await?
+        rayon_spawn_async(move || PreparedBlock::new(block, rx_vm.as_deref()))
+            .await
+            .map_err(BlockVerificationError::invalid_pow)?
     };
 
     // get the difficulty cache for this alt chain.
@@ -102,22 +107,30 @@ where
         &mut alt_context_cache,
         &mut context_svc,
     )
-    .await?;
+    .await
+    .map_err(BlockVerificationError::invalid_pow)?;
 
     // Check the alt block timestamp is in the correct range.
     //
     // Unlike monerod we also check the future time limit.
     let median_timestamp =
         difficulty_cache.median_timestamp(u64_to_usize(BLOCKCHAIN_TIMESTAMP_CHECK_WINDOW));
-    check_timestamp(&prepped_block.block, median_timestamp).map_err(ConsensusError::Block)?;
+    check_timestamp(&prepped_block.block, median_timestamp)
+        .map_err(ConsensusError::Block)
+        .map_err(BlockVerificationError::invalid_pow)?;
 
     let next_difficulty = difficulty_cache.next_difficulty(prepped_block.hf_version);
     // make sure the block's PoW is valid for this difficulty.
-    check_block_pow(&prepped_block.pow_hash, next_difficulty).map_err(ConsensusError::Block)?;
+    check_block_pow(&prepped_block.pow_hash, next_difficulty)
+        .map_err(ConsensusError::Block)
+        .map_err(BlockVerificationError::invalid_pow)?;
+
+    // TODO: weight check before PoW check?
 
     let cumulative_difficulty = difficulty_cache.cumulative_difficulty() + next_difficulty;
 
-    let ordered_txs = pull_ordered_transactions(&prepped_block.block, txs)?;
+    let ordered_txs = pull_ordered_transactions(&prepped_block.block, txs)
+        .map_err(BlockVerificationError::valid_pow)?;
 
     let block_weight =
         prepped_block.miner_tx_weight + ordered_txs.iter().map(|tx| tx.tx_weight).sum::<usize>();
@@ -127,14 +140,16 @@ where
         &mut alt_context_cache,
         &mut context_svc,
     )
-    .await?;
+    .await
+    .map_err(BlockVerificationError::valid_pow)?;
 
     // Check the block weight is below the limit.
     check_block_weight(
         block_weight,
         alt_weight_cache.median_for_block_reward(prepped_block.hf_version),
     )
-    .map_err(ConsensusError::Block)?;
+    .map_err(ConsensusError::Block)
+    .map_err(BlockVerificationError::valid_pow)?;
 
     let long_term_weight = weight::calculate_block_long_term_weight(
         prepped_block.hf_version,
@@ -193,7 +208,8 @@ where
             cache: alt_context_cache,
             _token: AltChainRequestToken,
         })
-        .await?;
+        .await
+        .map_err(BlockVerificationError::valid_pow)?;
 
     Ok(block_info)
 }

--- a/consensus/src/block/alt_block.rs
+++ b/consensus/src/block/alt_block.rs
@@ -51,7 +51,7 @@ where
     C::Future: Send + 'static,
 {
     // Fetch the alt-chains context cache.
-    let BlockChainContextResponse::AltChainContextCache(mut alt_context_cache) = context_svc
+    let BlockChainContextResponse::AltChainContextCache(alt_context_cache) = context_svc
         .ready()
         .await?
         .call(BlockChainContextRequest::AltChainContextCache {
@@ -61,6 +61,10 @@ where
         .await?
     else {
         panic!("Context service returned wrong response!");
+    };
+
+    let Some(mut alt_context_cache) = alt_context_cache else {
+        return Err(ConsensusError::Block(BlockError::PreviousIDIncorrect).into());
     };
 
     // Check if the block's miner input is formed correctly.
@@ -274,6 +278,10 @@ where
                 panic!("Context service returned wrong response!");
             };
 
+            let Some(cache) = cache else {
+                return Err(ConsensusError::Block(BlockError::PreviousIDIncorrect).into());
+            };
+
             Ok(difficulty_cache.insert(cache))
         }
     }
@@ -306,6 +314,10 @@ where
                 .await?
             else {
                 panic!("Context service returned wrong response!");
+            };
+
+            let Some(cache) = cache else {
+                return Err(ConsensusError::Block(BlockError::PreviousIDIncorrect).into());
             };
 
             Ok(weight_cache.insert(cache))

--- a/consensus/src/block/batch_prepare.rs
+++ b/consensus/src/block/batch_prepare.rs
@@ -60,7 +60,7 @@ pub async fn batch_prepare_main_chain_blocks<D: Database>(
     .await?;
 
     let Some(last_block) = blocks.last() else {
-        return Err(ExtendedConsensusError::NoBlocksToVerify);
+        return Err(ConsensusError::Block(BlockError::NoBlocksToVerify).into());
     };
 
     // hard-forks cannot be reversed, so the last block will contain the highest hard fork (provided the
@@ -199,10 +199,10 @@ pub async fn batch_prepare_main_chain_blocks<D: Database>(
 
                 Ok((block, txs))
             })
-            .collect::<Result<Vec<_>, ExtendedConsensusError>>()?;
+            .collect::<Result<Vec<_>, ConsensusError>>()?;
 
         if !batch_verifier.verify() {
-            return Err(ExtendedConsensusError::OneOrMoreBatchVerificationStatementsInvalid);
+            return Err(ConsensusError::Block(BlockError::BatchVerificationFailed));
         }
 
         Ok(res)

--- a/consensus/src/block/free.rs
+++ b/consensus/src/block/free.rs
@@ -3,17 +3,18 @@ use std::collections::HashMap;
 
 use monero_oxide::block::Block;
 
+use cuprate_consensus_rules::{blocks::BlockError, ConsensusError};
 use cuprate_types::TransactionVerificationData;
-
-use crate::ExtendedConsensusError;
 
 /// Orders the [`TransactionVerificationData`] list the same as it appears in [`Block::transactions`]
 pub(crate) fn order_transactions(
     block: &Block,
     txs: &mut [TransactionVerificationData],
-) -> Result<(), ExtendedConsensusError> {
+) -> Result<(), ConsensusError> {
     if block.transactions.len() != txs.len() {
-        return Err(ExtendedConsensusError::TxsIncludedWithBlockIncorrect);
+        return Err(ConsensusError::Block(
+            BlockError::TxsIncludedWithBlockIncorrect,
+        ));
     }
 
     for (i, tx_hash) in block.transactions.iter().enumerate() {
@@ -21,7 +22,9 @@ pub(crate) fn order_transactions(
             let at_index = txs[i..]
                 .iter()
                 .position(|tx| &tx.tx_hash == tx_hash)
-                .ok_or(ExtendedConsensusError::TxsIncludedWithBlockIncorrect)?;
+                .ok_or(ConsensusError::Block(
+                    BlockError::TxsIncludedWithBlockIncorrect,
+                ))?;
 
             // The above `position` will give an index from inside its view of the slice so we need to add the difference.
             txs.swap(i, i + at_index);
@@ -43,18 +46,20 @@ pub(crate) fn order_transactions(
 pub(crate) fn pull_ordered_transactions(
     block: &Block,
     mut txs: HashMap<[u8; 32], TransactionVerificationData>,
-) -> Result<Vec<TransactionVerificationData>, ExtendedConsensusError> {
+) -> Result<Vec<TransactionVerificationData>, ConsensusError> {
     if block.transactions.len() != txs.len() {
-        return Err(ExtendedConsensusError::TxsIncludedWithBlockIncorrect);
+        return Err(ConsensusError::Block(
+            BlockError::TxsIncludedWithBlockIncorrect,
+        ));
     }
 
     let mut ordered_txs = Vec::with_capacity(txs.len());
 
     if !block.transactions.is_empty() {
         for tx_hash in &block.transactions {
-            let tx = txs
-                .remove(tx_hash)
-                .ok_or(ExtendedConsensusError::TxsIncludedWithBlockIncorrect)?;
+            let tx = txs.remove(tx_hash).ok_or(ConsensusError::Block(
+                BlockError::TxsIncludedWithBlockIncorrect,
+            ))?;
             ordered_txs.push(tx);
         }
         drop(txs);

--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -45,7 +45,7 @@ pub enum ExtendedConsensusError {
     ConsensusError(#[from] ConsensusError),
     /// A service error that we cannot recover from.
     ///
-    /// If this happens, no more consensus verifiction should be done with the given inner services.
+    /// If this happens, no more consensus verification should be done with the given inner services.
     #[error("Fatal error: {0}")]
     FatalError(#[from] tower::BoxError),
 }

--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -39,7 +39,6 @@ pub use cuprate_types::{
 
 /// An Error returned from one of the consensus services.
 #[derive(Debug, thiserror::Error)]
-#[expect(variant_size_differences)]
 pub enum ExtendedConsensusError {
     /// A consensus error.
     #[error("{0}")]
@@ -47,15 +46,6 @@ pub enum ExtendedConsensusError {
     /// A database error.
     #[error("Database error: {0}")]
     DBErr(#[from] tower::BoxError),
-    /// The transactions passed in with this block were not the ones needed.
-    #[error("The transactions passed in with the block are incorrect.")]
-    TxsIncludedWithBlockIncorrect,
-    /// One or more statements in the batch verifier was invalid.
-    #[error("One or more statements in the batch verifier was invalid.")]
-    OneOrMoreBatchVerificationStatementsInvalid,
-    /// A request to verify a batch of blocks had no blocks in the batch.
-    #[error("A request to verify a batch of blocks had no blocks in the batch.")]
-    NoBlocksToVerify,
 }
 
 use __private::Database;

--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -42,10 +42,12 @@ pub use cuprate_types::{
 pub enum ExtendedConsensusError {
     /// A consensus error.
     #[error("{0}")]
-    ConErr(#[from] ConsensusError),
-    /// A database error.
-    #[error("Database error: {0}")]
-    DBErr(#[from] tower::BoxError),
+    ConsensusError(#[from] ConsensusError),
+    /// A service error that we cannot recover from.
+    ///
+    /// If this happens, no more consensus verifiction should be done with the given inner services.
+    #[error("Fatal error: {0}")]
+    FatalError(#[from] tower::BoxError),
 }
 
 use __private::Database;

--- a/consensus/src/tests/context/difficulty.rs
+++ b/consensus/src/tests/context/difficulty.rs
@@ -235,7 +235,7 @@ proptest! {
                 new_cache.new_block(new_cache.last_accounted_height+1, timestamp, cumulative_difficulty);
             }
 
-            new_cache.pop_blocks_main_chain(blocks_to_pop, database).await?;
+            new_cache.pop_blocks_main_chain(blocks_to_pop, database).await.unwrap();
 
             prop_assert_eq!(new_cache, old_cache);
 
@@ -259,7 +259,7 @@ proptest! {
                 new_cache.new_block(new_cache.last_accounted_height+1, timestamp, cumulative_difficulty);
             }
 
-            new_cache.pop_blocks_main_chain(blocks_to_pop, database).await?;
+            new_cache.pop_blocks_main_chain(blocks_to_pop, database).await.unwrap();
 
             prop_assert_eq!(new_cache, old_cache);
 

--- a/consensus/src/tests/context/hardforks.rs
+++ b/consensus/src/tests/context/hardforks.rs
@@ -107,7 +107,8 @@ proptest! {
                 TEST_HARD_FORK_CONFIG,
                 db.clone(),
             )
-            .await?;
+            .await
+            .unwrap();
 
             let state_clone = state.clone();
 
@@ -115,7 +116,7 @@ proptest! {
                 state.new_block(hf, state.last_height + i + 1);
             }
 
-            state.pop_blocks_main_chain(numb_pop_blocks, db).await?;
+            state.pop_blocks_main_chain(numb_pop_blocks, db).await.unwrap();
 
             prop_assert_eq!(state_clone, state);
 

--- a/consensus/src/transactions.rs
+++ b/consensus/src/transactions.rs
@@ -533,7 +533,9 @@ where
             })?;
 
         if !batch_verifier.verify() {
-            return Err(ExtendedConsensusError::OneOrMoreBatchVerificationStatementsInvalid);
+            return Err(
+                ConsensusError::Transaction(TransactionError::BatchVerificationFailed).into(),
+            );
         }
 
         txs.iter_mut()

--- a/p2p/dandelion-tower/src/pool/mod.rs
+++ b/p2p/dandelion-tower/src/pool/mod.rs
@@ -30,7 +30,7 @@ use futures::{future::BoxFuture, FutureExt};
 use rand_distr::Exp;
 use tokio::{
     sync::{mpsc, oneshot},
-    task::JoinSet,
+    task::{JoinHandle, JoinSet},
 };
 use tokio_util::{sync::PollSender, time::DelayQueue};
 use tower::Service;
@@ -49,8 +49,8 @@ pub use manager::DandelionPoolManager;
 
 /// Start the [`DandelionPoolManager`].
 ///
-/// This function spawns the [`DandelionPoolManager`] and returns [`DandelionPoolService`] which can be used to send
-/// requests to the pool.
+/// This function spawns the [`DandelionPoolManager`] and returns a
+/// [`DandelionPoolService`] and the manager's task handle.
 ///
 /// ### Args
 ///
@@ -64,7 +64,7 @@ pub fn start_dandelion_pool_manager<P, R, Tx, TxId, PeerId>(
     dandelion_router: R,
     backing_pool: P,
     config: DandelionConfig,
-) -> DandelionPoolService<Tx, TxId, PeerId>
+) -> (DandelionPoolService<Tx, TxId, PeerId>, JoinHandle<()>)
 where
     Tx: Clone + Send + 'static,
     TxId: Hash + Eq + Clone + Send + 'static,
@@ -92,11 +92,14 @@ where
         _tx: PhantomData,
     };
 
-    tokio::spawn(pool.run(rx));
+    let task = tokio::spawn(pool.run(rx));
 
-    DandelionPoolService {
-        tx: PollSender::new(tx),
-    }
+    (
+        DandelionPoolService {
+            tx: PollSender::new(tx),
+        },
+        task,
+    )
 }
 
 /// The dandelion pool manager service.
@@ -138,7 +141,7 @@ where
 
         async move {
             res?;
-            rx.await.expect("Oneshot dropped before response!");
+            rx.await.map_err(|_| DandelionPoolShutDown)?;
 
             Ok(())
         }

--- a/p2p/dandelion-tower/src/pool/mod.rs
+++ b/p2p/dandelion-tower/src/pool/mod.rs
@@ -36,7 +36,6 @@ use tokio_util::{sync::PollSender, time::DelayQueue};
 use tower::Service;
 
 use crate::{
-    pool::manager::DandelionPoolShutDown,
     traits::{TxStoreRequest, TxStoreResponse},
     DandelionConfig, DandelionRouteReq, DandelionRouterError, State,
 };
@@ -45,7 +44,7 @@ mod incoming_tx;
 mod manager;
 
 pub use incoming_tx::{IncomingTx, IncomingTxBuilder};
-pub use manager::DandelionPoolManager;
+pub use manager::{DandelionPoolManager, DandelionPoolShutDown};
 
 /// Start the [`DandelionPoolManager`].
 ///

--- a/p2p/dandelion-tower/src/tests/pool.rs
+++ b/p2p/dandelion-tower/src/tests/pool.rs
@@ -22,7 +22,7 @@ async fn basic_functionality() {
 
     let (pool_svc, _pool) = mock_in_memory_backing_pool();
 
-    let mut pool_svc = start_dandelion_pool_manager(15, router, pool_svc, config);
+    let (mut pool_svc, pool_task) = start_dandelion_pool_manager(15, router, pool_svc, config);
 
     pool_svc
         .ready()
@@ -40,4 +40,7 @@ async fn basic_functionality() {
     // all functionality.
     //assert!(pool.lock().unwrap().contains_key(&1));
     assert!(broadcast_rx.try_recv().is_ok());
+
+    drop(pool_svc);
+    pool_task.await.unwrap();
 }

--- a/p2p/p2p/src/inbound_server.rs
+++ b/p2p/p2p/src/inbound_server.rs
@@ -39,7 +39,7 @@ pub(super) async fn inbound_server<Z, T, HS, A>(
     mut handshaker: HS,
     mut address_book: A,
     config: P2PConfig<Z>,
-    transport_config: Option<T::ServerConfig>,
+    listener: Option<T::Listener>,
     inbound_semaphore: Arc<Semaphore>,
     peer_sync_callback: Option<PeerSyncCallback>,
 ) -> Result<(), tower::BoxError>
@@ -55,18 +55,11 @@ where
     // Copying the peer_id before borrowing for ping responses (Make us avoid a `clone()`).
     let our_peer_id = config.basic_node_data().peer_id;
 
-    // Mandatory. Extract server config from P2PConfig
-    let Some(server_config) = transport_config else {
-        tracing::warn!("No inbound server config provided, not listening for inbound connections.");
+    let Some(listener) = listener else {
         return Ok(());
     };
 
     tracing::info!("Starting inbound connection server");
-
-    let listener = T::incoming_connection_listener(server_config)
-        .await
-        .inspect_err(|e| tracing::warn!("Failed to start inbound server: {e}"))?;
-
     let mut listener = pin!(listener);
 
     // Use the provided semaphore for limiting to maximum inbound connections.

--- a/p2p/p2p/src/lib.rs
+++ b/p2p/p2p/src/lib.rs
@@ -167,6 +167,13 @@ where
         peer_sync_callback.clone(),
     );
 
+    let inbound_listener = if let Some(config) = transport_config.server_config {
+        Some(T::incoming_connection_listener(config).await?)
+    } else {
+        tracing::warn!("No inbound server config provided, not listening for inbound connections.");
+        None
+    };
+
     // Create semaphore for limiting inbound connections and monitoring
     let inbound_semaphore = Arc::new(tokio::sync::Semaphore::new(config.max_inbound_connections));
 
@@ -179,7 +186,7 @@ where
     );
 
     // Spawn inbound connection monitor task
-    if transport_config.server_config.is_some() {
+    if inbound_listener.is_some() {
         background_tasks.spawn(
             inbound_connection_monitor(
                 Arc::clone(&inbound_semaphore),
@@ -196,7 +203,7 @@ where
             inbound_handshaker,
             address_book.clone(),
             config,
-            transport_config.server_config,
+            inbound_listener,
             inbound_semaphore,
             peer_sync_callback,
         )

--- a/types/types/src/lib.rs
+++ b/types/types/src/lib.rs
@@ -21,7 +21,7 @@ pub use block_complete_entry::{BlockCompleteEntry, PrunedTxBlobEntry, Transactio
 pub use connection_state::ConnectionState;
 pub use hard_fork::{HardFork, HardForkError};
 pub use transaction_verification_data::{
-    CachedVerificationState, TransactionVerificationData, TxVersion,
+    CachedVerificationState, TransactionVerificationData, TxConversionError, TxVersion,
 };
 pub use types::{
     AltBlockInformation, BlockTemplate, Chain, ChainId, ExtendedBlockHeader, OutputOnChain,


### PR DESCRIPTION
### What
Depends on pt1, PR #585

Building on part 1, this replaces the panic-on-error patterns in cuprated's services with error propagation that makes use of the graceful shutdown mechanism

### Why
So we dont panic and insta-crash upon a error, shutdown should be graceful. Internal errors still caused panics before this via PANIC_CRITICAL_SERVICE_ERROR

### Where
- `cuprated`:
  - `blockchain/error.rs` (new):
    | Type | Kind | Variants |
    |---|---|---|
    | `BlockValidationError` | peer-fault (ban) | `HardFork(HardForkError)`, `Other(ExtendedConsensusError)` |
    | `BlockManagerError` | manager union | `Validation(BlockValidationError)`, `Internal(#[from] tower::BoxError)` |
    | `IncomingBlockError` | interface union | `Validation(BlockValidationError)`, `Internal(tower::BoxError)`, `Orphan`, `UnknownTransactions(_, _)`, `TooManyTxs`, `ChannelClosed` |

  - `txpool/error.rs` (new):
    | Type | Kind | Variants |
    |---|---|---|
    | `TxValidationError` | peer-fault (ban) | `Parse(io::Error)`, `Consensus(ExtendedConsensusError)`, `DuplicateTransaction`, `RelayRule(RelayRuleError)` |
    | `IncomingTxError` | union | `Validation(#[from] TxValidationError)`, `Internal(#[from] tower::BoxError)` |

  - `monitor.rs` - add `TaskExecutor::spawn_critical`, `panic_message` helper.
  - `logging.rs` - return the log guard, hold it until shutdown completes.
  - `constants.rs` - rename `PANIC_CRITICAL_SERVICE_ERROR` to `CRITICAL_SERVICE_ERROR`
  - `lib.rs` - `Node::launch` returns `Result`; on init failure it cancels partially spawned subsystems before returning the error.
  - `blockchain.rs` - `check_add_genesis` returns `Result`.
  - `blockchain/manager.rs` - run loop returns `Result`, `spawn_critical` for syncer + manager.
  - `blockchain/manager/handler.rs` - `.expect(...)` -> `?` throughout, handlers return `Result<_, BlockManagerError>` or `Result<_, tower::BoxError>`, `handle_command` routes `Internal` via `?` and `Validation` via response channel. Invariant violations kept as panics.
  - `txpool/manager.rs` - uniform DB-error escalation: all 6 handlers propagate `TxPoolError` via `?`. Reorder `promote_tx` and `remove_tx_from_pool` to write to DB first, then apply in memory.
  - `txpool/incoming_tx.rs` - `IncomingTxHandler::init` returns `Result`.
  - `tor.rs`, `p2p.rs` - `transport_*_config` / `initialize_clearnet_p2p` / `initialize_tor_p2p` return `Result`, Tor logs+skips on failure.
  - `rpc/server.rs` - `init_rpc_servers` returns `Result`, per-server task uses `spawn` - If a RPC server fails to start, the error is logged but doesn't initiate shutdown.
- `cuprate-types`
    - `TxConversionError` re-exported.

### How
#### 1. spawn_critical wraps each subsystem's future:

  | Outcome | Action |
  |---|---|
  | `Ok(())` | normal exit if shutdown was requested, else logged as a bug -> trigger shutdown |
  | `Err(_)` | log w/ subsystem name -> trigger shutdown |
  | panic | log via `panic_message` -> trigger shutdown |

#### 2. Added layered errors.
Per subsystem: a typed `ValidationError` for peer-fault paths, plus a union with `Validation` and `Internal(tower::BoxError)` arms. `From` impls route (`ExtendedConsensusError::DBErr` -> Internal; else -> Validation). The manager matches between the two:

  | Variant | Route | Caller's response |
  |---|---|---|
  | `Internal(_)` | `?` -> `spawn_critical` | log + graceful shutdown |
  | `Validation(_)` | back via response channel | ban peer / cancel downloader |