### PR TITLE
set tx to public after promotion from stem state

### DIFF
--- a/binaries/cuprated/src/txpool/manager.rs
+++ b/binaries/cuprated/src/txpool/manager.rs
@@ -402,6 +402,7 @@ impl TxpoolManager {
             tracing::trace!("not promoting tx, tx is already public");
             return;
         }
+        tx_info.private = false;
 
         tracing::debug!("promoting tx");
 


### PR DESCRIPTION
Fixes a small bug, currently this will lead to multiple timeouts being added to the delay queue for stem txs.