### PR TITLE
p2p: remove gray peer from list on promotion, invert default config

### DIFF
--- a/binaries/cuprated/src/config/p2p.rs
+++ b/binaries/cuprated/src/config/p2p.rs
@@ -312,7 +312,7 @@ impl Default for ClearNetConfig {
             outbound_connections: 32,
             extra_outbound_connections: 8,
             max_inbound_connections: 128,
-            gray_peers_percent: 0.7,
+            gray_peers_percent: 0.3,
             address_book_config: AddressBookConfig::default(),
         }
     }
@@ -327,7 +327,7 @@ impl Default for TorNetConfig {
             outbound_connections: 12,
             extra_outbound_connections: 2,
             max_inbound_connections: 128,
-            gray_peers_percent: 0.7,
+            gray_peers_percent: 0.3,
             address_book_config: AddressBookConfig::default(),
         }
     }

--- a/p2p/address-book/src/book.rs
+++ b/p2p/address-book/src/book.rs
@@ -346,6 +346,7 @@ impl<Z: BorshNetworkZone> AddressBook<Z> {
         if let Some(addr) = peer.addr {
             // The peer is reachable, update our white list and add it to the anchor connections.
             self.update_white_list_peer_entry(&peer)?;
+            self.gray_list.remove_peer(&addr);
             self.anchor_list.insert(addr);
             self.white_list
                 .reduce_list(&self.anchor_list, self.cfg.max_white_list_length);


### PR DESCRIPTION
### What
patches for gray peers

### Why
parity

### Where
p2p, cuprated

### How
- invert `gray_peers_percent` default from 0.7 to 0.3.
   70%/0.7 is used for whitelist peer percentage (see monerods P2P_DEFAULT_WHITELIST_CONNECTIONS_PERCENT)
- remove peer from gray list after promotion to whitelist
