### PR TITLE
cuprated: fix database size on restricted RPC

### DIFF
--- a/binaries/cuprated/src/rpc/handlers/json_rpc.rs
+++ b/binaries/cuprated/src/rpc/handlers/json_rpc.rs
@@ -535,7 +535,8 @@ pub(super) async fn get_info(
     let (database_size, free_space) = blockchain::database_size(&mut state.blockchain_read).await?;
     let (database_size, free_space) = if restricted {
         // <https://github.com/monero-project/monero/blob/cc73fe71162d564ffda8e549b79a350bca53c454/src/rpc/core_rpc_server.cpp#L131-L134>
-        let database_size = database_size.div_ceil(5 * 1024 * 1024 * 1024);
+        let quantum = 5 * 1024 * 1024 * 1024;
+        let database_size = database_size.div_ceil(quantum) * quantum;
         (database_size, u64::MAX)
     } else {
         (database_size, free_space)


### PR DESCRIPTION
### What
fix database size returned on restricted RPC

### Why
without multiplying back by `5 * 1024 * 1024 * 1024` it just returned how many 5GiB chunks were there

### Where
`cuprated`

### How
multiply back by `5 * 1024 * 1024 * 1024` after div_ceil, use the same `quantum` variable as monerod