### PR TITLE
cuprated: trim whitespace and ignore ASCII case in config strings

### DIFF
--- a/binaries/cuprated/src/config.rs
+++ b/binaries/cuprated/src/config.rs
@@ -23,7 +23,7 @@ use cuprate_p2p_core::{ClearNet, Tor};
 use cuprate_wire::OnionAddr;
 
 use crate::{
-    logging::eprintln_red,
+    logging::{eprintln_red, eprintln_yellow},
     tor::{TorContext, TorMode},
 };
 
@@ -125,6 +125,107 @@ pub fn find_config() -> Result<Option<Config>, anyhow::Error> {
     Ok(None)
 }
 
+/// Deserializes a string into `T` via its [`FromStr`] implementation.
+///
+/// Used with `#[serde(deserialize_with = "...")]` on config fields whose [`FromStr`]
+/// implementations match strings case-insensitively, see:
+/// <https://github.com/Cuprate/cuprate/issues/598>.
+pub(crate) fn deserialize_from_str<'de, D, T>(deserializer: D) -> Result<T, D::Error>
+where
+    D: serde::Deserializer<'de>,
+    T: FromStr,
+    T::Err: fmt::Display,
+{
+    let s = String::deserialize(deserializer)?;
+    T::from_str(&s).map_err(serde::de::Error::custom)
+}
+
+/// Trims leading/trailing whitespace from every string value in the given config text,
+/// printing a warning for each trimmed value.
+///
+/// Returns the text unchanged if it is not parseable TOML, the regular
+/// parsing path will then report the error.
+fn trim_config_text(text: String) -> String {
+    trim_string_values(&text).map_or(text, |(trimmed_text, trimmed_paths)| {
+        for path in trimmed_paths {
+            eprintln_yellow(&format!(
+                "Warning: ignoring leading/trailing whitespace in config value `{path}`"
+            ));
+        }
+
+        trimmed_text
+    })
+}
+
+/// Trims leading/trailing whitespace from every string value in the given TOML text.
+///
+/// Values that would become empty when trimmed are left untouched.
+///
+/// Returns the cleaned TOML text and the dotted key paths of the values that were
+/// trimmed, or [`None`] if the text is not parseable TOML.
+fn trim_string_values(text: &str) -> Option<(String, Vec<String>)> {
+    let mut doc = toml_edit::DocumentMut::from_str(text).ok()?;
+
+    let mut trimmed = Vec::new();
+    trim_table(doc.as_table_mut(), "", &mut trimmed);
+
+    Some((doc.to_string(), trimmed))
+}
+
+/// [`trim_string_values`] on every item in a table.
+fn trim_table(table: &mut dyn toml_edit::TableLike, path: &str, trimmed: &mut Vec<String>) {
+    for (key, item) in table.iter_mut() {
+        let item_path = if path.is_empty() {
+            key.get().to_string()
+        } else {
+            format!("{path}.{}", key.get())
+        };
+
+        trim_item(item, &item_path, trimmed);
+    }
+}
+
+/// [`trim_string_values`] on a single item.
+fn trim_item(item: &mut toml_edit::Item, path: &str, trimmed: &mut Vec<String>) {
+    match item {
+        toml_edit::Item::None => (),
+        toml_edit::Item::Value(value) => trim_value(value, path, trimmed),
+        toml_edit::Item::Table(table) => trim_table(table, path, trimmed),
+        toml_edit::Item::ArrayOfTables(tables) => {
+            for (i, table) in tables.iter_mut().enumerate() {
+                trim_table(table, &format!("{path}[{i}]"), trimmed);
+            }
+        }
+    }
+}
+
+/// [`trim_string_values`] on a single value.
+fn trim_value(value: &mut toml_edit::Value, path: &str, trimmed: &mut Vec<String>) {
+    match value {
+        toml_edit::Value::String(s) => {
+            let trimmed_string = s.value().trim().to_string();
+
+            // Never trim a value down to the empty string, e.g. an all-whitespace
+            // `proxy` must not silently become "" (proxy disabled), it is left
+            // untouched for the field's own parser to reject loudly.
+            if !trimmed_string.is_empty() && trimmed_string != *s.value() {
+                *value = toml_edit::Value::String(toml_edit::Formatted::new(trimmed_string));
+                trimmed.push(path.to_string());
+            }
+        }
+        toml_edit::Value::Array(array) => {
+            for (i, element) in array.iter_mut().enumerate() {
+                trim_value(element, &format!("{path}[{i}]"), trimmed);
+            }
+        }
+        toml_edit::Value::InlineTable(table) => trim_table(table, path, trimmed),
+        toml_edit::Value::Integer(_)
+        | toml_edit::Value::Float(_)
+        | toml_edit::Value::Boolean(_)
+        | toml_edit::Value::Datetime(_) => (),
+    }
+}
+
 config_struct! {
     /// The config for all of Cuprate.
     #[derive(Debug, Deserialize, Serialize, PartialEq)]
@@ -132,7 +233,10 @@ config_struct! {
     pub struct Config {
         /// The network cuprated should run on.
         ///
+        /// This value is matched case-insensitively.
+        ///
         /// Valid values | "Mainnet", "Testnet", "Stagenet", "FakeChain"
+        ##[serde(deserialize_with = "deserialize_from_str")]
         pub network: Network,
 
         /// Enable/disable fast sync.
@@ -241,7 +345,7 @@ impl Config {
     ///
     /// Will return an [`Err`] if the file cannot be read or if the file is not a valid [`toml`] config.
     pub fn read_from_path(file: impl AsRef<Path>) -> Result<Self, anyhow::Error> {
-        let file_text = read_to_string(file.as_ref())?;
+        let file_text = trim_config_text(read_to_string(file.as_ref())?);
 
         let config: Self = toml::from_str(&file_text).with_context(|| {
             format!(
@@ -552,6 +656,7 @@ mod test {
     use toml::{from_str, to_string};
 
     use super::*;
+    use crate::p2p::ProxySettings;
 
     #[test]
     fn documented_config() {
@@ -559,6 +664,152 @@ mod test {
         let conf: Config = from_str(&str).unwrap();
 
         assert_eq!(conf, Config::default());
+    }
+
+    #[test]
+    fn trim_string_values_walks_nested_structure() {
+        let toml = r#"
+network = "  Mainnet"
+
+[tor]
+mode = "Daemon "
+
+[p2p.clear_net]
+proxy = " socks5://user:pass@127.0.0.1:9050"
+"#;
+
+        let (cleaned, trimmed) = trim_string_values(toml).unwrap();
+        assert_eq!(trimmed, ["network", "tor.mode", "p2p.clear_net.proxy"]);
+
+        let config: Config = from_str(&cleaned).unwrap();
+        assert_eq!(config.network, Network::Mainnet);
+        assert_eq!(config.tor.mode, TorMode::Daemon);
+        assert!(matches!(
+            config.p2p.clear_net.proxy,
+            ProxySettings::Socks(_)
+        ));
+    }
+
+    #[test]
+    fn trim_string_values_arrays_and_inline_tables() {
+        #[derive(Deserialize)]
+        struct T {
+            a: Vec<String>,
+            b: B,
+            d: Vec<D>,
+        }
+        #[derive(Deserialize)]
+        struct B {
+            c: String,
+        }
+        #[derive(Deserialize)]
+        struct D {
+            e: String,
+        }
+
+        let toml = r#"
+a = ["  x", "y  ", "z"]
+b = { c = " v " }
+
+[[d]]
+e = " w"
+"#;
+
+        let (cleaned, trimmed) = trim_string_values(toml).unwrap();
+        assert_eq!(trimmed, ["a[0]", "a[1]", "b.c", "d[0].e"]);
+
+        let t: T = from_str(&cleaned).unwrap();
+        assert_eq!(t.a, ["x", "y", "z"]);
+        assert_eq!(t.b.c, "v");
+        assert_eq!(t.d[0].e, "w");
+    }
+
+    #[test]
+    fn trim_string_values_no_changes() {
+        let toml = "a = \"x\"\nb = 1\n";
+
+        let (cleaned, trimmed) = trim_string_values(toml).unwrap();
+        assert!(trimmed.is_empty());
+        assert_eq!(cleaned, toml);
+    }
+
+    #[test]
+    fn trim_string_values_keeps_whitespace_only_values() {
+        // An all-whitespace proxy must NOT be trimmed to "" (proxy disabled),
+        // the field's own parser must reject it like it did before trimming existed.
+        let toml = "[p2p.clear_net]\nproxy = \" \"\n";
+
+        let (cleaned, trimmed) = trim_string_values(toml).unwrap();
+        assert!(trimmed.is_empty());
+        assert_eq!(cleaned, toml);
+        assert!(from_str::<Config>(&cleaned).is_err());
+    }
+
+    #[test]
+    fn trim_string_values_invalid_toml() {
+        assert!(trim_string_values("a = = 1").is_none());
+    }
+
+    #[test]
+    fn config_values_ignore_ascii_case() {
+        let config: Config = from_str(r#"network = "MAINNET""#).unwrap();
+        assert_eq!(config.network, Network::Mainnet);
+
+        let config: Config = from_str(r#"network = "fakechain""#).unwrap();
+        assert_eq!(config.network, Network::FakeChain);
+
+        let config: Config = from_str("[tor]\nmode = \"daemon\"").unwrap();
+        assert_eq!(config.tor.mode, TorMode::Daemon);
+
+        let config: Config = from_str(r#"target_max_memory = "default""#).unwrap();
+        assert_eq!(config.target_max_memory, DefaultOrCustom::Default);
+
+        let config: Config = from_str("[p2p.clear_net]\nproxy = \"tor\"").unwrap();
+        assert_eq!(config.p2p.clear_net.proxy, ProxySettings::Tor);
+
+        let config: Config = from_str("[p2p.clear_net]\nproxy = \"TOR\"").unwrap();
+        assert_eq!(config.p2p.clear_net.proxy, ProxySettings::Tor);
+
+        let config: Config =
+            from_str("[p2p.clear_net]\nproxy = \"SOCKS5://127.0.0.1:9050\"").unwrap();
+        assert!(matches!(
+            config.p2p.clear_net.proxy,
+            ProxySettings::Socks(_)
+        ));
+    }
+
+    #[test]
+    fn config_values_still_reject_invalid_strings() {
+        assert!(from_str::<Config>(r#"network = "mainnet2""#).is_err());
+        assert!(from_str::<Config>("network = 5").is_err());
+        assert!(from_str::<Config>("[tor]\nmode = \"daemonn\"").is_err());
+        assert!(from_str::<Config>(r#"target_max_memory = "defaults""#).is_err());
+        assert!(from_str::<Config>("target_max_memory = -5").is_err());
+    }
+
+    #[test]
+    fn default_or_custom_custom_values_parse() {
+        let config: Config = from_str("target_max_memory = 1000").unwrap();
+        assert_eq!(config.target_max_memory, DefaultOrCustom::Custom(1000));
+    }
+
+    #[test]
+    fn read_from_path_trims_string_values() {
+        let tmp_dir = tempdir().unwrap();
+        let config_path = tmp_dir.path().join("config.toml");
+        fs::write(&config_path, "network = \" Mainnet \"\n").unwrap();
+
+        let config = Config::read_from_path(config_path).unwrap();
+        assert_eq!(config.network(), Network::Mainnet);
+    }
+
+    #[test]
+    fn read_from_path_invalid_toml_still_errors() {
+        let tmp_dir = tempdir().unwrap();
+        let config_path = tmp_dir.path().join("config.toml");
+        fs::write(&config_path, "network = = 1\n").unwrap();
+
+        assert!(Config::read_from_path(config_path).is_err());
     }
 
     #[test]

--- a/binaries/cuprated/src/config/default.rs
+++ b/binaries/cuprated/src/config/default.rs
@@ -1,4 +1,4 @@
-use serde::{Deserialize, Serialize};
+use serde::{de::Error, Deserialize, Deserializer, Serialize};
 
 /// An enum that can be either a default value or a custom value.
 ///
@@ -7,11 +7,38 @@ use serde::{Deserialize, Serialize};
 ///
 /// The [`DefaultOrCustom::Default`] variant will be serialised as a string: "Default",
 /// [`DefaultOrCustom::Custom`] will just use the serialisation of the inner value.
-#[derive(Copy, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+///
+/// Deserialisation of the [`DefaultOrCustom::Default`] variant ignores ASCII case,
+/// so "default" and "DEFAULT" are also accepted. This means `T` must not be a
+/// string-like type, otherwise the string "default" would never reach it.
+#[derive(Copy, Clone, Debug, Serialize, PartialEq, Eq)]
 pub enum DefaultOrCustom<T> {
     Default,
     #[serde(untagged)]
     Custom(T),
+}
+
+impl<'de, T: Deserialize<'de>> Deserialize<'de> for DefaultOrCustom<T> {
+    /// This is implemented manually (instead of derived with `#[serde(untagged)]`)
+    /// so that the "Default" keyword is matched case-insensitively, see:
+    /// <https://github.com/Cuprate/cuprate/issues/598>.
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = toml::Value::deserialize(deserializer)?;
+
+        let is_default =
+            matches!(&value, toml::Value::String(s) if s.eq_ignore_ascii_case("default"));
+
+        if is_default {
+            Ok(Self::Default)
+        } else {
+            T::deserialize(value)
+                .map(Self::Custom)
+                .map_err(D::Error::custom)
+        }
+    }
 }
 
 impl<T> DefaultOrCustom<T> {

--- a/binaries/cuprated/src/config/p2p.rs
+++ b/binaries/cuprated/src/config/p2p.rs
@@ -230,6 +230,9 @@ config_struct! {
         ///
         /// Enabling this setting will disable inbound connections.
         ///
+        /// The "Tor" value and the "socks5://" scheme are
+        /// matched case-insensitively.
+        ///
         /// Type         | String
         /// Valid values | "Tor", "socks5://ip:port", "socks5://user:pass@ip:port"
         /// Examples     | "Tor", "socks5://127.0.0.1:9050"

--- a/binaries/cuprated/src/config/tor.rs
+++ b/binaries/cuprated/src/config/tor.rs
@@ -96,9 +96,12 @@ config_struct! {
         /// When "Daemon" is set, the Tor daemon address to use can be
         /// specified in `tor.daemon.address`.
         ///
+        /// This value is matched case-insensitively.
+        ///
         /// Type         | String
         /// Valid values | "Auto", "Arti", "Daemon"
         /// Examples     | "Arti"
+        ##[serde(deserialize_with = "crate::config::deserialize_from_str")]
         pub mode: TorMode,
 
         #[child = true]

--- a/binaries/cuprated/src/logging.rs
+++ b/binaries/cuprated/src/logging.rs
@@ -145,8 +145,18 @@ pub fn modify_file_output(f: impl FnOnce(&mut CupratedTracingFilter)) {
 
 /// Prints some text using [`eprintln`], with [`nu_ansi_term::Color::Red`] applied.
 pub fn eprintln_red(s: &str) {
+    eprintln_color(nu_ansi_term::Color::Red, s);
+}
+
+/// Prints some text using [`eprintln`], with [`nu_ansi_term::Color::Yellow`] applied.
+pub fn eprintln_yellow(s: &str) {
+    eprintln_color(nu_ansi_term::Color::Yellow, s);
+}
+
+/// Prints some text using [`eprintln`], with the given [`nu_ansi_term::Color`] applied.
+fn eprintln_color(color: nu_ansi_term::Color, s: &str) {
     if ansi_enabled(&std::io::stderr()) {
-        eprintln!("{}", nu_ansi_term::Color::Red.bold().paint(s));
+        eprintln!("{}", color.bold().paint(s));
     } else {
         eprintln!("{s}");
     }

--- a/binaries/cuprated/src/p2p.rs
+++ b/binaries/cuprated/src/p2p.rs
@@ -60,10 +60,12 @@ impl TryFrom<String> for ProxySettings {
     fn try_from(s: String) -> Result<Self, Self::Error> {
         match s.as_str() {
             "" => Ok(Self::Disabled),
-            "Tor" => Ok(Self::Tor),
-            // TODO: use `if let` guard when on >=1.95
-            url if url.starts_with("socks5://") => {
-                let url = url.strip_prefix("socks5://").unwrap();
+            s if s.eq_ignore_ascii_case("tor") => Ok(Self::Tor),
+            url if url
+                .get(..9)
+                .is_some_and(|scheme| scheme.eq_ignore_ascii_case("socks5://")) =>
+            {
+                let url = url.get(9..).unwrap_or_default();
 
                 let (authentication, addr) = match url.rsplit_once('@') {
                     Some((userpass, addr)) => {

--- a/binaries/cuprated/src/tor.rs
+++ b/binaries/cuprated/src/tor.rs
@@ -4,8 +4,9 @@
 
 //---------------------------------------------------------------------------------------------------- Imports
 
-use std::{default, sync::Arc};
+use std::{default, str::FromStr, sync::Arc};
 
+use anyhow::anyhow;
 use serde::{Deserialize, Serialize};
 use tracing::info;
 
@@ -48,6 +49,27 @@ pub enum TorMode {
     Arti,
     /// Use of external tor daemon
     Daemon,
+}
+
+impl FromStr for TorMode {
+    type Err = anyhow::Error;
+
+    /// Parses a [`TorMode`] from a string, ignoring ASCII case.
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            s if s.eq_ignore_ascii_case("auto") => Ok(Self::Auto),
+            s if s.eq_ignore_ascii_case("daemon") => Ok(Self::Daemon),
+            #[cfg(feature = "arti")]
+            s if s.eq_ignore_ascii_case("arti") => Ok(Self::Arti),
+            #[cfg(not(feature = "arti"))]
+            s if s.eq_ignore_ascii_case("arti") => Err(anyhow!(
+                "\"Arti\" mode requires cuprated to be built with the `arti` feature"
+            )),
+            _ => Err(anyhow!(
+                "invalid Tor mode: '{s}', expected one of \"Auto\", \"Arti\", \"Daemon\" (case-insensitive)"
+            )),
+        }
+    }
 }
 
 /// Contains the necessary Tor configuration or structures

--- a/helper/src/network.rs
+++ b/helper/src/network.rs
@@ -51,15 +51,26 @@ impl Network {
 #[derive(Debug, PartialEq, Eq)]
 pub struct ParseNetworkError;
 
+impl core::error::Error for ParseNetworkError {}
+
+impl Display for ParseNetworkError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        f.write_str(
+            r#"invalid network, expected one of "Mainnet", "Testnet", "Stagenet", "FakeChain" (case-insensitive)"#,
+        )
+    }
+}
+
 impl FromStr for Network {
     type Err = ParseNetworkError;
 
+    /// Parses a [`Network`] from a string, ignoring ASCII case.
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "mainnet" | "Mainnet" => Ok(Self::Mainnet),
-            "testnet" | "Testnet" => Ok(Self::Testnet),
-            "stagenet" | "Stagenet" => Ok(Self::Stagenet),
-            "fakechain" | "FakeChain" => Ok(Self::FakeChain),
+            s if s.eq_ignore_ascii_case("mainnet") => Ok(Self::Mainnet),
+            s if s.eq_ignore_ascii_case("testnet") => Ok(Self::Testnet),
+            s if s.eq_ignore_ascii_case("stagenet") => Ok(Self::Stagenet),
+            s if s.eq_ignore_ascii_case("fakechain") => Ok(Self::FakeChain),
             _ => Err(ParseNetworkError),
         }
     }
@@ -72,5 +83,37 @@ impl Display for Network {
             Self::Stagenet => "stagenet",
             Self::FakeChain => "fakechain",
         })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn from_str_ignores_ascii_case() {
+        for (input, expected) in [
+            ("mainnet", Network::Mainnet),
+            ("Mainnet", Network::Mainnet),
+            ("MAINNET", Network::Mainnet),
+            ("testnet", Network::Testnet),
+            ("Testnet", Network::Testnet),
+            ("TESTNET", Network::Testnet),
+            ("stagenet", Network::Stagenet),
+            ("Stagenet", Network::Stagenet),
+            ("STAGENET", Network::Stagenet),
+            ("fakechain", Network::FakeChain),
+            ("FakeChain", Network::FakeChain),
+            ("FAKECHAIN", Network::FakeChain),
+        ] {
+            assert_eq!(input.parse(), Ok(expected));
+        }
+    }
+
+    #[test]
+    fn from_str_rejects_invalid_networks() {
+        for input in ["", "mainnet2", " mainnet", "main net"] {
+            assert_eq!(input.parse::<Network>(), Err(ParseNetworkError));
+        }
     }
 }


### PR DESCRIPTION
### What
Closes #598.

Two changes to how `cuprated` reads string values from the config file:

1. Leading/trailing whitespace in string values is trimmed before parsing.  A warning naming the exact key is printed for each trimmed value, e.g.:
   ```
   Warning: ignoring leading/trailing whitespace in config value `p2p.clear_net.proxy`
   ```
   This is option 1 from the issue discussion (warn, trim, proceed).  The trim pass returns the list of trimmed key paths, so switching to option 2 (error and exit) is a one-line change in `trim_config_text` if that is preferred.

   One deliberate exception: a value that would become *empty* when trimmed is left untouched, so the field's own parser rejects it loudly.  Without this, an all-whitespace `proxy = " "` would silently collapse to `""` (proxy disabled) where it previously hard-errored, which seemed unacceptable for a privacy-relevant field.

2. String values that map to enum-like types now match case-insensitively:
   - `network`: "mainnet", "MAINNET", "FakeChain", ... all work
   - `tor.mode`: "auto", "Daemon", "ARTI", ...
   - `p2p.clear_net.proxy`: "tor" and the "SOCKS5://" scheme (schemes are case-insensitive per RFC 3986; the user:pass and address parts are untouched)
   - the "Default" keyword on every `DefaultOrCustom` field ("default", "DEFAULT", ...)
   - log levels were already case-insensitive via `LevelFilter`'s `FromStr`, so nothing changed there

### Why
Whitespace typos in config files produce confusing errors (see the discussion in #596 that prompted this issue), and users should not need to know Rust's UpperCamelCase enum variant convention to write a config file.

### Where
- `binaries/cuprated/src/config.rs`: trim pass + warnings in `Config::read_from_path`, shared `deserialize_from_str` helper, tests
- `binaries/cuprated/src/config/default.rs`: manual `Deserialize` for `DefaultOrCustom`
- `binaries/cuprated/src/config/{tor,p2p}.rs`: field attributes + doc updates
- `binaries/cuprated/src/tor.rs`: case-insensitive `FromStr` for `TorMode` (without the `arti` feature, "arti" input now gets an actionable "requires the `arti` feature" error instead of an opaque unknown-variant error)
- `binaries/cuprated/src/p2p.rs`: case-insensitive matching in `ProxySettings::try_from`
- `binaries/cuprated/src/logging.rs`: `eprintln_yellow` (shared impl with `eprintln_red`)
- `helper/src/network.rs`: `Network::FromStr` widened to ASCII-case-insensitive, `Display` + `core::error::Error` for `ParseNetworkError`, tests

### How
- `Config::read_from_path` first parses the file with `toml_edit` and walks every string value (nested tables, inline tables, arrays, arrays-of-tables), trimming whitespace and recording the dotted key path of every change, then hands the cleaned text to the existing `toml::from_str` path.  If the file is not parseable TOML the text is passed through unchanged, so error reporting for invalid files is identical to before (covered by a test).
- Case-insensitivity is implemented where each type is defined: `Network` and `TorMode` get case-insensitive `FromStr` impls wired into serde by a shared `deserialize_from_str` helper (same pattern as the existing `level_filter_serde`), `ProxySettings::try_from` compares with `eq_ignore_ascii_case`, and `DefaultOrCustom` implements `Deserialize` manually (the derived `untagged` setup cannot case-fold the "Default" keyword).  As a bonus, `DefaultOrCustom` parse failures now produce concrete "invalid type" messages instead of the derive's "data did not match any variant".
- Serialization is untouched everywhere, so `--generate-config` output is unchanged apart from the new doc lines, and `Network`'s derived serde impls (used outside the config) are unchanged; only `cuprated`'s config fields opt into the case-insensitive path.  The CLI `--network` flag (clap `PossibleValuesParser`, lowercase-only) is also unchanged; happy to unify it with `.ignore_case(true)` here or in a follow-up if wanted.

Known limitation: `toml_edit` 0.23 targets TOML spec 1.0 while `toml` 0.9 targets 1.1, so a config using 1.1-only syntax would skip the trim pass (falling back to today's behavior, with the regular parse still succeeding).  Both crates sit on the same `toml_parser`, so this is a narrow edge that disappears as `toml_edit` adopts 1.1.

The trim walker is exercised against synthetic TOML (arrays, inline tables, arrays-of-tables) rather than `Config` because `Config` currently has no string arrays; the warning emission itself is a plain `eprintln` and is not unit-tested, but the path-collection seam it wraps is.

Disclosure: portions of this change were drafted with AI assistance.  I have personally reviewed, tested, and verified every line, and I take full responsibility for its correctness.
