### PR TITLE
cuprated: disable ANSI when not in a interactive terminal, adopt NO_COLOR

### DIFF
--- a/binaries/cuprated/src/logging.rs
+++ b/binaries/cuprated/src/logging.rs
@@ -4,6 +4,7 @@
 use std::ops::BitAnd;
 use std::{
     fmt::{Display, Formatter},
+    io::IsTerminal,
     mem::forget,
     sync::OnceLock,
 };
@@ -93,6 +94,7 @@ pub fn init_logging(config: &Config) {
 
     let stdout_layer = FmtLayer::default()
         .with_target(false)
+        .with_ansi(ansi_enabled(&std::io::stdout()))
         .with_filter(stdout_filter);
 
     // create the tracing appender.
@@ -143,5 +145,17 @@ pub fn modify_file_output(f: impl FnOnce(&mut CupratedTracingFilter)) {
 
 /// Prints some text using [`eprintln`], with [`nu_ansi_term::Color::Red`] applied.
 pub fn eprintln_red(s: &str) {
-    eprintln!("{}", nu_ansi_term::Color::Red.bold().paint(s));
+    if ansi_enabled(&std::io::stderr()) {
+        eprintln!("{}", nu_ansi_term::Color::Red.bold().paint(s));
+    } else {
+        eprintln!("{s}");
+    }
+}
+
+/// Whether to emit ANSI escape codes on `stream`.
+fn ansi_enabled(stream: &impl IsTerminal) -> bool {
+    if std::env::var_os("NO_COLOR").is_some_and(|v| !v.is_empty()) {
+        return false;
+    }
+    stream.is_terminal()
 }


### PR DESCRIPTION
### What
Closes #617 


### Why
When sending cuprate output to a file (`./cuprated > log`), ANSI codes were always sent through so the output contained garbage characters

```
�[2m2026-05-20T14:11:13.063522Z�[0m �[32m INFO�[0m Recovering database at /Users/red/Library/Application Support/Cuprate/fjall
```

Now:
```
2026-05-20T14:16:15.333730Z  INFO Recovering database at /Users/red/Library/Application Support/Cuprate/fjall
```

### Where
`cuprated`

### How
gate ANSI code usage with `std::io::stdout().is_terminal()`
adopts NO_COLOR environment usage for parity with monerod, disabling ANSI if it is set: https://github.com/monero-project/monero/issues/8688