### PR TITLE
consensus: pass spent KIs to cuprated

### DIFF
--- a/binaries/cuprated/src/blockchain/manager/handler.rs
+++ b/binaries/cuprated/src/blockchain/manager/handler.rs
@@ -3,10 +3,7 @@ use std::{collections::HashMap, sync::Arc};
 
 use bytes::Bytes;
 use futures::{TryFutureExt, TryStreamExt};
-use monero_oxide::{
-    block::Block,
-    transaction::{Input, Transaction},
-};
+use monero_oxide::block::Block;
 use rayon::prelude::*;
 use tower::{Service, ServiceExt};
 use tracing::{info, instrument, warn, Span};
@@ -14,8 +11,9 @@ use tracing::{info, instrument, warn, Span};
 use cuprate_blockchain::service::{BlockchainReadHandle, BlockchainWriteHandle};
 use cuprate_consensus::{
     block::{
-        batch_prepare_main_chain_blocks, sanity_check_alt_block, verify_main_chain_block,
-        verify_prepped_main_chain_block, PreparedBlock,
+        alt_block_to_verified_block, batch_prepare_main_chain_blocks, sanity_check_alt_block,
+        verify_main_chain_block, verify_prepped_main_chain_block, PreparedBlock, PreparedBlockTxs,
+        VerifiedBlock,
     },
     transactions::new_tx_verification_data,
     BlockChainContextRequest, BlockChainContextResponse, ExtendedConsensusError,
@@ -229,11 +227,11 @@ impl super::BlockchainManager {
             return;
         };
 
-        for (block, txs) in prepped_blocks {
+        for (block, txs_with_kis) in prepped_blocks {
             let hash = block.block_hash;
             let verified_block = match verify_prepped_main_chain_block(
                 block,
-                txs,
+                PreparedBlockTxs::Checked(txs_with_kis),
                 &mut self.blockchain_context_service,
                 self.blockchain_read_handle.clone(),
                 Some(&mut output_cache),
@@ -525,7 +523,7 @@ impl super::BlockchainManager {
         }
 
         for block in blocks {
-            let verified_block = alt_block_to_verified_block_information(
+            let verified_block = alt_block_to_verified_block(
                 block,
                 self.blockchain_context_service.blockchain_context(),
             );
@@ -607,7 +605,7 @@ impl super::BlockchainManager {
 
             let verified_block = verify_prepped_main_chain_block(
                 prepped_block,
-                prepped_txs,
+                PreparedBlockTxs::Unchecked(prepped_txs),
                 &mut self.blockchain_context_service,
                 self.blockchain_read_handle.clone(),
                 None,
@@ -621,7 +619,7 @@ impl super::BlockchainManager {
         Ok(())
     }
 
-    /// Adds a [`VerifiedBlockInformation`] to the main-chain.
+    /// Adds a [`VerifiedBlock`] to the main-chain.
     ///
     /// This function will update the blockchain database and the context cache,
     /// and announce the block to peers if `source` is [`BlockSource::Incoming`].
@@ -632,29 +630,20 @@ impl super::BlockchainManager {
     /// recover from.
     async fn add_valid_block_to_main_chain(
         &mut self,
-        verified_block: VerifiedBlockInformation,
+        verified_block: VerifiedBlock,
         source: BlockSource,
     ) {
-        // FIXME: this is pretty inefficient, we should probably return the KI map created in the consensus crate.
-        let spent_key_images = verified_block
-            .txs
-            .iter()
-            .flat_map(|tx| {
-                tx.tx.prefix().inputs.iter().map(|input| match input {
-                    Input::ToKey { key_image, .. } => key_image.to_bytes(),
-                    Input::Gen(_) => unreachable!(),
-                })
-            })
-            .collect::<Vec<[u8; 32]>>();
+        let VerifiedBlock {
+            info,
+            spent_key_images,
+        } = verified_block;
 
         let block_blob = matches!(source, BlockSource::Incoming)
-            .then(|| Bytes::copy_from_slice(&verified_block.block_blob));
+            .then(|| Bytes::copy_from_slice(&info.block_blob));
 
-        self.add_valid_block_to_blockchain_cache(&verified_block)
-            .await;
+        self.add_valid_block_to_blockchain_cache(&info).await;
 
-        self.add_valid_block_to_blockchain_database(verified_block)
-            .await;
+        self.add_valid_block_to_blockchain_database(info).await;
 
         if let Some(block_blob) = block_blob {
             let chain_height = self
@@ -759,45 +748,4 @@ enum BlockSource {
     BatchSync,
     /// A block re-applied during a reorg.
     Reorg,
-}
-
-/// Creates a [`VerifiedBlockInformation`] from an alt-block known to be valid.
-///
-/// # Panics
-///
-/// This may panic if used on an invalid block.
-pub fn alt_block_to_verified_block_information(
-    block: AltBlockInformation,
-    blockchain_ctx: &BlockchainContext,
-) -> VerifiedBlockInformation {
-    assert_eq!(
-        block.height, blockchain_ctx.chain_height,
-        "alt-block invalid"
-    );
-
-    let total_fees = block.txs.iter().map(|tx| tx.fee).sum::<u64>();
-    let total_outputs = block
-        .block
-        .miner_transaction()
-        .prefix()
-        .outputs
-        .iter()
-        .map(|output| output.amount.unwrap_or(0))
-        .sum::<u64>();
-
-    let generated_coins = total_outputs - total_fees;
-
-    VerifiedBlockInformation {
-        block_blob: block.block_blob,
-        txs: block.txs,
-        block_hash: block.block_hash,
-        pow_hash: [u8::MAX; 32],
-        height: block.height,
-        generated_coins,
-        weight: block.weight,
-        long_term_weight: blockchain_ctx.next_block_long_term_weight(block.weight),
-        cumulative_difficulty: blockchain_ctx.cumulative_difficulty
-            + blockchain_ctx.next_difficulty,
-        block: block.block,
-    }
 }

--- a/binaries/cuprated/src/blockchain/manager/handler.rs
+++ b/binaries/cuprated/src/blockchain/manager/handler.rs
@@ -2,20 +2,21 @@
 use std::{collections::HashMap, sync::Arc};
 
 use bytes::Bytes;
-use monero_oxide::{block::Block, transaction::Input};
+use monero_oxide::block::Block;
 use rayon::prelude::*;
 use tower::{Service, ServiceExt};
 use tracing::{info, instrument, warn};
 
 use cuprate_consensus::{
     block::{
-        batch_prepare_main_chain_blocks, sanity_check_alt_block, verify_main_chain_block,
-        verify_prepped_main_chain_block, BlockVerificationError, PreparedBlock,
+        alt_block_to_verified_block, batch_prepare_main_chain_blocks, sanity_check_alt_block,
+        verify_main_chain_block, verify_prepped_main_chain_block, BlockVerificationError,
+        PreparedBlock, PreparedBlockTxs, VerifiedBlock,
     },
     transactions::new_tx_verification_data,
     BlockChainContextRequest, ExtendedConsensusError, VerificationContext,
 };
-use cuprate_consensus_context::{distribution::rct_output_count, BlockchainContext, NewBlockData};
+use cuprate_consensus_context::{distribution::rct_output_count, NewBlockData};
 use cuprate_fast_sync::{block_to_verified_block_information, fast_sync_stop_height};
 use cuprate_helper::cast::usize_to_u64;
 use cuprate_p2p::{block_downloader::BlockBatch, constants::MEDIUM_BAN, BroadcastRequest};
@@ -249,13 +250,14 @@ impl super::BlockchainManager {
         let mut verification_context =
             VerificationContext::<ConsensusBlockchainReadHandle>::BatchPrepareCache(output_cache);
         let mut valid_blocks = Vec::with_capacity(prepped_blocks.len());
+        let mut spent_key_images = Vec::new();
         let mut error = false;
 
-        for (block, txs) in prepped_blocks {
+        for (block, txs_with_kis) in prepped_blocks {
             let hash = block.block_hash;
             let verified_block = match verify_prepped_main_chain_block(
                 block,
-                txs,
+                PreparedBlockTxs::Checked(txs_with_kis),
                 &mut self.blockchain_context_service,
                 &mut verification_context,
             )
@@ -279,14 +281,18 @@ impl super::BlockchainManager {
                 },
             };
 
-            self.add_valid_block_to_blockchain_cache(&verified_block)
+            self.add_valid_block_to_blockchain_cache(&verified_block.info)
                 .await?;
 
-            valid_blocks.push(verified_block);
+            spent_key_images.extend(verified_block.spent_key_images);
+            valid_blocks.push(verified_block.info);
         }
 
         let valid_blocks_len = valid_blocks.len();
         self.batch_add_valid_block_to_blockchain_database(valid_blocks)
+            .await?;
+        self.txpool_manager_handle
+            .new_block(spent_key_images)
             .await?;
 
         if error {
@@ -571,7 +577,7 @@ impl super::BlockchainManager {
         }
 
         for block in blocks {
-            let verified_block = alt_block_to_verified_block_information(
+            let verified_block = alt_block_to_verified_block(
                 block,
                 self.blockchain_context_service.blockchain_context(),
             );
@@ -645,7 +651,7 @@ impl super::BlockchainManager {
 
             let verified_block = verify_prepped_main_chain_block(
                 prepped_block,
-                prepped_txs,
+                PreparedBlockTxs::Unchecked(prepped_txs),
                 &mut self.blockchain_context_service,
                 &mut VerificationContext::Database(self.blockchain_read_handle.clone()),
             )
@@ -658,7 +664,7 @@ impl super::BlockchainManager {
         Ok(())
     }
 
-    /// Adds a [`VerifiedBlockInformation`] to the main-chain.
+    /// Adds a [`VerifiedBlock`] to the main-chain.
     ///
     /// This function will update the blockchain database and the context cache,
     /// and announce the block to peers if `source` is [`BlockSource::Incoming`].
@@ -669,29 +675,20 @@ impl super::BlockchainManager {
     /// recover from.
     async fn add_valid_block_to_main_chain(
         &mut self,
-        verified_block: VerifiedBlockInformation,
+        verified_block: VerifiedBlock,
         source: BlockSource,
     ) -> Result<(), FatalError> {
-        // FIXME: this is pretty inefficient, we should probably return the KI map created in the consensus crate.
-        let spent_key_images = verified_block
-            .txs
-            .iter()
-            .flat_map(|tx| {
-                tx.tx.prefix().inputs.iter().map(|input| match input {
-                    Input::ToKey { key_image, .. } => key_image.to_bytes(),
-                    Input::Gen(_) => unreachable!(),
-                })
-            })
-            .collect::<Vec<[u8; 32]>>();
+        let VerifiedBlock {
+            info,
+            spent_key_images,
+        } = verified_block;
 
         let block_blob = matches!(source, BlockSource::Incoming)
-            .then(|| Bytes::copy_from_slice(&verified_block.block_blob));
+            .then(|| Bytes::copy_from_slice(&info.block_blob));
 
-        self.add_valid_block_to_blockchain_cache(&verified_block)
-            .await?;
+        self.add_valid_block_to_blockchain_cache(&info).await?;
 
-        self.add_valid_block_to_blockchain_database(verified_block)
-            .await?;
+        self.add_valid_block_to_blockchain_database(info).await?;
 
         if let Some(block_blob) = block_blob {
             let chain_height = self
@@ -794,45 +791,4 @@ enum BlockSource {
     Incoming,
     /// A block re-applied during a reorg.
     Reorg,
-}
-
-/// Creates a [`VerifiedBlockInformation`] from an alt-block known to be valid.
-///
-/// # Panics
-///
-/// This may panic if used on an invalid block.
-fn alt_block_to_verified_block_information(
-    block: AltBlockInformation,
-    blockchain_ctx: &BlockchainContext,
-) -> VerifiedBlockInformation {
-    assert_eq!(
-        block.height, blockchain_ctx.chain_height,
-        "alt-block invalid"
-    );
-
-    let total_fees = block.txs.iter().map(|tx| tx.fee).sum::<u64>();
-    let total_outputs = block
-        .block
-        .miner_transaction()
-        .prefix()
-        .outputs
-        .iter()
-        .map(|output| output.amount.unwrap_or(0))
-        .sum::<u64>();
-
-    let generated_coins = total_outputs - total_fees;
-
-    VerifiedBlockInformation {
-        block_blob: block.block_blob,
-        txs: block.txs,
-        block_hash: block.block_hash,
-        pow_hash: [u8::MAX; 32],
-        height: block.height,
-        generated_coins,
-        weight: block.weight,
-        long_term_weight: blockchain_ctx.next_block_long_term_weight(block.weight),
-        cumulative_difficulty: blockchain_ctx.cumulative_difficulty
-            + blockchain_ctx.next_difficulty,
-        block: block.block,
-    }
 }

--- a/binaries/cuprated/src/txpool/incoming_tx.rs
+++ b/binaries/cuprated/src/txpool/incoming_tx.rs
@@ -216,7 +216,7 @@ async fn handle_incoming_txs(
             context.current_hf,
             &mut VerificationContext::Database(blockchain_read_handle),
         )
-        .verify()
+        .verify(None)
         .await?;
 
     for tx in txs {

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -8,7 +8,7 @@ authors = ["Boog900"]
 repository = "https://github.com/Cuprate/cuprate/tree/main/consensus"
 
 [dependencies]
-cuprate-helper              = { workspace = true, default-features = false, features = ["std", "asynch", "num"] }
+cuprate-helper              = { workspace = true, default-features = false, features = ["std", "asynch", "num", "tx"] }
 cuprate-consensus-rules     = { workspace = true, features = ["rayon"] }
 cuprate-types               = { workspace = true }
 cuprate-consensus-context   = { workspace = true }

--- a/consensus/src/block.rs
+++ b/consensus/src/block.rs
@@ -35,7 +35,7 @@ mod alt_block;
 mod batch_prepare;
 mod free;
 
-pub use alt_block::sanity_check_alt_block;
+pub use alt_block::{alt_block_to_verified_block, sanity_check_alt_block};
 pub use batch_prepare::{batch_prepare_main_chain_blocks, BatchPrepareCache};
 use free::pull_ordered_transactions;
 
@@ -192,13 +192,36 @@ impl PreparedBlock {
     }
 }
 
+/// A block's ordered transactions paired with the key images they spend.
+#[derive(Debug)]
+pub struct TxsWithKis {
+    pub(crate) txs: Vec<TransactionVerificationData>,
+    pub(crate) spent_key_images: Vec<[u8; 32]>,
+}
+
+/// A verified block paired with its spent key images.
+#[derive(Debug)]
+pub struct VerifiedBlock {
+    pub info: VerifiedBlockInformation,
+    pub spent_key_images: Vec<[u8; 32]>,
+}
+
+/// Ordered transactions for a prepared block.
+pub enum PreparedBlockTxs {
+    /// Transactions whose key images have not yet been checked.
+    Unchecked(Vec<TransactionVerificationData>),
+    /// Transactions with key images already checked unique within the batch and
+    /// unspent in the chain.
+    Checked(TxsWithKis),
+}
+
 /// Fully verify a block and all its transactions.
 pub async fn verify_main_chain_block<D>(
     block: Block,
     txs: HashMap<[u8; 32], TransactionVerificationData>,
     context_svc: &mut BlockchainContextService,
     database: D,
-) -> Result<VerifiedBlockInformation, ExtendedConsensusError>
+) -> Result<VerifiedBlock, ExtendedConsensusError>
 where
     D: Database + Clone + Send + 'static,
 {
@@ -243,20 +266,32 @@ where
     // Check that the txs included are what we need and that there are not any extra.
     let ordered_txs = pull_ordered_transactions(&prepped_block.block, txs)?;
 
-    verify_prepped_main_chain_block(prepped_block, ordered_txs, context_svc, database, None).await
+    verify_prepped_main_chain_block(
+        prepped_block,
+        PreparedBlockTxs::Unchecked(ordered_txs),
+        context_svc,
+        database,
+        None,
+    )
+    .await
 }
 
 /// Fully verify a block that has already been prepared using [`batch_prepare_main_chain_blocks`].
 pub async fn verify_prepped_main_chain_block<D>(
     prepped_block: PreparedBlock,
-    mut txs: Vec<TransactionVerificationData>,
+    txs: PreparedBlockTxs,
     context_svc: &mut BlockchainContextService,
     database: D,
     batch_prep_cache: Option<&mut BatchPrepareCache>,
-) -> Result<VerifiedBlockInformation, ExtendedConsensusError>
+) -> Result<VerifiedBlock, ExtendedConsensusError>
 where
     D: Database + Clone + Send + 'static,
 {
+    let (mut txs, precomputed_kis) = match txs {
+        PreparedBlockTxs::Unchecked(txs) => (txs, None),
+        PreparedBlockTxs::Checked(twk) => (twk.txs, Some(twk.spent_key_images)),
+    };
+
     let context = context_svc.blockchain_context();
 
     tracing::debug!("verifying block: {}", hex::encode(prepped_block.block_hash));
@@ -268,14 +303,16 @@ where
         return Err(ExtendedConsensusError::TxsIncludedWithBlockIncorrect);
     }
 
-    if !prepped_block.block.transactions.is_empty() {
+    let spent_key_images = if prepped_block.block.transactions.is_empty() {
+        precomputed_kis.unwrap_or_default()
+    } else {
         for (expected_tx_hash, tx) in prepped_block.block.transactions.iter().zip(txs.iter()) {
             if expected_tx_hash != &tx.tx_hash {
                 return Err(ExtendedConsensusError::TxsIncludedWithBlockIncorrect);
             }
         }
 
-        let temp = start_tx_verification()
+        let (verified_txs, kis) = start_tx_verification()
             .append_prepped_txs(mem::take(&mut txs))
             .prepare()?
             .full(
@@ -286,11 +323,11 @@ where
                 database,
                 batch_prep_cache.as_deref(),
             )
-            .verify()
+            .verify_with_kis(precomputed_kis)
             .await?;
-
-        txs = temp;
-    }
+        txs = verified_txs;
+        kis
+    };
 
     let block_weight =
         prepped_block.miner_tx_weight + txs.iter().map(|tx| tx.tx_weight).sum::<usize>();
@@ -306,7 +343,7 @@ where
     )
     .map_err(ConsensusError::Block)?;
 
-    let block = VerifiedBlockInformation {
+    let info = VerifiedBlockInformation {
         block_hash: prepped_block.block_hash,
         block: prepped_block.block,
         block_blob: prepped_block.block_blob,
@@ -336,8 +373,11 @@ where
     };
 
     if let Some(batch_prep_cache) = batch_prep_cache {
-        batch_prep_cache.output_cache.add_block_to_cache(&block);
+        batch_prep_cache.output_cache.add_block_to_cache(&info);
     }
 
-    Ok(block)
+    Ok(VerifiedBlock {
+        info,
+        spent_key_images,
+    })
 }

--- a/consensus/src/block.rs
+++ b/consensus/src/block.rs
@@ -37,7 +37,7 @@ mod alt_block;
 mod batch_prepare;
 mod free;
 
-pub use alt_block::sanity_check_alt_block;
+pub use alt_block::{alt_block_to_verified_block, sanity_check_alt_block};
 pub use batch_prepare::{batch_prepare_main_chain_blocks, BatchPrepareCache};
 use free::pull_ordered_transactions;
 
@@ -240,13 +240,37 @@ impl PreparedBlock {
     }
 }
 
+/// A block's ordered transactions paired with the key images they spend.
+#[derive(Debug)]
+pub struct TxsWithKis {
+    pub(crate) txs: Vec<TransactionVerificationData>,
+    pub(crate) spent_key_images: Vec<[u8; 32]>,
+}
+
+/// A verified block paired with its spent key images.
+#[derive(Debug)]
+pub struct VerifiedBlock {
+    pub info: VerifiedBlockInformation,
+    pub spent_key_images: Vec<[u8; 32]>,
+}
+
+/// Ordered transactions for a prepared block.
+#[derive(Debug)]
+pub enum PreparedBlockTxs {
+    /// Transactions whose key images have not yet been checked.
+    Unchecked(Vec<TransactionVerificationData>),
+    /// Transactions with key images already checked unique within the batch and
+    /// unspent in the chain.
+    Checked(TxsWithKis),
+}
+
 /// Fully verify a block and all its transactions.
 pub async fn verify_main_chain_block<D>(
     block: Block,
     txs: HashMap<[u8; 32], TransactionVerificationData>,
     context_svc: &mut BlockchainContextService,
     database: D,
-) -> Result<VerifiedBlockInformation, BlockVerificationError>
+) -> Result<VerifiedBlock, BlockVerificationError>
 where
     D: Database + Clone + Send + 'static,
 {
@@ -298,7 +322,7 @@ where
 
     verify_prepped_main_chain_block(
         prepped_block,
-        ordered_txs,
+        PreparedBlockTxs::Unchecked(ordered_txs),
         context_svc,
         &mut VerificationContext::Database(database),
     )
@@ -308,13 +332,18 @@ where
 /// Fully verify a block that has already been prepared using [`batch_prepare_main_chain_blocks`].
 pub async fn verify_prepped_main_chain_block<D>(
     prepped_block: PreparedBlock,
-    mut txs: Vec<TransactionVerificationData>,
+    txs: PreparedBlockTxs,
     context_svc: &mut BlockchainContextService,
     verification_context: &mut VerificationContext<D>,
-) -> Result<VerifiedBlockInformation, BlockVerificationError>
+) -> Result<VerifiedBlock, BlockVerificationError>
 where
     D: Database + Clone + Send + 'static,
 {
+    let (mut txs, mut spent_key_images, collect_key_images) = match txs {
+        PreparedBlockTxs::Unchecked(txs) => (txs, Vec::new(), true),
+        PreparedBlockTxs::Checked(twk) => (twk.txs, twk.spent_key_images, false),
+    };
+
     let context = context_svc.blockchain_context();
 
     tracing::debug!("verifying block: {}", hex::encode(prepped_block.block_hash));
@@ -338,7 +367,7 @@ where
             }
         }
 
-        let temp = start_tx_verification()
+        txs = start_tx_verification()
             .append_prepped_txs(mem::take(&mut txs))
             .prepare()
             .map_err(BlockVerificationError::valid_pow)?
@@ -349,11 +378,9 @@ where
                 context.current_hf,
                 verification_context,
             )
-            .verify()
+            .verify(collect_key_images.then_some(&mut spent_key_images))
             .await
             .map_err(BlockVerificationError::valid_pow)?;
-
-        txs = temp;
     }
 
     let block_weight =
@@ -371,7 +398,7 @@ where
     .map_err(ConsensusError::Block)
     .map_err(BlockVerificationError::valid_pow)?;
 
-    let block = VerifiedBlockInformation {
+    let info = VerifiedBlockInformation {
         block_hash: prepped_block.block_hash,
         block: prepped_block.block,
         block_blob: prepped_block.block_blob,
@@ -401,8 +428,11 @@ where
     };
 
     if let VerificationContext::BatchPrepareCache(batch_prep_cache) = verification_context {
-        batch_prep_cache.output_cache.add_block_to_cache(&block);
+        batch_prep_cache.output_cache.add_block_to_cache(&info);
     }
 
-    Ok(block)
+    Ok(VerifiedBlock {
+        info,
+        spent_key_images,
+    })
 }

--- a/consensus/src/block/alt_block.rs
+++ b/consensus/src/block/alt_block.rs
@@ -11,7 +11,8 @@ use cuprate_consensus_context::{
     difficulty::DifficultyCache,
     rx_vms::RandomXVm,
     weight::{self, BlockWeightsCache},
-    AltChainContextCache, AltChainRequestToken, BLOCKCHAIN_TIMESTAMP_CHECK_WINDOW,
+    AltChainContextCache, AltChainRequestToken, BlockchainContext,
+    BLOCKCHAIN_TIMESTAMP_CHECK_WINDOW,
 };
 use cuprate_consensus_rules::{
     blocks::{
@@ -22,12 +23,12 @@ use cuprate_consensus_rules::{
 };
 use cuprate_helper::{asynch::rayon_spawn_async, cast::u64_to_usize};
 use cuprate_types::{
-    AltBlockInformation, Chain, ChainId, TransactionVerificationData,
+    AltBlockInformation, Chain, ChainId, TransactionVerificationData, VerifiedBlockInformation,
     VerifiedTransactionInformation,
 };
 
 use crate::{
-    block::{free::pull_ordered_transactions, PreparedBlock},
+    block::{free::pull_ordered_transactions, PreparedBlock, VerifiedBlock},
     BlockChainContextRequest, BlockChainContextResponse, ExtendedConsensusError,
 };
 
@@ -310,5 +311,57 @@ where
 
             Ok(weight_cache.insert(cache))
         }
+    }
+}
+
+/// Creates a new [`VerifiedBlock`] from a previously-verified [`AltBlockInformation`].
+///
+/// `block.height` must match `blockchain_ctx.chain_height` or this will panic.
+pub fn alt_block_to_verified_block(
+    block: AltBlockInformation,
+    blockchain_ctx: &BlockchainContext,
+) -> VerifiedBlock {
+    assert_eq!(
+        block.height, blockchain_ctx.chain_height,
+        "alt-block invalid"
+    );
+
+    let mut total_fees: u64 = 0;
+    let mut spent_key_images =
+        Vec::with_capacity(block.txs.iter().map(|tx| tx.tx.prefix().inputs.len()).sum());
+    for tx in &block.txs {
+        total_fees += tx.fee;
+        spent_key_images.extend(tx.tx.prefix().inputs.iter().map(|input| match input {
+            Input::ToKey { key_image, .. } => key_image.to_bytes(),
+            Input::Gen(_) => unreachable!(),
+        }));
+    }
+
+    let total_outputs = block
+        .block
+        .miner_transaction()
+        .prefix()
+        .outputs
+        .iter()
+        .map(|output| output.amount.unwrap_or(0))
+        .sum::<u64>();
+
+    let generated_coins = total_outputs - total_fees;
+
+    VerifiedBlock {
+        info: VerifiedBlockInformation {
+            block_blob: block.block_blob,
+            txs: block.txs,
+            block_hash: block.block_hash,
+            pow_hash: [u8::MAX; 32],
+            height: block.height,
+            generated_coins,
+            weight: block.weight,
+            long_term_weight: blockchain_ctx.next_block_long_term_weight(block.weight),
+            cumulative_difficulty: blockchain_ctx.cumulative_difficulty
+                + blockchain_ctx.next_difficulty,
+            block: block.block,
+        },
+        spent_key_images,
     }
 }

--- a/consensus/src/block/alt_block.rs
+++ b/consensus/src/block/alt_block.rs
@@ -11,7 +11,8 @@ use cuprate_consensus_context::{
     difficulty::DifficultyCache,
     rx_vms::RandomXVm,
     weight::{self, BlockWeightsCache},
-    AltChainContextCache, AltChainRequestToken, BLOCKCHAIN_TIMESTAMP_CHECK_WINDOW,
+    AltChainContextCache, AltChainRequestToken, BlockchainContext,
+    BLOCKCHAIN_TIMESTAMP_CHECK_WINDOW,
 };
 use cuprate_consensus_rules::{
     blocks::{
@@ -20,14 +21,16 @@ use cuprate_consensus_rules::{
     miner_tx::MinerTxError,
     ConsensusError,
 };
-use cuprate_helper::{asynch::rayon_spawn_async, cast::u64_to_usize};
+use cuprate_helper::{asynch::rayon_spawn_async, cast::u64_to_usize, tx::tx_key_images};
 use cuprate_types::{
-    AltBlockInformation, Chain, ChainId, TransactionVerificationData,
+    AltBlockInformation, Chain, ChainId, TransactionVerificationData, VerifiedBlockInformation,
     VerifiedTransactionInformation,
 };
 
 use crate::{
-    block::{free::pull_ordered_transactions, BlockVerificationError, PreparedBlock},
+    block::{
+        free::pull_ordered_transactions, BlockVerificationError, PreparedBlock, VerifiedBlock,
+    },
     BlockChainContextRequest, BlockChainContextResponse, ExtendedConsensusError,
 };
 
@@ -338,5 +341,53 @@ where
 
             Ok(weight_cache.insert(cache))
         }
+    }
+}
+
+/// Creates a new [`VerifiedBlock`] from a previously-verified [`AltBlockInformation`].
+///
+/// `block.height` must match `blockchain_ctx.chain_height` or this will panic.
+pub fn alt_block_to_verified_block(
+    block: AltBlockInformation,
+    blockchain_ctx: &BlockchainContext,
+) -> VerifiedBlock {
+    assert_eq!(
+        block.height, blockchain_ctx.chain_height,
+        "alt-block invalid"
+    );
+
+    let total_fees = block.txs.iter().map(|tx| tx.fee).sum::<u64>();
+    let spent_key_images = block
+        .txs
+        .iter()
+        .flat_map(|tx| tx_key_images(tx.tx.prefix()))
+        .collect();
+
+    let total_outputs = block
+        .block
+        .miner_transaction()
+        .prefix()
+        .outputs
+        .iter()
+        .map(|output| output.amount.unwrap_or(0))
+        .sum::<u64>();
+
+    let generated_coins = total_outputs - total_fees;
+
+    VerifiedBlock {
+        info: VerifiedBlockInformation {
+            block_blob: block.block_blob,
+            txs: block.txs,
+            block_hash: block.block_hash,
+            pow_hash: [u8::MAX; 32],
+            height: block.height,
+            generated_coins,
+            weight: block.weight,
+            long_term_weight: blockchain_ctx.next_block_long_term_weight(block.weight),
+            cumulative_difficulty: blockchain_ctx.cumulative_difficulty
+                + blockchain_ctx.next_difficulty,
+            block: block.block,
+        },
+        spent_key_images,
     }
 }

--- a/consensus/src/block/batch_prepare.rs
+++ b/consensus/src/block/batch_prepare.rs
@@ -12,14 +12,14 @@ use cuprate_consensus_rules::{
     miner_tx::MinerTxError,
     ConsensusError, HardFork,
 };
-use cuprate_helper::asynch::rayon_spawn_async;
-use cuprate_types::{output_cache::OutputCache, TransactionVerificationData};
+use cuprate_helper::{asynch::rayon_spawn_async, tx::tx_key_images};
+use cuprate_types::output_cache::OutputCache;
 
 use crate::{
     __private::Database,
     batch_verifier::MultiThreadedBatchVerifier,
-    block::{free::order_transactions, PreparedBlock, PreparedBlockExPow},
-    transactions::{check_kis_unique, contextual_data::get_output_cache, start_tx_verification},
+    block::{free::order_transactions, PreparedBlock, PreparedBlockExPow, TxsWithKis},
+    transactions::{check_kis, contextual_data::get_output_cache, start_tx_verification},
     BlockChainContextRequest, BlockChainContextResponse, ExtendedConsensusError,
 };
 
@@ -29,25 +29,15 @@ use crate::{
 /// other blocks.
 pub struct BatchPrepareCache {
     pub(crate) output_cache: OutputCache,
-    /// [`true`] if all the key images in the batch have been checked for double spends in the batch and
-    /// the whole chain.
-    pub(crate) key_images_spent_checked: bool,
 }
 
 /// Batch prepares a list of blocks for verification.
 #[instrument(level = "debug", name = "batch_prep_blocks", skip_all, fields(amt = blocks.len()))]
-#[expect(clippy::type_complexity)]
 pub async fn batch_prepare_main_chain_blocks<D: Database>(
     blocks: Vec<(Block, Vec<Transaction>)>,
     context_svc: &mut BlockchainContextService,
     mut database: D,
-) -> Result<
-    (
-        Vec<(PreparedBlock, Vec<TransactionVerificationData>)>,
-        BatchPrepareCache,
-    ),
-    ExtendedConsensusError,
-> {
+) -> Result<(Vec<(PreparedBlock, TxsWithKis)>, BatchPrepareCache), ExtendedConsensusError> {
     let (blocks, txs): (Vec<_>, Vec<_>) = blocks.into_iter().unzip();
 
     tracing::debug!("Calculating block hashes.");
@@ -197,7 +187,15 @@ pub async fn batch_prepare_main_chain_blocks<D: Database>(
                 // Order the txs correctly.
                 order_transactions(&block.block, &mut txs)?;
 
-                Ok((block, txs))
+                let spent_key_images = txs.iter().flat_map(|tx| tx_key_images(&tx.tx)).collect();
+
+                Ok((
+                    block,
+                    TxsWithKis {
+                        txs,
+                        spent_key_images,
+                    },
+                ))
             })
             .collect::<Result<Vec<_>, ExtendedConsensusError>>()?;
 
@@ -209,16 +207,20 @@ pub async fn batch_prepare_main_chain_blocks<D: Database>(
     })
     .await?;
 
-    check_kis_unique(blocks.iter().flat_map(|(_, txs)| txs.iter()), &mut database).await?;
+    check_kis(
+        blocks
+            .iter()
+            .flat_map(|(_, twk)| twk.spent_key_images.iter().copied()),
+        blocks
+            .iter()
+            .map(|(_, twk)| twk.spent_key_images.len())
+            .sum(),
+        &mut database,
+    )
+    .await?;
 
     let output_cache =
-        get_output_cache(blocks.iter().flat_map(|(_, txs)| txs.iter()), database).await?;
+        get_output_cache(blocks.iter().flat_map(|(_, twk)| twk.txs.iter()), database).await?;
 
-    Ok((
-        blocks,
-        BatchPrepareCache {
-            output_cache,
-            key_images_spent_checked: true,
-        },
-    ))
+    Ok((blocks, BatchPrepareCache { output_cache }))
 }

--- a/consensus/src/block/batch_prepare.rs
+++ b/consensus/src/block/batch_prepare.rs
@@ -12,14 +12,16 @@ use cuprate_consensus_rules::{
     miner_tx::MinerTxError,
     ConsensusError, HardFork,
 };
-use cuprate_helper::asynch::rayon_spawn_async;
-use cuprate_types::{output_cache::OutputCache, TransactionVerificationData};
+use cuprate_helper::{asynch::rayon_spawn_async, tx::tx_key_images};
+use cuprate_types::output_cache::OutputCache;
 
 use crate::{
     __private::Database,
     batch_verifier::MultiThreadedBatchVerifier,
-    block::{free::order_transactions, PreparedBlock, PreparedBlockExPow},
-    transactions::{check_kis_unique, contextual_data::get_output_cache, start_tx_verification},
+    block::{free::order_transactions, PreparedBlock, PreparedBlockExPow, TxsWithKis},
+    transactions::{
+        check_kis, contextual_data::get_output_cache, start_tx_verification, unique_kis,
+    },
     BlockChainContextRequest, BlockChainContextResponse, ExtendedConsensusError,
 };
 
@@ -33,18 +35,11 @@ pub struct BatchPrepareCache {
 
 /// Batch prepares a list of blocks for verification.
 #[instrument(level = "debug", name = "batch_prep_blocks", skip_all, fields(amt = blocks.len()))]
-#[expect(clippy::type_complexity)]
 pub async fn batch_prepare_main_chain_blocks<D: Database>(
     blocks: Vec<(Block, Vec<Transaction>)>,
     context_svc: &mut BlockchainContextService,
     mut database: D,
-) -> Result<
-    (
-        Vec<(PreparedBlock, Vec<TransactionVerificationData>)>,
-        BatchPrepareCache,
-    ),
-    ExtendedConsensusError,
-> {
+) -> Result<(Vec<(PreparedBlock, TxsWithKis)>, BatchPrepareCache), ExtendedConsensusError> {
     let (blocks, txs): (Vec<_>, Vec<_>) = blocks.into_iter().unzip();
 
     tracing::debug!("Calculating block hashes.");
@@ -194,7 +189,18 @@ pub async fn batch_prepare_main_chain_blocks<D: Database>(
                 // Order the txs correctly.
                 order_transactions(&block.block, &mut txs)?;
 
-                Ok((block, txs))
+                let spent_key_images = txs
+                    .iter()
+                    .flat_map(|tx| tx_key_images(tx.tx.prefix()))
+                    .collect();
+
+                Ok((
+                    block,
+                    TxsWithKis {
+                        txs,
+                        spent_key_images,
+                    },
+                ))
             })
             .collect::<Result<Vec<_>, ConsensusError>>()?;
 
@@ -206,10 +212,16 @@ pub async fn batch_prepare_main_chain_blocks<D: Database>(
     })
     .await?;
 
-    check_kis_unique(blocks.iter().flat_map(|(_, txs)| txs.iter()), &mut database).await?;
+    let spent_kis = unique_kis(
+        blocks
+            .iter()
+            .flat_map(|(_, twk)| twk.spent_key_images.iter().copied()),
+    )?;
+
+    check_kis(spent_kis, &mut database).await?;
 
     let output_cache =
-        get_output_cache(blocks.iter().flat_map(|(_, txs)| txs.iter()), database).await?;
+        get_output_cache(blocks.iter().flat_map(|(_, twk)| twk.txs.iter()), database).await?;
 
     Ok((blocks, BatchPrepareCache { output_cache }))
 }

--- a/consensus/src/transactions.rs
+++ b/consensus/src/transactions.rs
@@ -27,7 +27,7 @@
 //! ```
 use std::collections::HashSet;
 
-use monero_oxide::transaction::{Input, Timelock, Transaction};
+use monero_oxide::transaction::{Timelock, Transaction};
 use rayon::prelude::*;
 use tower::ServiceExt;
 
@@ -38,7 +38,7 @@ use cuprate_consensus_rules::{
     },
     ConsensusError, HardFork,
 };
-use cuprate_helper::asynch::rayon_spawn_async;
+use cuprate_helper::{asynch::rayon_spawn_async, tx::tx_key_images};
 use cuprate_types::{
     blockchain::{BlockchainReadRequest, BlockchainResponse},
     output_cache::OutputCache,
@@ -228,13 +228,43 @@ impl<D: Database + Clone> FullVerification<'_, D> {
     pub async fn verify(
         mut self,
     ) -> Result<Vec<TransactionVerificationData>, ExtendedConsensusError> {
-        if self
-            .batch_prep_cache
-            .is_none_or(|c| !c.key_images_spent_checked)
-        {
-            check_kis_unique(self.prepped_txs.iter(), &mut self.database).await?;
-        }
+        check_kis(
+            self.prepped_txs.iter().flat_map(|tx| tx_key_images(&tx.tx)),
+            self.prepped_txs
+                .iter()
+                .map(|tx| tx.tx.prefix().inputs.len())
+                .sum(),
+            &mut self.database,
+        )
+        .await?;
 
+        self.verify_inner().await
+    }
+
+    /// Fully verify each transaction, returning the spent key images.
+    ///
+    /// If `precomputed_kis` is [`Some`], those key images are returned as-is and the key
+    /// image checks are skipped.
+    pub(crate) async fn verify_with_kis(
+        mut self,
+        precomputed_kis: Option<Vec<[u8; 32]>>,
+    ) -> Result<(Vec<TransactionVerificationData>, Vec<[u8; 32]>), ExtendedConsensusError> {
+        let spent_kis = match precomputed_kis {
+            Some(kis) => kis,
+            None => extract_and_check_kis(&self.prepped_txs, &mut self.database).await?,
+        };
+
+        let verified_txs = self.verify_inner().await?;
+
+        Ok((verified_txs, spent_kis))
+    }
+
+    /// Run the verification of the transactions.
+    ///
+    /// The caller must have already checked the key images.
+    async fn verify_inner(
+        mut self,
+    ) -> Result<Vec<TransactionVerificationData>, ExtendedConsensusError> {
         let hashes_in_main_chain =
             hashes_referenced_in_main_chain(&self.prepped_txs, &mut self.database).await?;
 
@@ -279,25 +309,55 @@ impl<D: Database + Clone> FullVerification<'_, D> {
     }
 }
 
-/// Check that each key image used in each transaction is unique in the whole chain.
-pub(crate) async fn check_kis_unique<D: Database>(
-    mut txs: impl Iterator<Item = &TransactionVerificationData>,
+/// Check that each key image provided is unique in the whole chain.
+pub(crate) async fn check_kis<D: Database>(
+    key_images: impl IntoIterator<Item = [u8; 32]>,
+    capacity: usize,
     database: &mut D,
 ) -> Result<(), ExtendedConsensusError> {
-    let mut spent_kis = HashSet::with_capacity(txs.size_hint().1.unwrap_or(0) * 2);
+    let mut spent_kis = HashSet::with_capacity(capacity);
 
-    txs.try_for_each(|tx| {
-        tx.tx.prefix().inputs.iter().try_for_each(|input| {
-            if let Input::ToKey { key_image, .. } = input {
-                if !spent_kis.insert(key_image.to_bytes()) {
-                    tracing::debug!("Duplicate key image found in batch.");
-                    return Err(ConsensusError::Transaction(TransactionError::KeyImageSpent));
-                }
+    for ki in key_images {
+        if !spent_kis.insert(ki) {
+            tracing::debug!("Duplicate key image found in batch.");
+            return Err(ConsensusError::Transaction(TransactionError::KeyImageSpent).into());
+        }
+    }
+
+    check_kis_unspent(spent_kis, database).await
+}
+
+/// Extract the spent key images from `txs`, and check that they are unique in the whole chain.
+pub(crate) async fn extract_and_check_kis<D: Database>(
+    txs: &[TransactionVerificationData],
+    database: &mut D,
+) -> Result<Vec<[u8; 32]>, ExtendedConsensusError> {
+    let capacity = txs.iter().map(|tx| tx.tx.prefix().inputs.len()).sum();
+    let mut spent_kis = HashSet::with_capacity(capacity);
+    let mut captured = Vec::with_capacity(capacity);
+
+    for tx in txs {
+        for ki in tx_key_images(&tx.tx) {
+            if !spent_kis.insert(ki) {
+                tracing::debug!("Duplicate key image found in batch.");
+                return Err(ConsensusError::Transaction(TransactionError::KeyImageSpent).into());
             }
+            captured.push(ki);
+        }
+    }
 
-            Ok(())
-        })
-    })?;
+    check_kis_unspent(spent_kis, database).await?;
+    Ok(captured)
+}
+
+/// Check that none of `spent_kis` have been spent in the chain.
+async fn check_kis_unspent<D: Database>(
+    spent_kis: HashSet<[u8; 32]>,
+    database: &mut D,
+) -> Result<(), ExtendedConsensusError> {
+    if spent_kis.is_empty() {
+        return Ok(());
+    }
 
     let BlockchainResponse::KeyImagesSpent(kis_spent) = database
         .ready()

--- a/consensus/src/transactions.rs
+++ b/consensus/src/transactions.rs
@@ -27,7 +27,7 @@
 //! ```
 use std::collections::HashSet;
 
-use monero_oxide::transaction::{Input, Timelock, Transaction};
+use monero_oxide::transaction::{Timelock, Transaction};
 use rayon::prelude::*;
 use tower::ServiceExt;
 
@@ -38,7 +38,7 @@ use cuprate_consensus_rules::{
     },
     ConsensusError, HardFork,
 };
-use cuprate_helper::asynch::rayon_spawn_async;
+use cuprate_helper::{asynch::rayon_spawn_async, tx::tx_key_images};
 use cuprate_types::{
     blockchain::{BlockchainReadRequest, BlockchainResponse},
     CachedVerificationState, TransactionVerificationData, TxVersion,
@@ -219,13 +219,30 @@ pub struct FullVerification<'a, D> {
 }
 
 impl<D: Database + Clone> FullVerification<'_, D> {
-    /// Fully verify each transaction.
+    /// Fully verify each transaction, optionally collecting the key images they spend.
     pub async fn verify(
         mut self,
+        mut spent_key_images: Option<&mut Vec<[u8; 32]>>,
     ) -> Result<Vec<TransactionVerificationData>, ExtendedConsensusError> {
+        if let VerificationContext::Database(database) = &mut self.verification_context {
+            check_kis(
+                unique_kis(
+                    self.prepped_txs
+                        .iter()
+                        .flat_map(|tx| tx_key_images(tx.tx.prefix()))
+                        .inspect(|ki| {
+                            if let Some(spent_key_images) = &mut spent_key_images {
+                                spent_key_images.push(*ki);
+                            }
+                        }),
+                )?,
+                database,
+            )
+            .await?;
+        }
+
         let hashes_in_main_chain =
             if let VerificationContext::Database(database) = &mut self.verification_context {
-                check_kis_unique(self.prepped_txs.iter(), database).await?;
                 hashes_referenced_in_main_chain(&self.prepped_txs, database).await?
             } else {
                 HashSet::new()
@@ -270,25 +287,30 @@ impl<D: Database + Clone> FullVerification<'_, D> {
     }
 }
 
-/// Check that each key image used in each transaction is unique in the whole chain.
-pub(crate) async fn check_kis_unique<D: Database>(
-    mut txs: impl Iterator<Item = &TransactionVerificationData>,
+/// Collect the key images, erroring if any is a duplicate within the batch.
+pub(crate) fn unique_kis(
+    key_images: impl IntoIterator<Item = [u8; 32]>,
+) -> Result<HashSet<[u8; 32]>, ConsensusError> {
+    let mut spent_kis = HashSet::new();
+
+    for ki in key_images {
+        if !spent_kis.insert(ki) {
+            tracing::debug!("Duplicate key image found in batch.");
+            return Err(ConsensusError::Transaction(TransactionError::KeyImageSpent));
+        }
+    }
+
+    Ok(spent_kis)
+}
+
+/// Check that none of the key images are already spent in the whole chain.
+pub(crate) async fn check_kis<D: Database>(
+    spent_kis: HashSet<[u8; 32]>,
     database: &mut D,
 ) -> Result<(), ExtendedConsensusError> {
-    let mut spent_kis = HashSet::with_capacity(txs.size_hint().1.unwrap_or(0) * 2);
-
-    txs.try_for_each(|tx| {
-        tx.tx.prefix().inputs.iter().try_for_each(|input| {
-            if let Input::ToKey { key_image, .. } = input {
-                if !spent_kis.insert(key_image.to_bytes()) {
-                    tracing::debug!("Duplicate key image found in batch.");
-                    return Err(ConsensusError::Transaction(TransactionError::KeyImageSpent));
-                }
-            }
-
-            Ok(())
-        })
-    })?;
+    if spent_kis.is_empty() {
+        return Ok(());
+    }
 
     let BlockchainResponse::KeyImagesSpent(kis_spent) = database
         .ready()

--- a/consensus/tests/verify_correct_txs.rs
+++ b/consensus/tests/verify_correct_txs.rs
@@ -97,7 +97,7 @@ macro_rules! test_verify_valid_v2_tx {
                 .prepare()
                 .unwrap()
                 .full(10, [0; 32], u64::MAX, HardFork::$hf, &mut VerificationContext::Database(database.clone()))
-                .verify()
+                .verify(None)
                 .await.is_ok()
             );
 
@@ -125,7 +125,7 @@ macro_rules! test_verify_valid_v2_tx {
                 .prepare()
                 .unwrap()
                 .full(10, [0; 32], u64::MAX, HardFork::$hf, &mut VerificationContext::Database(database.clone()))
-                .verify()
+                .verify(None)
                 .await.is_err()
             );
 

--- a/helper/src/tx.rs
+++ b/helper/src/tx.rs
@@ -2,6 +2,14 @@
 
 use monero_oxide::transaction::{Input, Transaction};
 
+/// Iterates the spent key images of the [`Transaction`].
+pub fn tx_key_images(tx: &Transaction) -> impl Iterator<Item = [u8; 32]> + '_ {
+    tx.prefix().inputs.iter().filter_map(|input| match input {
+        Input::ToKey { key_image, .. } => Some(key_image.to_bytes()),
+        Input::Gen(_) => None,
+    })
+}
+
 /// Calculates the fee of the [`Transaction`].
 ///
 /// # Panics

--- a/helper/src/tx.rs
+++ b/helper/src/tx.rs
@@ -1,6 +1,14 @@
 //! Utils for working with [`Transaction`]
 
-use monero_oxide::transaction::{Input, Transaction};
+use monero_oxide::transaction::{Input, Transaction, TransactionPrefix};
+
+/// Iterates the spent key images of the [`TransactionPrefix`].
+pub fn tx_key_images(prefix: &TransactionPrefix) -> impl Iterator<Item = [u8; 32]> + '_ {
+    prefix.inputs.iter().filter_map(|input| match input {
+        Input::ToKey { key_image, .. } => Some(key_image.to_bytes()),
+        Input::Gen(_) => None,
+    })
+}
 
 /// Calculates the fee of the [`Transaction`].
 ///


### PR DESCRIPTION
### What
Addresses the FIXME in `add_valid_block_to_main_chain`.

### Why
Block verification in consensus walks every transaction's inputs to dedupe and check key images. After verification, cuprated walked them a second time to notify the txpool.

This makes it so that the KI vec is returned from consensus, eliminating the second walk.

### Where
consensus, helper, cuprated

### How
In `helper`:
- New `tx_key_images()` helper for extracting a transactions key images

In `consensus`:
- Batch preparation now returns `TxsWithKis` per block (transactions + validated key images).
- The verify functions now return `VerifiedBlock` (wrapper for verified block info + the spent key images).
- `verify_prepped_main_chain_block` takes a `PreparedBlockTxs::{Checked, Unchecked}` enum so the caller can say whether key images still need checking:
  -  `Unchecked(Vec<TransactionVerificationData>)` - single-block path. Extracts KIs and checks.
  - `Checked(TxsWithKis)` - batch-sync path. `TxsWithKis` is only produced by `batch_prepare_main_chain_blocks` where validation was already done, so we skip checking here and use the passed KIs as is.
- Split `FullVerification` into two methods, so the txpool path doesn't allocate a key-image Vec it would discard:
  - `verify` (txpool): returns just the transactions.
  - `verify_with_kis` (block, internal): returns transactions and key images.
- Key-image checking seperated into three:
  - `check_kis`: used by the batch & txpool paths. Takes pre-computed key images.
  - `extract_and_check_kis`: single-block path. Walks inputs once and builds both the KI dedup set and Vec in one pass.
  - `check_kis_unspent`: shared chain-spent db query, skipped on a empty set.
- `key_images_spent_checked` bool removed from `BatchPrepareCache`. The existence of `TxsWithKis` means that the key images were checked, so this becomes redundant.
- Capacity hint change: `check_kis_unique`'s old `with_capacity(size_hint().1.unwrap_or(0) * 2)` always resolved to zero for the batch caller, because [when `flat_map` is used on a slice iter, the upper-bound size hint is always `None`](https://users.rust-lang.org/t/how-can-i-make-flatmap-size-hint-use-my-iterators-size-hint/112891/2). To avoid rehashing, we count the KIs once up front and pass capacity as a param.
- New `alt_block_to_verified_block` replaces cuprated's `alt_block_to_verified_block_information`. Computes `total_fees` and `spent_key_images` in one pass, then constructs a `VerifiedBlock`.

In `cuprated`:
- `add_valid_block_to_main_chain` splits the new `VerifiedBlock` into block information and key images, used like before.
- The reorg-reverse path now calls the new `alt_block_to_verified_block` in consensus; the local helper is removed.