### PR TITLE
cuprated: rename, move SyncerHandle to BlockchainInterface

### DIFF
--- a/binaries/cuprated/src/blockchain.rs
+++ b/binaries/cuprated/src/blockchain.rs
@@ -44,6 +44,8 @@ pub struct BlockchainInterface {
     context_svc: BlockchainContextService,
     /// A handle to the blockchain manager.
     manager: BlockchainManagerHandle,
+    /// A handle to the blockchain syncer.
+    syncer: SyncerHandle,
 }
 
 impl BlockchainInterface {
@@ -51,11 +53,13 @@ impl BlockchainInterface {
         read: BlockchainReadHandle,
         context_svc: BlockchainContextService,
         manager: BlockchainManagerHandle,
+        syncer: SyncerHandle,
     ) -> Self {
         Self {
             read,
             context_svc,
             manager,
+            syncer,
         }
     }
 
@@ -72,6 +76,11 @@ impl BlockchainInterface {
     /// Returns a handle to the blockchain manager.
     pub fn manager(&self) -> BlockchainManagerHandle {
         self.manager.clone()
+    }
+
+    /// Returns a handle to the blockchain syncer.
+    pub fn syncer(&self) -> SyncerHandle {
+        self.syncer.clone()
     }
 
     /// Returns the blockchain context service.

--- a/binaries/cuprated/src/blockchain.rs
+++ b/binaries/cuprated/src/blockchain.rs
@@ -25,12 +25,12 @@ mod chain_service;
 mod fast_sync;
 pub mod interface;
 mod manager;
-pub(crate) mod syncer;
+mod syncer;
 mod types;
 
 pub use fast_sync::get_fast_sync_hashes;
 pub use interface::BlockchainManagerHandle;
-pub use syncer::{Syncer, SyncerHandle};
+pub use syncer::BlockchainSyncerHandle;
 pub use types::ConsensusBlockchainReadHandle;
 
 pub(crate) use manager::init_blockchain_manager;
@@ -45,7 +45,7 @@ pub struct BlockchainInterface {
     /// A handle to the blockchain manager.
     manager: BlockchainManagerHandle,
     /// A handle to the blockchain syncer.
-    syncer: SyncerHandle,
+    syncer: BlockchainSyncerHandle,
 }
 
 impl BlockchainInterface {
@@ -53,7 +53,7 @@ impl BlockchainInterface {
         read: BlockchainReadHandle,
         context_svc: BlockchainContextService,
         manager: BlockchainManagerHandle,
-        syncer: SyncerHandle,
+        syncer: BlockchainSyncerHandle,
     ) -> Self {
         Self {
             read,
@@ -79,7 +79,7 @@ impl BlockchainInterface {
     }
 
     /// Returns a handle to the blockchain syncer.
-    pub fn syncer(&self) -> SyncerHandle {
+    pub fn syncer(&self) -> BlockchainSyncerHandle {
         self.syncer.clone()
     }
 

--- a/binaries/cuprated/src/blockchain.rs
+++ b/binaries/cuprated/src/blockchain.rs
@@ -13,7 +13,7 @@ use cuprate_consensus::{
 };
 use cuprate_cryptonight::cryptonight_hash_v0;
 use cuprate_p2p::{block_downloader::BlockDownloaderConfig, NetworkInterface};
-use cuprate_p2p_core::{ClearNet, Network};
+use cuprate_p2p_core::{client::PeerSyncCallback, ClearNet, Network};
 use cuprate_types::{
     blockchain::{BlockchainReadRequest, BlockchainWriteRequest},
     VerifiedBlockInformation,
@@ -86,6 +86,12 @@ impl BlockchainInterface {
     /// Returns the blockchain context service.
     pub(crate) fn context_svc(&self) -> BlockchainContextService {
         self.context_svc.clone()
+    }
+
+    /// Creates a [`PeerSyncCallback`] that filters and wakes the syncer.
+    pub(crate) fn peer_sync_callback(&self) -> PeerSyncCallback {
+        self.syncer
+            .callback(self.context_svc.clone(), self.manager.clone())
     }
 }
 

--- a/binaries/cuprated/src/blockchain/interface.rs
+++ b/binaries/cuprated/src/blockchain/interface.rs
@@ -63,7 +63,7 @@ pub enum IncomingBlockError {
 
 impl BlockchainManagerHandle {
     /// Create a new handle and command receiver pair.
-    pub fn new() -> (Self, mpsc::Receiver<BlockchainManagerCommand>) {
+    pub(crate) fn new() -> (Self, mpsc::Receiver<BlockchainManagerCommand>) {
         let (command_tx, command_rx) = mpsc::channel(3);
         (
             Self {

--- a/binaries/cuprated/src/blockchain/manager.rs
+++ b/binaries/cuprated/src/blockchain/manager.rs
@@ -24,7 +24,9 @@ use cuprate_types::{
 };
 
 use crate::{
-    blockchain::{chain_service::ChainService, syncer, types::ConsensusBlockchainReadHandle},
+    blockchain::{
+        chain_service::ChainService, syncer::BlockchainSyncer, types::ConsensusBlockchainReadHandle,
+    },
     constants::PANIC_CRITICAL_SERVICE_ERROR,
     txpool::TxpoolManagerHandle,
     LaunchContext,
@@ -37,18 +39,17 @@ mod handler;
 mod tests;
 
 pub use commands::{BlockchainManagerCommand, IncomingBlockOk};
-use syncer::Syncer;
 
 /// Initialize the blockchain manager.
 ///
-/// This function sets up the `BlockchainManager` and the [`Syncer`] so that the functions in [`interface`](super::interface)
+/// This function sets up the `BlockchainManager` and the [`BlockchainSyncer`] so that the functions in [`interface`](super::interface)
 /// can be called.
 pub(crate) async fn init_blockchain_manager(
     launch_ctx: &LaunchContext,
     clearnet_interface: NetworkInterface<ClearNet>,
     blockchain_write_handle: BlockchainWriteHandle,
     txpool_manager_handle: TxpoolManagerHandle,
-    syncer: Syncer,
+    synced_tx: futures::channel::oneshot::Sender<()>,
     command_rx: mpsc::Receiver<BlockchainManagerCommand>,
 ) -> Result<(), anyhow::Error> {
     let block_downloader_config = launch_ctx.config.block_downloader_config();
@@ -58,6 +59,8 @@ pub(crate) async fn init_blockchain_manager(
     let (batch_tx, batch_rx) = mpsc::channel(1);
     let stop_current_block_downloader = Arc::new(Notify::new());
     let fast_sync_hashes = launch_ctx.config.fast_sync_hashes();
+
+    let syncer = BlockchainSyncer::new(&launch_ctx.blockchain.syncer(), synced_tx);
 
     launch_ctx.task_executor.spawn(syncer.run(
         launch_ctx.blockchain.context_svc(),
@@ -107,7 +110,7 @@ pub struct BlockchainManager {
     /// The blockchain context cache, this caches the current state of the blockchain to quickly calculate/retrieve
     /// values without needing to go to a [`BlockchainReadHandle`].
     blockchain_context_service: BlockchainContextService,
-    /// A [`Notify`] to tell the [`Syncer`] that we want to cancel this current download
+    /// A [`Notify`] to tell the [`BlockchainSyncer`] that we want to cancel this current download
     /// attempt.
     stop_current_block_downloader: Arc<Notify>,
     /// The broadcast service, to broadcast new blocks.

--- a/binaries/cuprated/src/blockchain/syncer.rs
+++ b/binaries/cuprated/src/blockchain/syncer.rs
@@ -23,7 +23,7 @@ use cuprate_p2p_core::{client::PeerSyncCallback, ClearNet, CoreSyncData, Network
 
 use super::BlockchainManagerHandle;
 
-/// An error returned from the [`Syncer`].
+/// An error returned from the [`BlockchainSyncer`].
 #[derive(Debug, thiserror::Error)]
 pub enum SyncerError {
     #[error("Incoming block channel closed.")]
@@ -42,32 +42,23 @@ enum SyncStatus {
 }
 
 /// The syncer that makes sure we are fully synchronised with our connected peers.
-pub struct Syncer {
+pub struct BlockchainSyncer {
     notify_syncer: Arc<Notify>,
     synced_tx: Option<futures::channel::oneshot::Sender<()>>,
     target_height: Arc<AtomicU64>,
 }
 
-impl Syncer {
-    /// Create a new [`Syncer`] and its [`SyncerHandle`].
-    pub fn new() -> (Self, SyncerHandle) {
-        let notify_syncer = Arc::new(Notify::new());
-        let (synced_tx, synced_rx) = futures::channel::oneshot::channel();
-        let target_height = Arc::new(AtomicU64::new(0));
-
-        let syncer_handle = SyncerHandle {
-            notify_syncer: Arc::clone(&notify_syncer),
-            synced: synced_rx.shared(),
-            target_height: Arc::clone(&target_height),
-        };
-
-        let syncer = Self {
-            notify_syncer,
+impl BlockchainSyncer {
+    /// Create a new [`BlockchainSyncer`] from its handle and the sender used to signal the node has synced.
+    pub fn new(
+        handle: &BlockchainSyncerHandle,
+        synced_tx: futures::channel::oneshot::Sender<()>,
+    ) -> Self {
+        Self {
+            notify_syncer: Arc::clone(&handle.notify_syncer),
             synced_tx: Some(synced_tx),
-            target_height,
-        };
-
-        (syncer, syncer_handle)
+            target_height: Arc::clone(&handle.target_height),
+        }
     }
 
     /// Run the syncer.
@@ -217,9 +208,9 @@ impl Syncer {
     }
 }
 
-/// Handle for the [`Syncer`].
+/// Handle for the `BlockchainSyncer`.
 #[derive(Clone)]
-pub struct SyncerHandle {
+pub struct BlockchainSyncerHandle {
     /// The syncer notify channel, used to wake the syncer.
     notify_syncer: Arc<Notify>,
     /// The synced notify channel, used to wake the tasks waiting on cuprate to be synced.
@@ -228,7 +219,21 @@ pub struct SyncerHandle {
     target_height: Arc<AtomicU64>,
 }
 
-impl SyncerHandle {
+impl BlockchainSyncerHandle {
+    /// Create a new handle and the sender used to signal the node has synced.
+    pub(crate) fn new() -> (Self, futures::channel::oneshot::Sender<()>) {
+        let (synced_tx, synced_rx) = futures::channel::oneshot::channel();
+
+        (
+            Self {
+                notify_syncer: Arc::new(Notify::new()),
+                synced: synced_rx.shared(),
+                target_height: Arc::new(AtomicU64::new(0)),
+            },
+            synced_tx,
+        )
+    }
+
     /// Returns the target sync height. 0 if not syncing.
     pub fn target_height(&self) -> u64 {
         self.target_height.load(Ordering::Relaxed)

--- a/binaries/cuprated/src/blockchain/syncer.rs
+++ b/binaries/cuprated/src/blockchain/syncer.rs
@@ -21,7 +21,7 @@ use cuprate_p2p::{
 };
 use cuprate_p2p_core::{client::PeerSyncCallback, ClearNet, CoreSyncData, NetworkZone};
 
-use super::BlockchainInterface;
+use super::BlockchainManagerHandle;
 
 /// An error returned from the [`Syncer`].
 #[derive(Debug, thiserror::Error)]
@@ -242,9 +242,11 @@ impl SyncerHandle {
     }
 
     /// Creates a [`PeerSyncCallback`] that filters and wakes the syncer.
-    pub fn callback(&self, blockchain: &BlockchainInterface) -> PeerSyncCallback {
-        let context_svc = blockchain.context_svc();
-        let blockchain_manager = blockchain.manager();
+    pub(crate) fn callback(
+        &self,
+        context_svc: BlockchainContextService,
+        blockchain_manager: BlockchainManagerHandle,
+    ) -> PeerSyncCallback {
         let sync_handle = self.clone();
         let disconnect_handle = self.clone();
 

--- a/binaries/cuprated/src/lib.rs
+++ b/binaries/cuprated/src/lib.rs
@@ -58,7 +58,7 @@ use cuprate_txpool::service::TxpoolReadHandle;
 use cuprate_types::blockchain::BlockchainWriteRequest;
 
 use crate::{
-    blockchain::{BlockchainInterface, BlockchainManagerHandle, Syncer},
+    blockchain::{BlockchainInterface, BlockchainManagerHandle, BlockchainSyncerHandle},
     config::Config,
     constants::DATABASE_CORRUPT_MSG,
     monitor::TaskExecutor,
@@ -191,8 +191,8 @@ impl Node {
                 .await
                 .map_err(anyhow::Error::from_boxed)?;
 
-        // Create the syncer and handle.
-        let (syncer, syncer_handle) = Syncer::new();
+        // Create the blockchain syncer handle and synced signal sender.
+        let (blockchain_syncer_handle, synced_tx) = BlockchainSyncerHandle::new();
 
         // Create the blockchain manager handle and command receiver.
         let (blockchain_manager_handle, command_rx) = BlockchainManagerHandle::new();
@@ -202,7 +202,7 @@ impl Node {
             blockchain_read_handle,
             context_svc,
             blockchain_manager_handle,
-            syncer_handle,
+            blockchain_syncer_handle,
         );
 
         // Create the launch context.
@@ -251,7 +251,7 @@ impl Node {
             clearnet_interface.clone(),
             blockchain_write_handle,
             tx_handler.txpool_manager.clone(),
-            syncer,
+            synced_tx,
             command_rx,
         )
         .await?;

--- a/binaries/cuprated/src/lib.rs
+++ b/binaries/cuprated/src/lib.rs
@@ -199,9 +199,9 @@ impl Node {
 
         // Create the blockchain interface.
         let blockchain_interface = BlockchainInterface::new(
-            blockchain_read_handle.clone(),
-            context_svc.clone(),
-            blockchain_manager_handle.clone(),
+            blockchain_read_handle,
+            context_svc,
+            blockchain_manager_handle,
             syncer_handle,
         );
 
@@ -210,7 +210,7 @@ impl Node {
             config,
             reorg_lock: Arc::new(RwLock::new(())),
             blockchain: blockchain_interface,
-            txpool_read: txpool_read_handle.clone(),
+            txpool_read: txpool_read_handle,
             task_executor: TaskExecutor::new(),
         };
 
@@ -230,7 +230,7 @@ impl Node {
             &launch_ctx,
             clearnet_interface.clone(),
             tor_router_rx,
-            txpool_write_handle.clone(),
+            txpool_write_handle,
         )
         .await;
 

--- a/binaries/cuprated/src/lib.rs
+++ b/binaries/cuprated/src/lib.rs
@@ -92,9 +92,6 @@ pub(crate) struct LaunchContext {
     /// Read handle to the transaction pool.
     pub txpool_read: TxpoolReadHandle,
 
-    /// Syncer handle.
-    pub syncer: SyncerHandle,
-
     /// Task spawning and shutdown coordination.
     pub task_executor: TaskExecutor,
 }
@@ -115,9 +112,6 @@ pub struct Node {
 
     /// Tor P2P interface (available after sync).
     pub tor: Option<oneshot::Receiver<NetworkInterface<Tor>>>,
-
-    /// Syncer handle.
-    pub syncer: SyncerHandle,
 
     /// The configuration this node was launched with.
     pub config: Arc<Config>,
@@ -208,6 +202,7 @@ impl Node {
             blockchain_read_handle.clone(),
             context_svc.clone(),
             blockchain_manager_handle.clone(),
+            syncer_handle.clone(),
         );
 
         // Create the launch context.
@@ -216,7 +211,6 @@ impl Node {
             reorg_lock: Arc::new(RwLock::new(())),
             blockchain: blockchain_interface,
             txpool_read: txpool_read_handle.clone(),
-            syncer: syncer_handle,
             task_executor: TaskExecutor::new(),
         };
 
@@ -279,7 +273,6 @@ impl Node {
         let LaunchContext {
             blockchain,
             txpool_read,
-            syncer,
             config,
             task_executor,
             ..
@@ -290,7 +283,6 @@ impl Node {
             txpool: txpool_read,
             clearnet: clearnet_interface,
             tor: if tor_enabled { Some(tor_rx) } else { None },
-            syncer,
             config,
             task_executor,
         })

--- a/binaries/cuprated/src/lib.rs
+++ b/binaries/cuprated/src/lib.rs
@@ -58,7 +58,7 @@ use cuprate_txpool::service::TxpoolReadHandle;
 use cuprate_types::blockchain::BlockchainWriteRequest;
 
 use crate::{
-    blockchain::{BlockchainInterface, BlockchainManagerHandle, Syncer, SyncerHandle},
+    blockchain::{BlockchainInterface, BlockchainManagerHandle, Syncer},
     config::Config,
     constants::DATABASE_CORRUPT_MSG,
     monitor::TaskExecutor,
@@ -202,7 +202,7 @@ impl Node {
             blockchain_read_handle.clone(),
             context_svc.clone(),
             blockchain_manager_handle.clone(),
-            syncer_handle.clone(),
+            syncer_handle,
         );
 
         // Create the launch context.

--- a/binaries/cuprated/src/p2p.rs
+++ b/binaries/cuprated/src/p2p.rs
@@ -128,7 +128,8 @@ pub async fn initialize_clearnet_p2p(
     tor_ctx: &TorContext,
 ) -> (NetworkInterface<ClearNet>, Sender<IncomingTxHandler>) {
     let config = launch_ctx.config.as_ref();
-    let peer_sync_callback = launch_ctx.blockchain.syncer().callback(&launch_ctx.blockchain);
+    let blockchain = &launch_ctx.blockchain;
+    let peer_sync_callback = blockchain.syncer().callback(blockchain);
 
     match &config.p2p.clear_net.proxy {
         ProxySettings::Tor => match tor_ctx.mode {
@@ -136,7 +137,7 @@ pub async fn initialize_clearnet_p2p(
             TorMode::Arti => {
                 tracing::info!("Anonymizing clearnet connections through Arti.");
                 start_zone_p2p::<ClearNet, Arti>(
-                    &launch_ctx.blockchain,
+                    blockchain,
                     launch_ctx.txpool_read.clone(),
                     config.clearnet_p2p_config(),
                     transport_clearnet_arti_config(tor_ctx),
@@ -157,7 +158,7 @@ pub async fn initialize_clearnet_p2p(
             TorMode::Auto => unreachable!("Auto mode should be resolved before this point"),
         },
         ProxySettings::Disabled => start_zone_p2p::<ClearNet, Tcp>(
-            &launch_ctx.blockchain,
+            blockchain,
             launch_ctx.txpool_read.clone(),
             config.clearnet_p2p_config(),
             config.p2p.clear_net.tcp_transport_config(config.network),
@@ -166,7 +167,7 @@ pub async fn initialize_clearnet_p2p(
         .await
         .unwrap(),
         ProxySettings::Socks(socks_config) => start_zone_p2p::<ClearNet, Socks>(
-            &launch_ctx.blockchain,
+            blockchain,
             launch_ctx.txpool_read.clone(),
             config.clearnet_p2p_config(),
             TransportConfig {

--- a/binaries/cuprated/src/p2p.rs
+++ b/binaries/cuprated/src/p2p.rs
@@ -129,7 +129,7 @@ pub async fn initialize_clearnet_p2p(
 ) -> (NetworkInterface<ClearNet>, Sender<IncomingTxHandler>) {
     let config = launch_ctx.config.as_ref();
     let blockchain = &launch_ctx.blockchain;
-    let peer_sync_callback = blockchain.syncer().callback(blockchain);
+    let peer_sync_callback = blockchain.peer_sync_callback();
 
     match &config.p2p.clear_net.proxy {
         ProxySettings::Tor => match tor_ctx.mode {

--- a/binaries/cuprated/src/p2p.rs
+++ b/binaries/cuprated/src/p2p.rs
@@ -128,7 +128,7 @@ pub async fn initialize_clearnet_p2p(
     tor_ctx: &TorContext,
 ) -> (NetworkInterface<ClearNet>, Sender<IncomingTxHandler>) {
     let config = launch_ctx.config.as_ref();
-    let peer_sync_callback = launch_ctx.syncer.callback(&launch_ctx.blockchain);
+    let peer_sync_callback = launch_ctx.blockchain.syncer().callback(&launch_ctx.blockchain);
 
     match &config.p2p.clear_net.proxy {
         ProxySettings::Tor => match tor_ctx.mode {
@@ -197,7 +197,7 @@ pub fn initialize_tor_p2p(
     task_executor.spawn(async move {
         // Wait for the node to synchronize with the network, or shutdown.
         tokio::select! {
-            result = launch_ctx.syncer.wait_for_synced() => {
+            result = launch_ctx.blockchain.syncer().wait_for_synced() => {
                 if result.is_err() {
                     tracing::info!("Not starting Tor P2P zone, syncer stopped");
                     return;

--- a/binaries/cuprated/src/rpc/handlers/json_rpc.rs
+++ b/binaries/cuprated/src/rpc/handlers/json_rpc.rs
@@ -542,7 +542,7 @@ pub(super) async fn get_info(
         state.start_instant_unix
     };
 
-    let target_height = state.syncer_handle.target_height();
+    let target_height = state.blockchain_syncer.target_height();
     let busy_syncing = target_height > 0;
     let synchronized = !busy_syncing;
     let target = c.current_hf.block_time().as_secs();
@@ -861,7 +861,7 @@ async fn get_version(
     _: GetVersionRequest,
 ) -> Result<GetVersionResponse, Error> {
     let current_height = usize_to_u64(state.blockchain_context.blockchain_context().chain_height);
-    let target_height = state.syncer_handle.target_height();
+    let target_height = state.blockchain_syncer.target_height();
 
     let mut hard_forks: Vec<HardForkEntry> =
         blockchain_context::hard_fork_infos(&mut state.blockchain_context)

--- a/binaries/cuprated/src/rpc/rpc_handler.rs
+++ b/binaries/cuprated/src/rpc/rpc_handler.rs
@@ -213,7 +213,7 @@ impl CupratedRpcHandler {
             blockchain_read: launch_ctx.blockchain.read(),
             blockchain_context: launch_ctx.blockchain.context_svc(),
             txpool_read: launch_ctx.txpool_read.clone(),
-            syncer_handle: launch_ctx.syncer.clone(),
+            syncer_handle: launch_ctx.blockchain.syncer(),
             blockchain_manager: launch_ctx.blockchain.manager(),
             start_instant_unix,
             task_executor: launch_ctx.task_executor.clone(),

--- a/binaries/cuprated/src/rpc/rpc_handler.rs
+++ b/binaries/cuprated/src/rpc/rpc_handler.rs
@@ -22,7 +22,7 @@ use cuprate_txpool::service::TxpoolReadHandle;
 use cuprate_types::BlockTemplate;
 
 use crate::{
-    blockchain::{BlockchainManagerHandle, SyncerHandle},
+    blockchain::{BlockchainManagerHandle, BlockchainSyncerHandle},
     monitor::TaskExecutor,
     rpc::handlers,
     txpool::IncomingTxHandler,
@@ -181,8 +181,8 @@ pub struct CupratedRpcHandler {
 
     pub tx_handler: IncomingTxHandler,
 
-    /// Handle to the syncer — used to query target sync height.
-    pub syncer_handle: SyncerHandle,
+    /// Handle to the blockchain syncer.
+    pub blockchain_syncer: BlockchainSyncerHandle,
 
     /// Command channel to the blockchain manager.
     pub blockchain_manager: BlockchainManagerHandle,
@@ -213,7 +213,7 @@ impl CupratedRpcHandler {
             blockchain_read: launch_ctx.blockchain.read(),
             blockchain_context: launch_ctx.blockchain.context_svc(),
             txpool_read: launch_ctx.txpool_read.clone(),
-            syncer_handle: launch_ctx.blockchain.syncer(),
+            blockchain_syncer: launch_ctx.blockchain.syncer(),
             blockchain_manager: launch_ctx.blockchain.manager(),
             start_instant_unix,
             task_executor: launch_ctx.task_executor.clone(),


### PR DESCRIPTION
### What
moves SyncerHandle to be accessable from BlockchainInterfac

Renamed Syncer to BlockchainSyncer, to match how other items are prefixed with `Blockchain`

Have BlockchainSyncer be constructed inside of the blockchain manager spawn function

### Why
Symmetry. Syncer is spawned by the blockchain module, so it makes sense for it's handle to join the rest of the blockchain handle crew. Same way how `syncer.rs` is located in `blockchain/`

### Where
`cuprated`

### How
clone SyncerHandle into BlockchainInterface at construction and remove the field from Node. Embedders now should call `node.blockchain.syncer()` to get a clone of the handle. Longer but reads nicer too imo