### PR TITLE
cuprated: parse SOCKS5 proxy URL

### DIFF
--- a/binaries/cuprated/src/config/p2p.rs
+++ b/binaries/cuprated/src/config/p2p.rs
@@ -224,16 +224,15 @@ config_struct! {
         #[comment_out = true]
         /// The proxy to use for outgoing P2P connections
         ///
-        /// This setting can only take "Tor" at the moment.
-        /// This will anonymise clearnet connections through Tor.
+        /// Setting this to "Tor" will anonymise clearnet connections through Tor.
         ///
         /// Setting this to "" (an empty string) will disable the proxy.
         ///
         /// Enabling this setting will disable inbound connections.
         ///
         /// Type         | String
-        /// Valid values | "Tor"
-        /// Examples     | "Tor"
+        /// Valid values | "Tor", "socks5://[user:pass@]host:port"
+        /// Examples     | "Tor", "socks5://127.0.0.1:9050"
         pub proxy: ProxySettings,
     }
 
@@ -309,7 +308,7 @@ impl Default for ClearNetConfig {
             listen_on: Ipv4Addr::UNSPECIFIED,
             enable_inbound_v6: false,
             listen_on_v6: Ipv6Addr::UNSPECIFIED,
-            proxy: ProxySettings::Socks(String::new()),
+            proxy: ProxySettings::Disabled,
             outbound_connections: 32,
             extra_outbound_connections: 8,
             max_inbound_connections: 128,

--- a/binaries/cuprated/src/config/p2p.rs
+++ b/binaries/cuprated/src/config/p2p.rs
@@ -231,7 +231,7 @@ config_struct! {
         /// Enabling this setting will disable inbound connections.
         ///
         /// Type         | String
-        /// Valid values | "Tor", "socks5://[user:pass@]host:port"
+        /// Valid values | "Tor", "socks5://host:port", "socks5://user:pass@host:port"
         /// Examples     | "Tor", "socks5://127.0.0.1:9050"
         pub proxy: ProxySettings,
     }

--- a/binaries/cuprated/src/config/p2p.rs
+++ b/binaries/cuprated/src/config/p2p.rs
@@ -231,7 +231,7 @@ config_struct! {
         /// Enabling this setting will disable inbound connections.
         ///
         /// Type         | String
-        /// Valid values | "Tor", "socks5://host:port", "socks5://user:pass@host:port"
+        /// Valid values | "Tor", "socks5://ip:port", "socks5://user:pass@ip:port"
         /// Examples     | "Tor", "socks5://127.0.0.1:9050"
         pub proxy: ProxySettings,
     }

--- a/binaries/cuprated/src/p2p.rs
+++ b/binaries/cuprated/src/p2p.rs
@@ -62,10 +62,9 @@ impl TryFrom<String> for ProxySettings {
         match s.as_str() {
             "" => Ok(Self::Disabled),
             "Tor" => Ok(Self::Tor),
-            url => {
-                let url = url
-                    .strip_prefix("socks5://")
-                    .ok_or_else(|| anyhow!("Invalid proxy url header, expected socks5://"))?;
+            // TODO: use `if let` guard when on >=1.95
+            url if url.starts_with("socks5://") => {
+                let url = url.strip_prefix("socks5://").unwrap();
 
                 let (authentication, addr) = match url.rsplit_once('@') {
                     Some((userpass, addr)) => {
@@ -87,6 +86,7 @@ impl TryFrom<String> for ProxySettings {
                     authentication,
                 }))
             }
+            _ => Err(anyhow!("Unsupported proxy: '{s}'")),
         }
     }
 }

--- a/binaries/cuprated/src/p2p.rs
+++ b/binaries/cuprated/src/p2p.rs
@@ -48,33 +48,60 @@ pub use network_address::CrossNetworkInternalPeerId;
 
 /// A simple parsing enum for the `p2p.clear_net.proxy` field
 #[derive(Debug, Deserialize, Serialize, PartialEq, Eq, Clone)]
+#[serde(try_from = "String", into = "String")]
 pub enum ProxySettings {
+    Disabled,
     Tor,
-    #[serde(untagged)]
-    Socks(String),
+    Socks(SocksClientConfig),
 }
 
-/// Converts a `str` to a [`SocksClientConfig`].
-fn socks_proxy_str_to_config(url: &str) -> Result<SocksClientConfig, anyhow::Error> {
-    let Some((_, url)) = url.split_once("socks5://") else {
-        return Err(anyhow!("Invalid proxy url header."));
-    };
+impl TryFrom<String> for ProxySettings {
+    type Error = anyhow::Error;
 
-    let (authentication, addr) = url
-        .split_once('@')
-        .map(|(up, ad)| {
-            (
-                up.split_once(':')
-                    .map(|(a, b)| (a.to_string(), b.to_string())),
-                ad,
-            )
-        })
-        .unwrap_or((None, url));
+    fn try_from(s: String) -> Result<Self, Self::Error> {
+        match s.as_str() {
+            "" => Ok(Self::Disabled),
+            "Tor" => Ok(Self::Tor),
+            url => {
+                let url = url
+                    .strip_prefix("socks5://")
+                    .ok_or_else(|| anyhow!("Invalid proxy url header, expected socks5://"))?;
 
-    Ok(SocksClientConfig {
-        proxy: addr.parse()?,
-        authentication,
-    })
+                let (authentication, addr) = match url.rsplit_once('@') {
+                    Some((userpass, addr)) => {
+                        let (user, pass) = userpass.split_once(':').ok_or_else(|| {
+                            anyhow!("Invalid proxy authentication, expected user:pass format, got: {userpass}")
+                        })?;
+
+                        if user.is_empty() || pass.is_empty() {
+                            return Err(anyhow!("Proxy username and password must not be empty."));
+                        }
+
+                        (Some((user.to_string(), pass.to_string())), addr)
+                    }
+                    None => (None, url),
+                };
+
+                Ok(Self::Socks(SocksClientConfig {
+                    proxy: addr.parse()?,
+                    authentication,
+                }))
+            }
+        }
+    }
+}
+
+impl From<ProxySettings> for String {
+    fn from(settings: ProxySettings) -> Self {
+        match settings {
+            ProxySettings::Disabled => Self::new(),
+            ProxySettings::Tor => "Tor".into(),
+            ProxySettings::Socks(config) => match config.authentication {
+                Some((u, p)) => format!("socks5://{u}:{p}@{}", config.proxy),
+                None => format!("socks5://{}", config.proxy),
+            },
+        }
+    }
 }
 
 /// This struct collect all supported and optional network zone interfaces.
@@ -105,7 +132,7 @@ pub async fn initialize_clearnet_p2p(
     tor_ctx: &TorContext,
     peer_sync_callback: PeerSyncCallback,
 ) -> (NetworkInterface<ClearNet>, Sender<IncomingTxHandler>) {
-    match config.p2p.clear_net.proxy {
+    match &config.p2p.clear_net.proxy {
         ProxySettings::Tor => match tor_ctx.mode {
             #[cfg(feature = "arti")]
             TorMode::Arti => {
@@ -133,34 +160,29 @@ pub async fn initialize_clearnet_p2p(
             .unwrap(),
             TorMode::Auto => unreachable!("Auto mode should be resolved before this point"),
         },
-        ProxySettings::Socks(ref s) => {
-            if s.is_empty() {
-                start_zone_p2p::<ClearNet, Tcp>(
-                    blockchain_read_handle,
-                    context_svc,
-                    txpool_read_handle,
-                    config.clearnet_p2p_config(),
-                    config.p2p.clear_net.tcp_transport_config(config.network),
-                    Some(peer_sync_callback.clone()),
-                )
-                .await
-                .unwrap()
-            } else {
-                start_zone_p2p::<ClearNet, Socks>(
-                    blockchain_read_handle,
-                    context_svc,
-                    txpool_read_handle,
-                    config.clearnet_p2p_config(),
-                    TransportConfig {
-                        client_config: socks_proxy_str_to_config(s).unwrap(),
-                        server_config: None,
-                    },
-                    Some(peer_sync_callback.clone()),
-                )
-                .await
-                .unwrap()
-            }
-        }
+        ProxySettings::Disabled => start_zone_p2p::<ClearNet, Tcp>(
+            blockchain_read_handle,
+            context_svc,
+            txpool_read_handle,
+            config.clearnet_p2p_config(),
+            config.p2p.clear_net.tcp_transport_config(config.network),
+            Some(peer_sync_callback.clone()),
+        )
+        .await
+        .unwrap(),
+        ProxySettings::Socks(socks_config) => start_zone_p2p::<ClearNet, Socks>(
+            blockchain_read_handle,
+            context_svc,
+            txpool_read_handle,
+            config.clearnet_p2p_config(),
+            TransportConfig {
+                client_config: socks_config.clone(),
+                server_config: None,
+            },
+            Some(peer_sync_callback.clone()),
+        )
+        .await
+        .unwrap(),
     }
 }
 

--- a/p2p/p2p-transport/src/socks.rs
+++ b/p2p/p2p-transport/src/socks.rs
@@ -47,7 +47,7 @@ pub async fn is_socks5_proxy(addr: SocketAddr) -> bool {
 #[derive(Debug, Clone, Copy, Default)]
 pub struct Socks;
 
-#[derive(Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SocksClientConfig {
     /// Proxy address
     pub proxy: SocketAddr,


### PR DESCRIPTION
### What
Closes #579 

### Why
no unparsed string :)

### Where
cuprated, p2p

### How
Add a `TryFrom<String>` impl that parses "", "Tor", falls through to attempting to parse anything else as a SOCKS5 proxy url, checking if each part is correct
Also `From<ProxySettings>` for `String` for test compatibility