### PR TITLE
p2p: TODO or add peer ban behaviour

### DIFF
--- a/binaries/cuprated/src/p2p/request_handler.rs
+++ b/binaries/cuprated/src/p2p/request_handler.rs
@@ -277,8 +277,8 @@ async fn fluffy_missing_txs<A: NetZoneAddress>(
     // deallocate the backing `Bytes`.
     drop(request);
 
-    let mut seen = HashSet::with_capacity(tx_indexes.len());
-    tx_indexes.iter().try_for_each(|idx| {
+    let mut seen = HashSet::new();
+    for idx in &tx_indexes {
         if !seen.insert(idx) {
             tracing::warn!(
                 "Peer requested duplicate tx index {} for block {}, banning peer.",
@@ -288,8 +288,7 @@ async fn fluffy_missing_txs<A: NetZoneAddress>(
             peer_information.handle.ban_peer(SHORT_BAN);
             anyhow::bail!("Peer requested duplicate tx indices.");
         }
-        Ok(())
-    })?;
+    }
 
     let BlockchainResponse::TxsInBlock(res) = blockchain_read_handle
         .ready()

--- a/binaries/cuprated/src/p2p/request_handler.rs
+++ b/binaries/cuprated/src/p2p/request_handler.rs
@@ -30,6 +30,7 @@ use cuprate_helper::{
 };
 use cuprate_p2p::constants::{
     MAX_BLOCKS_IDS_IN_CHAIN_ENTRY, MAX_BLOCK_BATCH_LEN, MAX_TRANSACTION_BLOB_SIZE, MEDIUM_BAN,
+    SHORT_BAN,
 };
 use cuprate_p2p_core::{
     client::{InternalPeerID, PeerInformation},
@@ -144,9 +145,12 @@ where
             ProtocolRequest::GetChain(r) => {
                 get_chain(r, self.blockchain_read_handle.clone()).boxed()
             }
-            ProtocolRequest::FluffyMissingTxs(r) => {
-                fluffy_missing_txs(r, self.blockchain_read_handle.clone()).boxed()
-            }
+            ProtocolRequest::FluffyMissingTxs(r) => fluffy_missing_txs(
+                self.peer_information.clone(),
+                r,
+                self.blockchain_read_handle.clone(),
+            )
+            .boxed(),
             ProtocolRequest::NewBlock(_) => ready(Err(anyhow::anyhow!(
                 "Peer sent a full block when we support fluffy blocks"
             )))
@@ -261,7 +265,8 @@ async fn get_chain(
 }
 
 /// [`ProtocolRequest::FluffyMissingTxs`]
-async fn fluffy_missing_txs(
+async fn fluffy_missing_txs<A: NetZoneAddress>(
+    peer_information: PeerInformation<A>,
     mut request: FluffyMissingTransactionsRequest,
     mut blockchain_read_handle: BlockchainReadHandle,
 ) -> anyhow::Result<ProtocolResponse> {
@@ -271,6 +276,20 @@ async fn fluffy_missing_txs(
 
     // deallocate the backing `Bytes`.
     drop(request);
+
+    let mut seen = HashSet::with_capacity(tx_indexes.len());
+    tx_indexes.iter().try_for_each(|idx| {
+        if !seen.insert(idx) {
+            tracing::warn!(
+                "Peer requested duplicate tx index {} for block {}, banning peer.",
+                idx,
+                hex::encode(block_hash)
+            );
+            peer_information.handle.ban_peer(SHORT_BAN);
+            anyhow::bail!("Peer requested duplicate tx indices.");
+        }
+        Ok(())
+    })?;
 
     let BlockchainResponse::TxsInBlock(res) = blockchain_read_handle
         .ready()

--- a/binaries/cuprated/src/p2p/request_handler.rs
+++ b/binaries/cuprated/src/p2p/request_handler.rs
@@ -330,6 +330,7 @@ async fn new_fluffy_block<A: NetZoneAddress>(
 ) -> anyhow::Result<ProtocolResponse> {
     let current_blockchain_height = request.current_blockchain_height;
 
+    // TODO: ban peer if their `current_height` keeps regressing
     peer_information
         .core_sync_data
         .lock()

--- a/p2p/p2p-core/src/client/request_handler.rs
+++ b/p2p/p2p-core/src/client/request_handler.rs
@@ -105,6 +105,7 @@ where
     ) -> Result<TimedSyncResponse, tower::BoxError> {
         // TODO: add a limit on the amount of these requests in a certain time period.
 
+        // TODO: ban peer if their `current_height` keeps regressing
         *self.peer_info.core_sync_data.lock().unwrap() = req.payload_data.clone();
 
         if let Some(on_peer_sync) = &self.on_peer_sync {

--- a/p2p/p2p-core/src/client/timeout_monitor.rs
+++ b/p2p/p2p-core/src/client/timeout_monitor.rs
@@ -129,6 +129,7 @@ where
             ))
             .await?;
 
+        // TODO: ban peer if their `current_height` keeps regressing
         *peer_information.core_sync_data.lock().unwrap() = timed_sync.payload_data.clone();
 
         if let Some(on_peer_sync) = &on_peer_sync {

--- a/p2p/p2p-core/src/client/timeout_monitor.rs
+++ b/p2p/p2p-core/src/client/timeout_monitor.rs
@@ -111,6 +111,7 @@ where
             timed_sync.local_peerlist_new.len()
         );
 
+        // TODO: ban peer on repeated invalid peer lists in timed sync responses
         if timed_sync.local_peerlist_new.len() > MAX_PEERS_IN_PEER_LIST_MESSAGE {
             return Err("Peer sent too many peers in peer list".into());
         }

--- a/p2p/p2p/src/block_downloader/download_batch.rs
+++ b/p2p/p2p/src/block_downloader/download_batch.rs
@@ -70,7 +70,7 @@ async fn request_batch_from_peer<N: NetworkZone>(
     };
 
     // Initial sanity checks
-    if blocks_response.blocks.len() > ids.len() {
+    if blocks_response.blocks.is_empty() || blocks_response.blocks.len() > ids.len() {
         client.info.handle.ban_peer(MEDIUM_BAN);
         return Err(BlockDownloadError::PeersResponseWasInvalid);
     }

--- a/p2p/p2p/src/block_downloader/request_chain.rs
+++ b/p2p/p2p/src/block_downloader/request_chain.rs
@@ -1,4 +1,4 @@
-use std::mem;
+use std::{collections::HashSet, mem};
 
 use tokio::{task::JoinSet, time::timeout};
 use tower::{util::BoxCloneService, Service, ServiceExt};
@@ -44,29 +44,37 @@ pub(crate) async fn request_chain_entry_from_peer<N: NetworkZone>(
         panic!("Connection task returned wrong response!");
     };
 
-    if chain_res.m_block_ids.is_empty()
-        || chain_res.m_block_ids.len() > MAX_BLOCKS_IDS_IN_CHAIN_ENTRY
-    {
+    let block_ids: Vec<[u8; 32]> = (&chain_res.m_block_ids).into();
+
+    if block_ids.is_empty() || block_ids.len() > MAX_BLOCKS_IDS_IN_CHAIN_ENTRY {
         client.info.handle.ban_peer(MEDIUM_BAN);
         return Err(BlockDownloadError::PeersResponseWasInvalid);
     }
 
+    // We must not receive duplicate block IDs.
+    let mut seen = HashSet::with_capacity(block_ids.len());
+    block_ids.iter().try_for_each(|id| {
+        if !seen.insert(id) {
+            client.info.handle.ban_peer(MEDIUM_BAN);
+            return Err(BlockDownloadError::PeersResponseWasInvalid);
+        }
+        Ok(())
+    })?;
+
     // We must have at least one overlapping block.
-    if !(chain_res.m_block_ids[0] == short_history[0]
-        || chain_res.m_block_ids[0] == short_history[1])
-    {
+    if !(block_ids[0] == short_history[0] || block_ids[0] == short_history[1]) {
         client.info.handle.ban_peer(MEDIUM_BAN);
         return Err(BlockDownloadError::PeersResponseWasInvalid);
     }
 
     // If the genesis is the overlapping block then this peer does not have our top tracked block in
     // its chain.
-    if chain_res.m_block_ids[0] == short_history[1] {
+    if block_ids[0] == short_history[1] {
         return Err(BlockDownloadError::PeerDidNotHaveRequestedData);
     }
 
     let entry = ChainEntry {
-        ids: (&chain_res.m_block_ids).into(),
+        ids: block_ids,
         peer: client.info.id,
         handle: client.info.handle.clone(),
     };

--- a/p2p/p2p/src/block_downloader/request_chain.rs
+++ b/p2p/p2p/src/block_downloader/request_chain.rs
@@ -44,22 +44,21 @@ pub(crate) async fn request_chain_entry_from_peer<N: NetworkZone>(
         panic!("Connection task returned wrong response!");
     };
 
-    let block_ids: Vec<[u8; 32]> = (&chain_res.m_block_ids).into();
-
-    if block_ids.is_empty() || block_ids.len() > MAX_BLOCKS_IDS_IN_CHAIN_ENTRY {
+    if chain_res.m_block_ids.is_empty()
+        || chain_res.m_block_ids.len() > MAX_BLOCKS_IDS_IN_CHAIN_ENTRY
+    {
         client.info.handle.ban_peer(MEDIUM_BAN);
         return Err(BlockDownloadError::PeersResponseWasInvalid);
     }
 
+    let block_ids: Vec<[u8; 32]> = (&chain_res.m_block_ids).into();
+
     // We must not receive duplicate block IDs.
     let mut seen = HashSet::with_capacity(block_ids.len());
-    block_ids.iter().try_for_each(|id| {
-        if !seen.insert(id) {
-            client.info.handle.ban_peer(MEDIUM_BAN);
-            return Err(BlockDownloadError::PeersResponseWasInvalid);
-        }
-        Ok(())
-    })?;
+    if !block_ids.iter().all(|id| seen.insert(id)) {
+        client.info.handle.ban_peer(MEDIUM_BAN);
+        return Err(BlockDownloadError::PeersResponseWasInvalid);
+    }
 
     // We must have at least one overlapping block.
     if !(block_ids[0] == short_history[0] || block_ids[0] == short_history[1]) {

--- a/p2p/p2p/src/connection_maintainer.rs
+++ b/p2p/p2p/src/connection_maintainer.rs
@@ -163,6 +163,7 @@ where
 
         tokio::spawn(
             async move {
+                // TODO: ban peer on repeated `HandshakeError::PeerSentInvalidMessage`
                 if let Ok(Ok(peer)) = timeout(HANDSHAKE_TIMEOUT, connection_fut).await {
                     let csd = peer.info.core_sync_data.lock().unwrap().clone();
                     if new_peers_tx.send(peer).await.is_ok() {

--- a/p2p/p2p/src/inbound_server.rs
+++ b/p2p/p2p/src/inbound_server.rs
@@ -131,6 +131,7 @@ where
                             }
                         }
                         Err(_) => tracing::debug!("Timed out"),
+                        // TODO: ban peer on repeated `HandshakeError::IncorrectNetwork`
                         Ok(Err(e)) => tracing::debug!("error: {e:?}"),
                     }
                 }


### PR DESCRIPTION
### What
Add ban behaviours from monerod, or TODOs in places where bans would be needed but would require ban system upgrades.

### Why
Consistency, documentation for future upgrades

### Where
`cuprated`, `p2p`

### How
New bans added for places where monerod drops connection with a ban score contribution (`drop_connection(_,true,_)`).
| Action | Trigger | Precedent (v0.18.5.0) |
|---|---|---|
| `SHORT_BAN` | Duplicate tx index in fluffy missing-tx request | [`cryptonote_protocol_handler.inl:782-794`](https://github.com/monero-project/monero/blob/v0.18.5.0/src/cryptonote_protocol/cryptonote_protocol_handler.inl#L782-L794) |
| `MEDIUM_BAN` | Duplicate block IDs in chain response | [`cryptonote_protocol_handler.inl:2544-2549`](https://github.com/monero-project/monero/blob/v0.18.5.0/src/cryptonote_protocol/cryptonote_protocol_handler.inl#L2544-L2549) |
| `MEDIUM_BAN` | Empty block batch response | [`cryptonote_protocol_handler.inl:1071-1077`](https://github.com/monero-project/monero/blob/v0.18.5.0/src/cryptonote_protocol/cryptonote_protocol_handler.inl#L1071-L1077) |

TODOs added in places where monerod contributes to the ban score accumulator (`add_host_fail` / `hit_score`), and triggers a ban only after repeated violations. Needs ban system upgrades, as currently it's either ban or do nothing.
| Trigger | Precedent (v0.18.5.0) |
|---|---|
| `current_blockchain_height` regression (3 sites: `new_fluffy_block`, timed-sync request, timed-sync response) | [`cryptonote_protocol_handler.inl:466-470`](https://github.com/monero-project/monero/blob/v0.18.5.0/src/cryptonote_protocol/cryptonote_protocol_handler.inl#L466-L470) [`cryptonote_protocol_handler.inl:1087-1091`](https://github.com/monero-project/monero/blob/v0.18.5.0/src/cryptonote_protocol/cryptonote_protocol_handler.inl#L1087-L1091) [`cryptonote_protocol_handler.inl:2509-2513`](https://github.com/monero-project/monero/blob/v0.18.5.0/src/cryptonote_protocol/cryptonote_protocol_handler.inl#L2509-L2513) |
| Inbound handshake wrong network ID | [`net_node.inl:2587-2594`](https://github.com/monero-project/monero/blob/v0.18.5.0/src/p2p/net_node.inl#L2587-L2594) |
| Outbound handshake invalid peerlist | [`net_node.inl:1170-1175`](https://github.com/monero-project/monero/blob/v0.18.5.0/src/p2p/net_node.inl#L1170-L1175) |
| Timed-sync invalid peerlist | [`net_node.inl:1250-1255`](https://github.com/monero-project/monero/blob/v0.18.5.0/src/p2p/net_node.inl#L1250-L1255) |