### PR TITLE
cuprated: broadcast block before notifying txpool

### DIFF
--- a/binaries/cuprated/src/blockchain/manager/handler.rs
+++ b/binaries/cuprated/src/blockchain/manager/handler.rs
@@ -148,15 +148,8 @@ impl super::BlockchainManager {
         )
         .await?;
 
-        let block_blob = Bytes::copy_from_slice(&verified_block.block_blob);
-        self.add_valid_block_to_main_chain(verified_block).await;
-
-        let chain_height = self
-            .blockchain_context_service
-            .blockchain_context()
-            .chain_height;
-
-        self.broadcast_block(block_blob, chain_height).await;
+        self.add_valid_block_to_main_chain(verified_block, BlockSource::Incoming)
+            .await;
 
         info!(
             hash = hex::encode(
@@ -260,7 +253,8 @@ impl super::BlockchainManager {
                 }
             };
 
-            self.add_valid_block_to_main_chain(verified_block).await;
+            self.add_valid_block_to_main_chain(verified_block, BlockSource::BatchSync)
+                .await;
         }
         info!(fast_sync = false, "Successfully added block batch");
     }
@@ -534,7 +528,8 @@ impl super::BlockchainManager {
                 block,
                 self.blockchain_context_service.blockchain_context(),
             );
-            self.add_valid_block_to_main_chain(verified_block).await;
+            self.add_valid_block_to_main_chain(verified_block, BlockSource::Reorg)
+                .await;
         }
 
         self.blockchain_write_handle
@@ -618,7 +613,8 @@ impl super::BlockchainManager {
             )
             .await?;
 
-            self.add_valid_block_to_main_chain(verified_block).await;
+            self.add_valid_block_to_main_chain(verified_block, BlockSource::Reorg)
+                .await;
         }
 
         Ok(())
@@ -626,15 +622,17 @@ impl super::BlockchainManager {
 
     /// Adds a [`VerifiedBlockInformation`] to the main-chain.
     ///
-    /// This function will update the blockchain database and the context cache.
+    /// This function will update the blockchain database and the context cache,
+    /// and announce the block to peers if `source` is [`BlockSource::Incoming`].
     ///
     /// # Panics
     ///
     /// This function will panic if any internal service returns an unexpected error that we cannot
     /// recover from.
-    pub async fn add_valid_block_to_main_chain(
+    async fn add_valid_block_to_main_chain(
         &mut self,
         verified_block: VerifiedBlockInformation,
+        source: BlockSource,
     ) {
         // FIXME: this is pretty inefficient, we should probably return the KI map created in the consensus crate.
         let spent_key_images = verified_block
@@ -648,16 +646,23 @@ impl super::BlockchainManager {
             })
             .collect::<Vec<[u8; 32]>>();
 
+        let block_blob = matches!(source, BlockSource::Incoming)
+            .then(|| Bytes::copy_from_slice(&verified_block.block_blob));
+
         self.add_valid_block_to_blockchain_cache(&verified_block)
             .await;
 
-        self.blockchain_write_handle
-            .ready()
-            .await
-            .expect(PANIC_CRITICAL_SERVICE_ERROR)
-            .call(BlockchainWriteRequest::WriteBlock(verified_block))
-            .await
-            .expect(PANIC_CRITICAL_SERVICE_ERROR);
+        self.add_valid_block_to_blockchain_database(verified_block)
+            .await;
+
+        if let Some(block_blob) = block_blob {
+            let chain_height = self
+                .blockchain_context_service
+                .blockchain_context()
+                .chain_height;
+
+            self.broadcast_block(block_blob, chain_height).await;
+        }
 
         self.txpool_manager_handle
             .new_block(spent_key_images)
@@ -693,6 +698,25 @@ impl super::BlockchainManager {
             .expect(PANIC_CRITICAL_SERVICE_ERROR);
     }
 
+    /// Writes a [`VerifiedBlockInformation`] to the blockchain database.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if any internal service returns an unexpected error that we cannot
+    /// recover from.
+    async fn add_valid_block_to_blockchain_database(
+        &mut self,
+        verified_block: VerifiedBlockInformation,
+    ) {
+        self.blockchain_write_handle
+            .ready()
+            .await
+            .expect(PANIC_CRITICAL_SERVICE_ERROR)
+            .call(BlockchainWriteRequest::WriteBlock(verified_block))
+            .await
+            .expect(PANIC_CRITICAL_SERVICE_ERROR);
+    }
+
     /// Batch writes the [`VerifiedBlockInformation`]s to the database.
     ///
     /// The blocks must be sequential.
@@ -723,6 +747,16 @@ enum AddAltBlock {
     NewlyCached(Bytes),
     /// The chain was reorged.
     Reorged,
+}
+
+/// The context in which a verified block is being added to the main chain.
+enum BlockSource {
+    /// A single incoming block. Will be announced to peers.
+    Incoming,
+    /// A block from the block downloader's batch sync.
+    BatchSync,
+    /// A block re-applied during a reorg.
+    Reorg,
 }
 
 /// Creates a [`VerifiedBlockInformation`] from an alt-block known to be valid.


### PR DESCRIPTION
### What
Closes #541 

### Why
Faster block propagation

### Where
cuprated

### How
Move the `block_blob` extraction and `broadcast_block` call inside `add_valid_block_to_main_chain`, between the DB write and the txpool notification. Add a `BlockSource` parameter naming each of the three call paths (Incoming, BatchSync, Reorg) - only `Incoming` triggers the broadcast.