### PR TITLE
cuprated: redact transaction hashes from logs

### DIFF
--- a/binaries/cuprated/src/args.rs
+++ b/binaries/cuprated/src/args.rs
@@ -39,6 +39,13 @@ pub struct Args {
     #[arg(long)]
     no_fast_sync: bool,
 
+    /// Show sensitive data in logs instead of redacting it.
+    ///
+    /// By default cuprated redacts sensitive data (such as transaction hashes) from logs. This
+    /// shows the raw values, which is useful for debugging but makes the log file more sensitive.
+    #[arg(long)]
+    no_redact: bool,
+
     /// The amount of outbound clear-net connections to maintain.
     #[arg(long)]
     pub outbound_connections: Option<usize>,
@@ -101,6 +108,7 @@ impl Args {
             config.fixed_difficulty = fixed_difficulty;
         }
         config.fast_sync = config.fast_sync && !self.no_fast_sync;
+        config.tracing.redact = config.tracing.redact && !self.no_redact;
 
         if let Some(outbound_connections) = self.outbound_connections {
             config.p2p.clear_net.outbound_connections = outbound_connections;

--- a/binaries/cuprated/src/config/tracing_config.rs
+++ b/binaries/cuprated/src/config/tracing_config.rs
@@ -5,9 +5,21 @@ use super::macros::config_struct;
 
 config_struct! {
     /// [`tracing`] config.
-    #[derive(Debug, Default, Deserialize, Serialize, Eq, PartialEq)]
+    #[derive(Debug, Deserialize, Serialize, Eq, PartialEq)]
     #[serde(deny_unknown_fields, default)]
     pub struct TracingConfig {
+        /// Redact sensitive data from logs.
+        ///
+        /// When enabled, sensitive values such as transaction hashes are
+        /// replaced with `[scrubbed]` in logs, so a shared log file does not
+        /// leak data that could deanonymise you or your peers.
+        ///
+        /// Disable this only if you need the raw values, e.g. for debugging.
+        ///
+        /// Type         | boolean
+        /// Valid values | true, false
+        pub redact: bool,
+
         #[child = true]
         /// Configuration for cuprated's stdout logging system.
         pub stdout: StdoutTracingConfig,
@@ -15,6 +27,16 @@ config_struct! {
         #[child = true]
         /// Configuration for cuprated's file logging system.
         pub file: FileTracingConfig,
+    }
+}
+
+impl Default for TracingConfig {
+    fn default() -> Self {
+        Self {
+            redact: true,
+            stdout: StdoutTracingConfig::default(),
+            file: FileTracingConfig::default(),
+        }
     }
 }
 
@@ -75,6 +97,22 @@ impl Default for FileTracingConfig {
             level: LevelFilter::DEBUG,
             max_log_files: 7,
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn redact_defaults_to_true() {
+        assert!(TracingConfig::default().redact);
+    }
+
+    #[test]
+    fn redact_can_be_disabled() {
+        let config: TracingConfig = toml::from_str("redact = false").unwrap();
+        assert!(!config.redact);
     }
 }
 

--- a/binaries/cuprated/src/logging.rs
+++ b/binaries/cuprated/src/logging.rs
@@ -29,6 +29,12 @@ use cuprate_helper::fs::logs_path;
 
 use crate::config::Config;
 
+/// A [`OnceLock`] which holds the [`safelog::Guard`] that disables log redaction.
+///
+/// Only set when the user opts out of redaction; while it is held, sensitive
+/// values are shown in cleartext. Initialized in [`init_logging`].
+static SAFE_LOGGING_GUARD: OnceLock<safelog::Guard> = OnceLock::new();
+
 /// A [`OnceLock`] which holds the [`Handle`] to update the file logging output.
 ///
 /// Initialized in [`init_logging`].
@@ -85,6 +91,16 @@ impl<S> Filter<S> for CupratedTracingFilter {
 
 /// Initialize [`tracing`] for logging to stdout and to a file.
 pub fn init_logging(config: &Config) {
+    // `safelog` redacts sensitive values (e.g. transaction hashes) from logs by
+    // default. If the user has opted out, disable redaction for the lifetime of
+    // the process.
+    if !config.tracing.redact {
+        let guard = safelog::disable_safe_logging().expect("nothing else enforces safe logging");
+        SAFE_LOGGING_GUARD
+            .set(guard)
+            .expect("init_logging must only be called once");
+    }
+
     // initialize the stdout filter, set `STDOUT_FILTER_HANDLE` and create the layer.
     let (stdout_filter, stdout_handle) = ReloadLayer::new(CupratedTracingFilter {
         level: config.tracing.stdout.level,

--- a/binaries/cuprated/src/txpool/incoming_tx.rs
+++ b/binaries/cuprated/src/txpool/incoming_tx.rs
@@ -7,6 +7,7 @@ use std::{
 use bytes::Bytes;
 use futures::{future::BoxFuture, FutureExt};
 use monero_oxide::transaction::Transaction;
+use safelog::Sensitive;
 use tokio::sync::{mpsc, oneshot, RwLock};
 use tower::{BoxError, Service, ServiceExt};
 use tracing::instrument;
@@ -228,7 +229,7 @@ async fn handle_incoming_txs(
         // Maybe we should remember these invalid txs for some time to prevent them getting repeatedly sent.
         if let Err(e) = check_tx_relay_rules(&tx, context) {
             if drop_relay_rule_errors {
-                tracing::debug!(err = %e, tx = hex::encode(tx.tx_hash), "Tx failed relay check, skipping.");
+                tracing::debug!(err = %e, tx = %Sensitive::new(hex::encode(tx.tx_hash)), "Tx failed relay check, skipping.");
                 continue;
             }
 
@@ -236,7 +237,7 @@ async fn handle_incoming_txs(
         }
 
         tracing::debug!(
-            tx = hex::encode(tx.tx_hash),
+            tx = %Sensitive::new(hex::encode(tx.tx_hash)),
             "passing tx to tx-pool manager"
         );
 

--- a/binaries/cuprated/src/txpool/manager.rs
+++ b/binaries/cuprated/src/txpool/manager.rs
@@ -7,6 +7,7 @@ use bytes::Bytes;
 use futures::StreamExt;
 use indexmap::IndexMap;
 use rand::Rng;
+use safelog::Sensitive;
 use tokio::sync::{mpsc, oneshot};
 use tokio_util::{sync::CancellationToken, time::delay_queue, time::DelayQueue};
 use tower::{Service, ServiceExt};
@@ -224,7 +225,7 @@ impl TxpoolManager {
     /// # Panics
     ///
     /// This function will panic if the tx is not in the tx-pool manager.
-    #[instrument(level = "debug", skip_all, fields(tx_id = hex::encode(tx)))]
+    #[instrument(level = "debug", skip_all, fields(tx_id = %Sensitive::new(hex::encode(tx))))]
     async fn remove_tx_from_pool(&mut self, tx: [u8; 32], remove_from_db: bool) {
         tracing::debug!("removing tx from pool");
 
@@ -250,7 +251,7 @@ impl TxpoolManager {
     /// # Panics
     ///
     /// This function will panic if the tx is not in the tx-pool.
-    #[instrument(level = "debug", skip_all, fields(tx_id = hex::encode(tx)))]
+    #[instrument(level = "debug", skip_all, fields(tx_id = %Sensitive::new(hex::encode(tx))))]
     async fn rerelay_tx(&mut self, tx: [u8; 32]) {
         tracing::debug!("re-relaying tx to network");
 
@@ -277,7 +278,7 @@ impl TxpoolManager {
 
     /// Handles a transaction timeout, be either rebroadcasting or dropping the tx from the pool.
     /// If a rebroadcast happens, this function will handle adding another timeout to the queue.
-    #[instrument(level = "debug", skip_all, fields(tx_id = hex::encode(tx)))]
+    #[instrument(level = "debug", skip_all, fields(tx_id = %Sensitive::new(hex::encode(tx))))]
     async fn handle_tx_timeout(&mut self, tx: [u8; 32]) {
         let Some(tx_info) = self.current_txs.get(&tx) else {
             tracing::warn!("tx timed out, but tx not in pool");
@@ -312,7 +313,7 @@ impl TxpoolManager {
     }
 
     /// Adds a tx to the tx-pool manager.
-    #[instrument(level = "trace", skip_all, fields(tx_id = hex::encode(tx)))]
+    #[instrument(level = "trace", skip_all, fields(tx_id = %Sensitive::new(hex::encode(tx))))]
     fn track_tx(&mut self, tx: [u8; 32], weight: usize, fee: u64, private: bool) {
         let now = current_unix_timestamp();
 
@@ -340,7 +341,7 @@ impl TxpoolManager {
     }
 
     /// Handles an incoming tx, adding it to the pool and routing it.
-    #[instrument(level = "debug", skip_all, fields(tx_id = hex::encode(tx.tx_hash), state))]
+    #[instrument(level = "debug", skip_all, fields(tx_id = %Sensitive::new(hex::encode(tx.tx_hash)), state))]
     async fn handle_incoming_tx(
         &mut self,
         tx: TransactionVerificationData,
@@ -370,7 +371,7 @@ impl TxpoolManager {
 
         if let Some(tx_hash) = double_spend {
             tracing::debug!(
-                double_spent = hex::encode(tx_hash),
+                double_spent = %Sensitive::new(hex::encode(tx_hash)),
                 "transaction is a double spend, ignoring"
             );
             return;
@@ -394,7 +395,7 @@ impl TxpoolManager {
     }
 
     /// Promote a tx to the public pool.
-    #[instrument(level = "debug", skip_all, fields(tx_id = hex::encode(tx)))]
+    #[instrument(level = "debug", skip_all, fields(tx_id = %Sensitive::new(hex::encode(tx))))]
     async fn promote_tx(&mut self, tx: [u8; 32]) {
         let Some(tx_info) = self.current_txs.get_mut(&tx) else {
             tracing::debug!("not promoting tx, tx not in pool");


### PR DESCRIPTION
### What
Adds opt-out redaction of sensitive data from logs, and applies it to the transaction-hash log sites in `cuprated`'s txpool.  This is a first slice of #540, not the whole thing (see "Scope" below).

- New config option `tracing.redact` (default `true`) and a `--no-redact` CLI flag.  When redaction is on (the default), sensitive values are shown as `[scrubbed]`; `--no-redact` (or `redact = false`) shows the raw values.
- Uses [`safelog`](https://docs.rs/safelog) (already a workspace dependency, pulled in by `cuprated` via arti), which is the crate the issue links to.  `safelog` redacts by default; at startup `cuprated` holds a process-lifetime `disable_safe_logging()` guard only when the user opts out.
- Wraps the 8 transaction-hash log/span sites in `txpool/{incoming_tx,manager}.rs` with `safelog::Sensitive`.

Example, default vs `--no-redact`:
```
# default
DEBUG handle_incoming_tx{tx_id=[scrubbed]}: passing tx to tx-pool manager
# --no-redact
DEBUG handle_incoming_tx{tx_id=a1b2...f9}: passing tx to tx-pool manager
```

This matters because the file log defaults to `debug` level, so these transaction hashes were being written to the log file by default.

### Why
Per the issue: to stop the log file from being a target.  A stem-phase transaction hash in a log links a transaction to the node that originated it, so redacting it by default is a privacy win, with an opt-out for debugging (matching the "opt-out by config/command line" decision in the thread).

### Where
- `binaries/cuprated/src/config/tracing_config.rs`: `tracing.redact` field (+ manual `Default`, tests)
- `binaries/cuprated/src/args.rs`: `--no-redact` flag, applied in `apply_args`
- `binaries/cuprated/src/logging.rs`: hold the `safelog` guard for the process when opted out
- `binaries/cuprated/src/txpool/{incoming_tx,manager}.rs`: wrap tx-hash log/span values in `Sensitive`

### How
`safelog::Sensitive<T>` Displays as `[scrubbed]` while safe-logging is enabled (the default) and as the inner value otherwise.  The log sites use the `%` (Display) sigil so the redaction decision is read from `safelog`'s global flag at record time.  The global flag is set once at startup in `init_logging` (before any tx flows), so the behavior is stable for the process.  Both stdout and file logs are redacted (the value is scrubbed at the `Display` layer, before reaching either).

### Scope (what this PR deliberately does NOT do)
To keep the diff contained and avoid unilaterally adding a dependency to library crates, this PR covers only the transaction-hash sites in the `cuprated` binary.  Left for follow-up / discussion:

- **Peer / onion addresses in library crates** (`p2p-core`: handshaker, connector, timeout_monitor spans; `p2p`: seed-node logging; `address-book`: ban/peer-list logging).  These need `safelog` added as a dependency to those crates.  `safelog` already implements `Redactable` for `IpAddr`/`SocketAddr` (partial redaction like `1.2.x.x`), so the extension is mechanical once the dependency is acceptable.  Happy to do it here or separately, your call.
- **The startup `info!("{config}")` dump** (`main.rs`), which prints the node's own config including its onion address and bind/proxy addresses via `Debug`.  That is the node's own configuration rather than per-tx/per-peer data, and redacting it needs a different approach (the `Config` `Debug`/`Display` impl, not per-call-site wrapping); flagging it rather than bundling it.
- **Block hashes** (`blockchain/manager/handler.rs`) and the **RPC bind-address** logs (`rpc/server.rs`) are left unredacted on purpose: block hashes are public chain data, and the RPC bind address is operator-local config, so scrubbing them would cost readability without a privacy benefit.

Open questions for maintainers: (1) OK to add `safelog` to `p2p-core`/`p2p`/`address-book` for the address sites?  (2) redact at all levels (current behavior) or only `info`+ as the arti guideline suggests?

Disclosure: portions of this change were drafted with AI assistance.  I have personally reviewed, tested, and verified every line, and I take full responsibility for its correctness.