### PR TITLE
cuprate-helper: Fix `RUST_BACKTRACE=1 cargo test -p cuprate-helper --lib fs::test::path_sanity_check`

### DIFF
--- a/helper/Cargo.toml
+++ b/helper/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/Cuprate/cuprate/tree/main/consensus"
 default   = []
 std       = []
 atomic    = ["dep:crossbeam"]
-asynch    = ["dep:futures", "dep:rayon"]
+asynch    = ["dep:futures", "dep:rayon", "dep:tokio"]
 cast      = []
 constants = []
 crypto    = ["dep:curve25519-dalek", "dep:monero-oxide", "std"]
@@ -38,6 +38,7 @@ monero-oxide     = { workspace = true, optional = true }
 rayon            = { workspace = true, optional = true }
 
 serde            = { workspace = true, optional = true, features = ["derive"] }
+tokio            = { workspace = true, optional = true, features = ["full"] }
 
 # This is kinda a stupid work around.
 # [thread] needs to activate one of these libs (windows|libc)
@@ -46,10 +47,6 @@ serde            = { workspace = true, optional = true, features = ["derive"] }
 target_os_lib = { package = "windows", version = ">=0.51", features = ["Win32_System_Threading", "Win32_Foundation"], optional = true }
 [target.'cfg(unix)'.dependencies]
 target_os_lib = { package = "libc", version = "0.2", optional = true }
-
-[dev-dependencies]
-tokio            = { workspace = true, features = ["full"] }
-curve25519-dalek = { workspace = true }
 
 [lints]
 workspace = true

--- a/helper/src/asynch.rs
+++ b/helper/src/asynch.rs
@@ -10,6 +10,7 @@ use core::{
 };
 
 use futures::{channel::oneshot, FutureExt};
+use tokio as _;
 
 //---------------------------------------------------------------------------------------------------- InfallibleOneshotReceiver
 /// A oneshot receiver channel that doesn't return an Error.


### PR DESCRIPTION
```
error: extern crate `curve25519_dalek` is unused in crate `cuprate_helper`
  |
  = help: remove the dependency or add `use curve25519_dalek as _;` to the crate root
  = note: requested on the command line with `-D unused-crate-dependencies`

error: extern crate `tokio` is unused in crate `cuprate_helper`
  |
  = help: remove the dependency or add `use tokio as _;` to the crate root

error: could not compile `cuprate-helper` (lib test) due to 2 previous errors
```

`cargo test` still fails `fs::test::path_sanity_check` (see https://github.com/Cuprate/cuprate/issues/610), but this fixed something.