### PR TITLE
cuprate-consensus: Update rx_vms.rs

### DIFF
--- a/consensus/src/tests/context/rx_vms.rs
+++ b/consensus/src/tests/context/rx_vms.rs
@@ -37,7 +37,6 @@ fn rx_heights_consistent() {
 }
 
 #[tokio::test]
-#[expect(unused_qualifications, reason = "false positive in tokio macro")]
 async fn rx_vm_created_on_hf_12() {
     let db = DummyDatabaseBuilder::default().finish(Some(10));
 
@@ -53,7 +52,6 @@ async fn rx_vm_created_on_hf_12() {
 }
 
 #[tokio::test]
-#[expect(unused_qualifications, reason = "false positive in tokio macro")]
 async fn rx_vm_pop_blocks() {
     let db = DummyDatabaseBuilder::default().finish(Some(2_000_000));
 


### PR DESCRIPTION
```
warning: this lint expectation is unfulfilled
  --> consensus/src/tests/context/rx_vms.rs:40:10
   |
40 | #[expect(unused_qualifications, reason = "false positive in tokio macro")]
   |          ^^^^^^^^^^^^^^^^^^^^^
   |
   = note: false positive in tokio macro
   = note: `#[warn(unfulfilled_lint_expectations)]` on by default

warning: this lint expectation is unfulfilled
  --> consensus/src/tests/context/rx_vms.rs:56:10
   |
56 | #[expect(unused_qualifications, reason = "false positive in tokio macro")]
   |          ^^^^^^^^^^^^^^^^^^^^^
   |
   = note: false positive in tokio macro
```