### PR TITLE
Consensus: use the last input in the ring as the youngest output

### DIFF
--- a/consensus/rules/src/transactions.rs
+++ b/consensus/rules/src/transactions.rs
@@ -481,14 +481,6 @@ fn check_inputs_contextual(
     current_chain_height: usize,
     hf: HardFork,
 ) -> Result<(), TransactionError> {
-    // This rule is not contained in monero-core explicitly, but it is enforced by how Monero picks ring members.
-    // When picking ring members monerod will only look in the DB at past blocks so an output has to be younger
-    // than this transaction to be used in this tx.
-    if tx_ring_members_info.youngest_used_out_height >= current_chain_height {
-        tracing::debug!("Transaction invalid: One or more ring members too young.");
-        return Err(TransactionError::OneOrMoreRingMembersLocked);
-    }
-
     check_10_block_lock(
         tx_ring_members_info.youngest_used_out_height,
         current_chain_height,

--- a/consensus/src/transactions/contextual_data.rs
+++ b/consensus/src/transactions/contextual_data.rs
@@ -76,12 +76,12 @@ pub fn new_ring_member_info(
             .iter()
             .map(|inp_outs| {
                 inp_outs
-                    .iter()
-                    // the output with the highest height is the youngest
+                    // Use the last output declared in the ring as the youngest.
+                    .last()
                     .map(|out| out.height)
-                    .max()
                     .expect("Input must have ring members")
             })
+            // the output with the highest height is the youngest
             .max()
             .expect("Tx must have inputs"),
         time_locked_outs: used_outs

--- a/types/types/src/output_cache.rs
+++ b/types/types/src/output_cache.rs
@@ -100,6 +100,8 @@ impl OutputCache {
     ///
     /// This function will add any outputs to the cache that were requested when building the cache
     /// but were not in the DB, if they are in the block.
+    ///
+    /// You should _not_ add blocks to the cache before the block has been verified.
     pub fn add_block_to_cache(&mut self, block: &VerifiedBlockInformation) {
         self.add_tx::<true>(block.height, block.block.miner_transaction());
 


### PR DESCRIPTION
This is faster than looping over all outputs and as outs use relative offsets is the same as before.