### PR TITLE
cuprated: add private file permissions for Windows

### DIFF
--- a/binaries/cuprated/src/config.rs
+++ b/binaries/cuprated/src/config.rs
@@ -235,6 +235,20 @@ impl Config {
         format!("{HEADER}{doc}")
     }
 
+    /// Returns the directories cuprate writes to.
+    pub fn writable_directories(&self) -> Vec<&Path> {
+        let mut paths = vec![
+            self.fs.fast_data_directory.as_path(),
+            self.fs.slow_data_directory.as_path(),
+            self.fs.cache_directory.as_path(),
+        ];
+        #[cfg(feature = "arti")]
+        if matches!(self.tor.mode, TorMode::Arti | TorMode::Auto) {
+            paths.push(self.tor.arti.directory_path.as_path());
+        }
+        paths
+    }
+
     /// Attempts to read a config file in [`toml`] format from the given [`Path`].
     ///
     /// # Errors
@@ -496,38 +510,10 @@ impl Config {
             });
         }
 
-        results.push(DryRunResult {
-            description: format!(
-                "File permissions are valid at {}",
-                self.fs.fast_data_directory.display()
-            ),
-            result: Self::check_dir_permissions(&self.fs.fast_data_directory),
-        });
-
-        results.push(DryRunResult {
-            description: format!(
-                "File permissions are valid at {}",
-                self.fs.slow_data_directory.display()
-            ),
-            result: Self::check_dir_permissions(&self.fs.slow_data_directory),
-        });
-
-        results.push(DryRunResult {
-            description: format!(
-                "File permissions are valid at {}",
-                self.fs.cache_directory.display()
-            ),
-            result: Self::check_dir_permissions(&self.fs.cache_directory),
-        });
-
-        #[cfg(feature = "arti")]
-        if matches!(self.tor.mode, TorMode::Arti | TorMode::Auto) {
+        for path in self.writable_directories() {
             results.push(DryRunResult {
-                description: format!(
-                    "File permissions are valid at {}",
-                    self.tor.arti.directory_path.display()
-                ),
-                result: Self::check_dir_permissions(&self.tor.arti.directory_path),
+                description: format!("File permissions are valid at {}", path.display()),
+                result: Self::check_dir_permissions(path),
             });
         }
 

--- a/binaries/cuprated/src/config.rs
+++ b/binaries/cuprated/src/config.rs
@@ -243,6 +243,20 @@ impl Config {
         format!("{HEADER}{doc}")
     }
 
+    /// Returns the directories cuprate writes to.
+    pub fn writable_directories(&self) -> Vec<&Path> {
+        let mut paths = vec![
+            self.fs.fast_data_directory.as_path(),
+            self.fs.slow_data_directory.as_path(),
+            self.fs.cache_directory.as_path(),
+        ];
+        #[cfg(feature = "arti")]
+        if matches!(self.tor.mode, TorMode::Arti | TorMode::Auto) {
+            paths.push(self.tor.arti.directory_path.as_path());
+        }
+        paths
+    }
+
     /// Attempts to read a config file in [`toml`] format from the given [`Path`].
     ///
     /// # Errors
@@ -518,38 +532,10 @@ impl Config {
             });
         }
 
-        results.push(DryRunResult {
-            description: format!(
-                "File permissions are valid at {}",
-                self.fs.fast_data_directory.display()
-            ),
-            result: Self::check_dir_permissions(&self.fs.fast_data_directory),
-        });
-
-        results.push(DryRunResult {
-            description: format!(
-                "File permissions are valid at {}",
-                self.fs.slow_data_directory.display()
-            ),
-            result: Self::check_dir_permissions(&self.fs.slow_data_directory),
-        });
-
-        results.push(DryRunResult {
-            description: format!(
-                "File permissions are valid at {}",
-                self.fs.cache_directory.display()
-            ),
-            result: Self::check_dir_permissions(&self.fs.cache_directory),
-        });
-
-        #[cfg(feature = "arti")]
-        if matches!(self.tor.mode, TorMode::Arti | TorMode::Auto) {
+        for path in self.writable_directories() {
             results.push(DryRunResult {
-                description: format!(
-                    "File permissions are valid at {}",
-                    self.tor.arti.directory_path.display()
-                ),
-                result: Self::check_dir_permissions(&self.tor.arti.directory_path),
+                description: format!("File permissions are valid at {}", path.display()),
+                result: Self::check_dir_permissions(path),
             });
         }
 

--- a/binaries/cuprated/src/main.rs
+++ b/binaries/cuprated/src/main.rs
@@ -46,6 +46,7 @@ use crate::{
 
 fn main() {
     // Set global private permissions for created files.
+    #[cfg(target_family = "unix")]
     cuprate_helper::fs::set_private_global_file_permissions();
 
     // Parse CLI args and read config.
@@ -175,6 +176,9 @@ fn load_config(args: &Args) -> Config {
     };
 
     let config = args.apply_args(config);
+
+    #[cfg(target_os = "windows")]
+    cuprate_helper::fs::set_private_directory_permissions(&config.writable_directories());
 
     if args.dry_run {
         let results = config.dry_run_check();

--- a/binaries/cuprated/src/main.rs
+++ b/binaries/cuprated/src/main.rs
@@ -50,6 +50,7 @@ fn main() -> ExitCode {
 
 fn main_inner() -> anyhow::Result<ExitCode> {
     // Set global private permissions for created files.
+    #[cfg(target_family = "unix")]
     cuprate_helper::fs::set_private_global_file_permissions();
 
     // Parse CLI args and read config.
@@ -57,6 +58,9 @@ fn main_inner() -> anyhow::Result<ExitCode> {
     args.do_quick_requests();
 
     let mut config = load_config(&args)?;
+
+    #[cfg(target_os = "windows")]
+    cuprate_helper::fs::set_private_directory_permissions(&config.writable_directories())?;
 
     if args.dry_run {
         return Ok(dry_run_config(&config));

--- a/helper/Cargo.toml
+++ b/helper/Cargo.toml
@@ -43,7 +43,13 @@ serde            = { workspace = true, optional = true, features = ["derive"] }
 # [thread] needs to activate one of these libs (windows|libc)
 # although it depends on what target we're building for.
 [target.'cfg(windows)'.dependencies]
-target_os_lib = { package = "windows", version = ">=0.51", features = ["Win32_System_Threading", "Win32_Foundation"], optional = true }
+target_os_lib = { package = "windows", version = ">=0.57", features = [
+    "Win32_Foundation",
+    "Win32_Security",
+    "Win32_Security_Authorization",
+    "Win32_Storage_FileSystem",
+    "Win32_System_Threading",
+], optional = true }
 [target.'cfg(unix)'.dependencies]
 target_os_lib = { package = "libc", version = "0.2", optional = true }
 

--- a/helper/src/fs.rs
+++ b/helper/src/fs.rs
@@ -236,26 +236,27 @@ pub fn address_book_path(cache_dir: &Path, network: Network) -> PathBuf {
 // `rwxr-x---`
 //
 // # Windows
-// TODO: does nothing.
-#[cfg_attr(
-    target_os = "windows",
-    expect(
-        clippy::missing_const_for_fn,
-        reason = "remove when Windows is implemented"
-    )
-)]
+// Not available. Permissions are set on a per-directory basis in `set_private_directory_permissions`.
+#[cfg(target_family = "unix")]
 pub fn set_private_global_file_permissions() {
-    #[cfg(target_family = "unix")]
     // SAFETY: calling C.
     unsafe {
         target_os_lib::umask(0o027);
     }
+}
 
-    #[cfg(target_os = "windows")]
-    // TODO: impl for Windows.
-    {
-        use target_os_lib as _;
-    }
+// Apply private permissions to `roots`.
+//
+// # Windows
+// Restricts each newly-created directory to the current user, SYSTEM, and Administrators.
+//
+// # Unix
+// Not available. Permissions are set globally by `set_private_global_file_permissions`.
+#[cfg(target_os = "windows")]
+mod windows_perms;
+#[cfg(target_os = "windows")]
+pub fn set_private_directory_permissions(roots: &[&Path]) {
+    windows_perms::apply(roots);
 }
 
 //---------------------------------------------------------------------------------------------------- Tests

--- a/helper/src/fs.rs
+++ b/helper/src/fs.rs
@@ -236,26 +236,27 @@ pub fn address_book_path(cache_dir: &Path, network: Network) -> PathBuf {
 // `rwxr-x---`
 //
 // # Windows
-// TODO: does nothing.
-#[cfg_attr(
-    target_os = "windows",
-    expect(
-        clippy::missing_const_for_fn,
-        reason = "remove when Windows is implemented"
-    )
-)]
+// Not available. Permissions are set on a per-directory basis in `set_private_directory_permissions`.
+#[cfg(target_family = "unix")]
 pub fn set_private_global_file_permissions() {
-    #[cfg(target_family = "unix")]
     // SAFETY: calling C.
     unsafe {
         target_os_lib::umask(0o027);
     }
+}
 
-    #[cfg(target_os = "windows")]
-    // TODO: impl for Windows.
-    {
-        use target_os_lib as _;
-    }
+// Apply private permissions to `roots`.
+//
+// # Windows
+// Restricts each newly-created directory to the current user, SYSTEM, and Administrators.
+//
+// # Unix
+// Not available. Permissions are set globally by `set_private_global_file_permissions`.
+#[cfg(target_os = "windows")]
+mod windows_perms;
+#[cfg(target_os = "windows")]
+pub fn set_private_directory_permissions(roots: &[&Path]) -> target_os_lib::core::Result<()> {
+    windows_perms::apply(roots)
 }
 
 //---------------------------------------------------------------------------------------------------- Tests

--- a/helper/src/fs/windows_perms.rs
+++ b/helper/src/fs/windows_perms.rs
@@ -1,0 +1,158 @@
+//! Windows ACL implementation for [`super::set_private_directory_permissions`].
+
+//---------------------------------------------------------------------------------------------------- Use
+use std::ffi::OsStr;
+use std::os::windows::ffi::OsStrExt;
+use std::path::Path;
+use std::ptr;
+
+use target_os_lib::core::{Error, Owned, Result, PCWSTR, PWSTR};
+use target_os_lib::Win32::Foundation::{
+    ERROR_ALREADY_EXISTS, ERROR_INSUFFICIENT_BUFFER, E_UNEXPECTED, HANDLE, HLOCAL,
+};
+use target_os_lib::Win32::Security::Authorization::{
+    ConvertSidToStringSidW, ConvertStringSecurityDescriptorToSecurityDescriptorW, SDDL_REVISION_1,
+};
+use target_os_lib::Win32::Security::{
+    GetTokenInformation, TokenUser, PSECURITY_DESCRIPTOR, SECURITY_ATTRIBUTES, TOKEN_ACCESS_MASK,
+    TOKEN_QUERY, TOKEN_USER,
+};
+use target_os_lib::Win32::Storage::FileSystem::CreateDirectoryW;
+use target_os_lib::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
+
+//---------------------------------------------------------------------------------------------------- SecurityDescriptor
+/// Security descriptor parsed from SDDL, with its `LocalAlloc` buffer freed on drop.
+struct SecurityDescriptor {
+    psd: PSECURITY_DESCRIPTOR,
+    _buf: Owned<HLOCAL>,
+}
+
+impl SecurityDescriptor {
+    fn from_sddl(sddl: &str) -> Result<Self> {
+        let sddl_w = to_wide_nul(OsStr::new(sddl));
+        let mut psd = PSECURITY_DESCRIPTOR::default();
+        // SAFETY: `sddl_w` is null-terminated and `psd` is a valid out-pointer.
+        unsafe {
+            ConvertStringSecurityDescriptorToSecurityDescriptorW(
+                PCWSTR(sddl_w.as_ptr()),
+                SDDL_REVISION_1,
+                &raw mut psd,
+                None,
+            )
+        }?;
+        Ok(Self {
+            psd,
+            // SAFETY: `psd.0` is a `LocalAlloc` buffer, freed by `Owned` on drop.
+            _buf: unsafe { Owned::new(HLOCAL(psd.0)) },
+        })
+    }
+}
+
+//---------------------------------------------------------------------------------------------------- Apply
+/// Apply a private ACL to each path in `roots`.
+///
+/// SYSTEM and Administrators are granted access alongside the user so
+/// Windows backup, antivirus, and indexer services keep working.
+pub(super) fn apply(roots: &[&Path]) {
+    let user = match current_user_sid_string() {
+        Ok(u) => u,
+        Err(e) => {
+            eprintln!("warning: could not retrieve user SID: {e}");
+            return;
+        }
+    };
+    let sddl = format!("O:{user}D:P(A;OICI;FA;;;{user})(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)");
+    let sd = match SecurityDescriptor::from_sddl(&sddl) {
+        Ok(sd) => sd,
+        Err(e) => {
+            eprintln!("warning: could not parse Windows security descriptor: {e}");
+            return;
+        }
+    };
+
+    #[expect(clippy::cast_possible_truncation, reason = "struct size fits in u32")]
+    let sa = SECURITY_ATTRIBUTES {
+        nLength: size_of::<SECURITY_ATTRIBUTES>() as u32,
+        lpSecurityDescriptor: sd.psd.0,
+        bInheritHandle: false.into(),
+    };
+    for root in roots {
+        if let Err(e) = create_private_directory(root, &sa) {
+            eprintln!(
+                "warning: could not create private directory {}: {e}",
+                root.display()
+            );
+        }
+    }
+}
+
+//---------------------------------------------------------------------------------------------------- Helpers
+fn current_user_sid_string() -> Result<String> {
+    let token = open_process_token(TOKEN_QUERY)?;
+
+    let mut len: u32 = 0;
+    // SAFETY: probe call with a null buffer and a valid `len` out-pointer.
+    match unsafe { GetTokenInformation(*token, TokenUser, None, 0, &raw mut len) } {
+        Err(e) if e.code() == ERROR_INSUFFICIENT_BUFFER.to_hresult() => {}
+        Err(e) => return Err(e),
+        Ok(()) => return Err(Error::from_hresult(E_UNEXPECTED)),
+    }
+
+    // `u64` elements satisfy `TOKEN_USER`'s 8-byte alignment.
+    let mut buf: Vec<u64> = vec![0; (len as usize).div_ceil(size_of::<u64>())];
+    // SAFETY: `buf` is sized by the probe and aligned for `TOKEN_USER`.
+    unsafe {
+        GetTokenInformation(
+            *token,
+            TokenUser,
+            Some(buf.as_mut_ptr().cast()),
+            len,
+            &raw mut len,
+        )
+    }?;
+
+    // SAFETY: `buf` was populated as a `TOKEN_USER` by the call above.
+    let token_user = unsafe { &*buf.as_ptr().cast::<TOKEN_USER>() };
+    let mut sid_pwstr = PWSTR::null();
+    // SAFETY: `token_user.User.Sid` is valid and the out-pointer is owned.
+    unsafe { ConvertSidToStringSidW(token_user.User.Sid, &raw mut sid_pwstr) }?;
+    // SAFETY: `sid_pwstr.0` is a `LocalAlloc` buffer, freed by `Owned` on drop.
+    let _sid_guard = unsafe { Owned::new(HLOCAL(sid_pwstr.0.cast())) };
+
+    // SAFETY: `sid_pwstr` was populated above and holds a valid SID string.
+    unsafe { sid_pwstr.to_string() }.map_err(|_| Error::from_hresult(E_UNEXPECTED))
+}
+
+fn create_private_directory(path: &Path, sa: &SECURITY_ATTRIBUTES) -> Result<()> {
+    if path.is_dir() {
+        return Ok(());
+    }
+
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            create_private_directory(parent, sa)?;
+        }
+    }
+
+    let path_w = to_wide_nul(path.as_os_str());
+    // SAFETY: `path_w` is null-terminated and `sa` outlives the call.
+    unsafe { CreateDirectoryW(PCWSTR(path_w.as_ptr()), Some(ptr::from_ref(sa))) }.or_else(|e| {
+        if e.code() == ERROR_ALREADY_EXISTS.to_hresult() {
+            Ok(())
+        } else {
+            Err(e)
+        }
+    })
+}
+
+fn open_process_token(access: TOKEN_ACCESS_MASK) -> Result<Owned<HANDLE>> {
+    let mut token = HANDLE::default();
+    // SAFETY: `token` is a valid out-pointer and the handle becomes owned below.
+    unsafe { OpenProcessToken(GetCurrentProcess(), access, &raw mut token) }?;
+    // SAFETY: `OpenProcessToken` succeeded, so `token` is now an owned handle.
+    Ok(unsafe { Owned::new(token) })
+}
+
+fn to_wide_nul(s: &OsStr) -> Vec<u16> {
+    s.encode_wide().chain(std::iter::once(0)).collect()
+}

--- a/helper/src/fs/windows_perms.rs
+++ b/helper/src/fs/windows_perms.rs
@@ -1,0 +1,141 @@
+//! Windows ACL implementation for [`super::set_private_directory_permissions`].
+
+//---------------------------------------------------------------------------------------------------- Use
+use std::ffi::OsStr;
+use std::os::windows::ffi::OsStrExt;
+use std::path::Path;
+use std::ptr;
+
+use target_os_lib::core::{Error, Owned, Result, PCWSTR, PWSTR};
+use target_os_lib::Win32::Foundation::{
+    ERROR_ALREADY_EXISTS, ERROR_INSUFFICIENT_BUFFER, ERROR_PATH_NOT_FOUND, E_UNEXPECTED, HANDLE,
+    HLOCAL,
+};
+use target_os_lib::Win32::Security::Authorization::{
+    ConvertSidToStringSidW, ConvertStringSecurityDescriptorToSecurityDescriptorW, SDDL_REVISION_1,
+};
+use target_os_lib::Win32::Security::{
+    GetTokenInformation, TokenUser, PSECURITY_DESCRIPTOR, SECURITY_ATTRIBUTES, TOKEN_ACCESS_MASK,
+    TOKEN_QUERY, TOKEN_USER,
+};
+use target_os_lib::Win32::Storage::FileSystem::CreateDirectoryW;
+use target_os_lib::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
+
+//---------------------------------------------------------------------------------------------------- SecurityDescriptor
+/// Security descriptor parsed from SDDL, with its `LocalAlloc` buffer freed on drop.
+struct SecurityDescriptor {
+    psd: PSECURITY_DESCRIPTOR,
+    _buf: Owned<HLOCAL>,
+}
+
+impl SecurityDescriptor {
+    fn from_sddl(sddl: &str) -> Result<Self> {
+        let sddl_w = to_wide_nul(OsStr::new(sddl));
+        let mut psd = PSECURITY_DESCRIPTOR::default();
+        // SAFETY: `sddl_w` is null-terminated and `psd` is a valid out-pointer.
+        unsafe {
+            ConvertStringSecurityDescriptorToSecurityDescriptorW(
+                PCWSTR(sddl_w.as_ptr()),
+                SDDL_REVISION_1,
+                &raw mut psd,
+                None,
+            )
+        }?;
+        Ok(Self {
+            psd,
+            // SAFETY: `psd.0` is a `LocalAlloc` buffer, freed by `Owned` on drop.
+            _buf: unsafe { Owned::new(HLOCAL(psd.0)) },
+        })
+    }
+}
+
+//---------------------------------------------------------------------------------------------------- Apply
+/// Apply a private ACL to each path in `roots`.
+///
+/// SYSTEM and Administrators are granted access alongside the user so
+/// Windows backup, antivirus, and indexer services keep working.
+pub(super) fn apply(roots: &[&Path]) -> Result<()> {
+    let user = current_user_sid_string()?;
+    let sddl = format!("O:{user}D:P(A;OICI;FA;;;{user})(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)");
+    let sd = SecurityDescriptor::from_sddl(&sddl)?;
+
+    #[expect(clippy::cast_possible_truncation, reason = "struct size fits in u32")]
+    let sa = SECURITY_ATTRIBUTES {
+        nLength: size_of::<SECURITY_ATTRIBUTES>() as u32,
+        lpSecurityDescriptor: sd.psd.0,
+        bInheritHandle: false.into(),
+    };
+    roots
+        .iter()
+        .try_for_each(|root| create_private_directory(&std::path::absolute(root)?, &sa))
+}
+
+//---------------------------------------------------------------------------------------------------- Helpers
+fn current_user_sid_string() -> Result<String> {
+    let token = open_process_token(TOKEN_QUERY)?;
+
+    let mut len: u32 = 0;
+    // SAFETY: probe call with a null buffer and a valid `len` out-pointer.
+    match unsafe { GetTokenInformation(*token, TokenUser, None, 0, &raw mut len) } {
+        Err(e) if e.code() == ERROR_INSUFFICIENT_BUFFER.to_hresult() => {}
+        Err(e) => return Err(e),
+        Ok(()) => return Err(Error::from_hresult(E_UNEXPECTED)),
+    }
+
+    // `u64` elements satisfy `TOKEN_USER`'s 8-byte alignment.
+    let mut buf: Vec<u64> = vec![0; (len as usize).div_ceil(size_of::<u64>())];
+    // SAFETY: `buf` is sized by the probe and aligned for `TOKEN_USER`.
+    unsafe {
+        GetTokenInformation(
+            *token,
+            TokenUser,
+            Some(buf.as_mut_ptr().cast()),
+            len,
+            &raw mut len,
+        )
+    }?;
+
+    // SAFETY: `buf` was populated as a `TOKEN_USER` by the call above.
+    let token_user = unsafe { &*buf.as_ptr().cast::<TOKEN_USER>() };
+    let mut sid_pwstr = PWSTR::null();
+    // SAFETY: `token_user.User.Sid` is valid and the out-pointer is owned.
+    unsafe { ConvertSidToStringSidW(token_user.User.Sid, &raw mut sid_pwstr) }?;
+    // SAFETY: `sid_pwstr.0` is a `LocalAlloc` buffer, freed by `Owned` on drop.
+    let _sid_guard = unsafe { Owned::new(HLOCAL(sid_pwstr.0.cast())) };
+
+    // SAFETY: `sid_pwstr` was populated above and holds a valid SID string.
+    unsafe { sid_pwstr.to_string() }.map_err(|_| Error::from_hresult(E_UNEXPECTED))
+}
+
+fn create_private_directory(path: &Path, sa: &SECURITY_ATTRIBUTES) -> Result<()> {
+    let ancestor = path
+        .ancestors()
+        .find(|p| p.is_dir())
+        .ok_or_else(|| Error::from_hresult(ERROR_PATH_NOT_FOUND.to_hresult()))?;
+
+    let mut created = ancestor.canonicalize()?;
+    for name in path.strip_prefix(ancestor).unwrap() {
+        created.push(name);
+        let path_w = to_wide_nul(created.as_os_str());
+        // SAFETY: `path_w` is null-terminated and `sa` outlives the call.
+        let result = unsafe { CreateDirectoryW(PCWSTR(path_w.as_ptr()), Some(ptr::from_ref(sa))) };
+        if let Err(e) = result {
+            if e.code() != ERROR_ALREADY_EXISTS.to_hresult() || !created.is_dir() {
+                return Err(e);
+            }
+        }
+    }
+    Ok(())
+}
+
+fn open_process_token(access: TOKEN_ACCESS_MASK) -> Result<Owned<HANDLE>> {
+    let mut token = HANDLE::default();
+    // SAFETY: `token` is a valid out-pointer and the handle becomes owned below.
+    unsafe { OpenProcessToken(GetCurrentProcess(), access, &raw mut token) }?;
+    // SAFETY: `OpenProcessToken` succeeded, so `token` is now an owned handle.
+    Ok(unsafe { Owned::new(token) })
+}
+
+fn to_wide_nul(s: &OsStr) -> Vec<u16> {
+    s.encode_wide().chain(std::iter::once(0)).collect()
+}

--- a/typos.toml
+++ b/typos.toml
@@ -10,6 +10,8 @@ extend-ignore-identifiers-re = [
 	"RO",
 	"Ro",
 	"ro",
+	# SDDL alias for `BUILTIN\Administrators`
+	"BA",
 ]
 
 [files]


### PR DESCRIPTION
### What
Closes #551 by adding the Windows equivalent.

### Why
In cases where the data paths were outside of the current user's profile directory, files in cuprate's data directories could be read by other users on the same Windows machine.

### Where
`helper`
  - `fs/windows_perms.rs` - Looks up the current user's ID, builds the ACL, makes it the default for files cuprate creates, and makes each folder it creates with it.
  - `fs.rs` - `set_private_global_file_permisisons` is now Unix-only (Windows doesn't really have a 1-to-1 global equivalent). A new Windows-only `set_private_directory_permissions(roots: &[&Path])` passes the folder paths to `windows_perms::apply`. Each function only exists on the OS that needs it
  - `Cargo.toml` - added new create features from `windows` that are needed for this to work

`cuprated`
  - `config.rs` - new `Config::writable_directories()` returns the directories cuprate writes to. On Windows only, `read_config_and_args` calls `set_private_directory_permissions` once the paths are resolved. This also gave a opportunity to rewrite `check_dir_permissions` to loop over the new helper.
  - `main.rs` - `set_private_global_file_permissions` call is now Unix-only

### How
The SDDL string is `O:{user}D:P(A;OICI;FA;;;{user})(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)` ([syntax reference](https://learn.microsoft.com/en-us/windows/win32/secauthz/security-descriptor-string-format)):
| Part | Meaning |
|------|---------|
| `O:{user}` | Owner is the user 
| `D:P` | Start of the access list, with the "protected" flag so it does not inherit from the parent folder |
| `(A;OICI;FA;;;{user})` | Allow the user full access; sub-folders and files inherit it |
| `(A;OICI;FA;;;SY)` | Same for `SYSTEM` |
| `(A;OICI;FA;;;BA)` | Same for `BUILTIN\Administrators` |

Precedent: [Win32-OpenSSH](https://github.com/PowerShell/Win32-OpenSSH/wiki/Security-protection-of-various-files-in-Win32-OpenSSH)

---

Example with a path like `D:\Cuprate`:
<img width="868" height="715" alt="image" src="https://github.com/user-attachments/assets/cea45b37-bfe0-453b-8a60-2f97663398d5" />
