### PR TITLE
cuprated: hide sensitive data in logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1301,6 +1301,7 @@ dependencies = [
  "hex",
  "hex-literal 1.1.0",
  "rand 0.8.8",
+ "safelog",
  "thiserror 2.0.20",
  "tokio",
  "tokio-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1317,6 +1317,7 @@ dependencies = [
  "hex",
  "hex-literal 1.1.0",
  "rand 0.8.7",
+ "safelog",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",

--- a/binaries/cuprated/Cargo.toml
+++ b/binaries/cuprated/Cargo.toml
@@ -15,7 +15,7 @@ name = "cuprated"
 
 [features]
 default = ["arti"]
-arti = ["arti-client", "tor-hsservice", "tor-persist", "tor-rtcompat", "cuprate-p2p-transport/arti", "dep:safelog"]
+arti = ["arti-client", "tor-hsservice", "tor-persist", "tor-rtcompat", "cuprate-p2p-transport/arti"]
 mimalloc = ["dep:mimalloc"]
 mimalloc-secure = ["mimalloc", "mimalloc/secure"]
 jemalloc = ["dep:tikv-jemallocator"]
@@ -64,7 +64,7 @@ monero-oxide          = { workspace = true, features = ["std", "compile-time-gen
 nu-ansi-term          = { workspace = true }
 pin-project-lite      = { workspace = true }
 rayon                 = { workspace = true }
-safelog               = { workspace = true, optional = true }
+safelog               = { workspace = true }
 serde_json            = { workspace = true }
 serde                 = { workspace = true }
 sysinfo               = { workspace = true, features = ["system"] }

--- a/binaries/cuprated/src/args.rs
+++ b/binaries/cuprated/src/args.rs
@@ -66,6 +66,13 @@ pub(crate) struct Args {
     #[arg(long)]
     pub offline: bool,
 
+    /// Show sensitive data in logs instead of redacting it.
+    ///
+    /// Off by default. Do not disable this on a public or shared node, as the log
+    /// file becomes a deanonymization target.
+    #[arg(long)]
+    no_log_redact: bool,
+
     /// The amount of outbound clear-net connections to maintain.
     #[arg(long)]
     pub outbound_connections: Option<usize>,
@@ -143,6 +150,7 @@ impl Args {
             config.fixed_difficulty = fixed_difficulty;
         }
         config.fast_sync = config.fast_sync && !self.no_fast_sync;
+        config.tracing.redact = config.tracing.redact && !self.no_log_redact;
 
         if let Some(outbound_connections) = self.outbound_connections {
             config.p2p.clear_net.outbound_connections = outbound_connections;

--- a/binaries/cuprated/src/args.rs
+++ b/binaries/cuprated/src/args.rs
@@ -43,6 +43,13 @@ pub struct Args {
     #[arg(long)]
     pub offline: bool,
 
+    /// Show sensitive data in logs instead of redacting it.
+    ///
+    /// Off by default. Do not disable this on a public or shared node, as the log
+    /// file becomes a deanonymization target.
+    #[arg(long)]
+    no_log_redact: bool,
+
     /// The amount of outbound clear-net connections to maintain.
     #[arg(long)]
     pub outbound_connections: Option<usize>,
@@ -108,6 +115,7 @@ impl Args {
             config.fixed_difficulty = fixed_difficulty;
         }
         config.fast_sync = config.fast_sync && !self.no_fast_sync;
+        config.tracing.redact = config.tracing.redact && !self.no_log_redact;
 
         if let Some(outbound_connections) = self.outbound_connections {
             config.p2p.clear_net.outbound_connections = outbound_connections;

--- a/binaries/cuprated/src/config/tor.rs
+++ b/binaries/cuprated/src/config/tor.rs
@@ -49,7 +49,7 @@ config_struct! {
     }
 
     /// Tor config
-    #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+    #[derive(Clone, Deserialize, Serialize, PartialEq, Eq)]
     #[serde(deny_unknown_fields, default)]
     #[allow(rustdoc::broken_intra_doc_links)]
     pub struct TorDaemonConfig {
@@ -112,6 +112,19 @@ config_struct! {
         ///
         /// Only relevant if `tor.mode` is set to "Daemon"
         pub daemon: TorDaemonConfig,
+    }
+}
+
+impl std::fmt::Debug for TorDaemonConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TorDaemonConfig")
+            .field("address", &self.address)
+            .field(
+                "anonymous_inbound",
+                &safelog::sensitive(&self.anonymous_inbound),
+            )
+            .field("listening_addr", &self.listening_addr)
+            .finish()
     }
 }
 

--- a/binaries/cuprated/src/config/tor.rs
+++ b/binaries/cuprated/src/config/tor.rs
@@ -118,13 +118,16 @@ config_struct! {
 
 impl Debug for TorDaemonConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let Self {
+            address,
+            anonymous_inbound,
+            listening_addr,
+        } = self;
+
         f.debug_struct("TorDaemonConfig")
-            .field("address", &self.address)
-            .field(
-                "anonymous_inbound",
-                &safelog::sensitive(&self.anonymous_inbound),
-            )
-            .field("listening_addr", &self.listening_addr)
+            .field("address", address)
+            .field("anonymous_inbound", &safelog::sensitive(anonymous_inbound))
+            .field("listening_addr", listening_addr)
             .finish()
     }
 }

--- a/binaries/cuprated/src/config/tor.rs
+++ b/binaries/cuprated/src/config/tor.rs
@@ -1,4 +1,5 @@
 use std::{
+    fmt::Debug,
     net::{Ipv4Addr, SocketAddr, SocketAddrV4},
     path::PathBuf,
 };
@@ -115,7 +116,7 @@ config_struct! {
     }
 }
 
-impl std::fmt::Debug for TorDaemonConfig {
+impl Debug for TorDaemonConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("TorDaemonConfig")
             .field("address", &self.address)

--- a/binaries/cuprated/src/config/tor.rs
+++ b/binaries/cuprated/src/config/tor.rs
@@ -1,4 +1,5 @@
 use std::{
+    fmt::Debug,
     net::{IpAddr, Ipv4Addr, SocketAddr, SocketAddrV4},
     path::PathBuf,
 };
@@ -115,7 +116,7 @@ config_struct! {
     }
 }
 
-impl std::fmt::Debug for TorDaemonConfig {
+impl Debug for TorDaemonConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("TorDaemonConfig")
             .field("address", &self.address)

--- a/binaries/cuprated/src/config/tracing_config.rs
+++ b/binaries/cuprated/src/config/tracing_config.rs
@@ -5,7 +5,7 @@ use super::macros::config_struct;
 
 config_struct! {
     /// [`tracing`] config.
-    #[derive(Debug, Default, Deserialize, Serialize, Eq, PartialEq)]
+    #[derive(Debug, Deserialize, Serialize, Eq, PartialEq)]
     #[serde(deny_unknown_fields, default)]
     pub struct TracingConfig {
         #[child = true]
@@ -15,6 +15,41 @@ config_struct! {
         #[child = true]
         /// Configuration for cuprated's file logging system.
         pub file: FileTracingConfig,
+
+        /// Whether to redact sensitive data (transaction hashes, peer and onion
+        /// addresses) from logs.
+        ///
+        /// When `true` (the default), such data is replaced with `[scrubbed]` (IP
+        /// addresses are partially redacted). Do not disable this on a public or
+        /// shared node, as the log file becomes a deanonymization target.
+        ///
+        /// Type         | boolean
+        /// Valid values | true, false
+        pub redact: bool,
+
+        /// Allow disabling log redaction even when RPC is publicly reachable.
+        ///
+        /// ⚠️ WARNING ⚠️
+        /// -------------
+        /// Log redaction should almost never be disabled on a public node.
+        /// If redaction is disabled (see `redact`) while RPC is bound to a
+        /// non-local address, cuprated will panic, unless this setting is
+        /// set to `true`.
+        ///
+        /// Type         | boolean
+        /// Valid values | true, false
+        pub i_know_what_im_doing_allow_unredacted_public_logs: bool,
+    }
+}
+
+impl Default for TracingConfig {
+    fn default() -> Self {
+        Self {
+            stdout: StdoutTracingConfig::default(),
+            file: FileTracingConfig::default(),
+            redact: true,
+            i_know_what_im_doing_allow_unredacted_public_logs: false,
+        }
     }
 }
 

--- a/binaries/cuprated/src/config/tracing_config.rs
+++ b/binaries/cuprated/src/config/tracing_config.rs
@@ -26,19 +26,6 @@ config_struct! {
         /// Type         | boolean
         /// Valid values | true, false
         pub redact: bool,
-
-        /// Allow disabling log redaction even when RPC is publicly reachable.
-        ///
-        /// ⚠️ WARNING ⚠️
-        /// -------------
-        /// Log redaction should almost never be disabled on a public node.
-        /// If redaction is disabled (see `redact`) while RPC is bound to a
-        /// non-local address, cuprated will panic, unless this setting is
-        /// set to `true`.
-        ///
-        /// Type         | boolean
-        /// Valid values | true, false
-        pub i_know_what_im_doing_allow_unredacted_public_logs: bool,
     }
 }
 
@@ -48,7 +35,6 @@ impl Default for TracingConfig {
             stdout: StdoutTracingConfig::default(),
             file: FileTracingConfig::default(),
             redact: true,
-            i_know_what_im_doing_allow_unredacted_public_logs: false,
         }
     }
 }

--- a/binaries/cuprated/src/logging.rs
+++ b/binaries/cuprated/src/logging.rs
@@ -85,6 +85,14 @@ impl<S> Filter<S> for CupratedTracingFilter {
 
 /// Initialize [`tracing`] for logging to stdout and to a file.
 pub fn init_logging(config: &Config) {
+    // disable log redaction if configured to do so.
+    if !config.tracing.redact {
+        match safelog::disable_safe_logging() {
+            Ok(guard) => forget(guard),
+            Err(e) => eprintln_red(&format!("failed to disable log redaction: {e}")),
+        }
+    }
+
     // initialize the stdout filter, set `STDOUT_FILTER_HANDLE` and create the layer.
     let (stdout_filter, stdout_handle) = ReloadLayer::new(CupratedTracingFilter {
         level: config.tracing.stdout.level,

--- a/binaries/cuprated/src/logging.rs
+++ b/binaries/cuprated/src/logging.rs
@@ -4,6 +4,7 @@
 use std::{
     fmt::{Display, Formatter},
     io::IsTerminal,
+    mem::forget,
     sync::OnceLock,
 };
 use tracing::{level_filters::LevelFilter, subscriber::Interest, Metadata};
@@ -84,6 +85,14 @@ impl<S> Filter<S> for CupratedTracingFilter {
 
 /// Initialize [`tracing`] for logging to stdout and to a file.
 pub fn init_logging(config: &Config) -> WorkerGuard {
+    // disable log redaction if configured to do so.
+    if !config.tracing.redact {
+        match safelog::disable_safe_logging() {
+            Ok(guard) => forget(guard),
+            Err(e) => eprintln_red(&format!("failed to disable log redaction: {e}")),
+        }
+    }
+
     // initialize the stdout filter, set `STDOUT_FILTER_HANDLE` and create the layer.
     let (stdout_filter, stdout_handle) = ReloadLayer::new(CupratedTracingFilter {
         level: config.tracing.stdout.level,

--- a/binaries/cuprated/src/main.rs
+++ b/binaries/cuprated/src/main.rs
@@ -63,8 +63,15 @@ fn main() {
     //Printing configuration
     info!("{config}");
 
-    // Initialize the thread-pools
+    // Warn if log redaction is disabled.
+    if !config.tracing.redact {
+        tracing::warn!(
+            "log redaction is disabled: transaction hashes and peer addresses will be \
+             written to logs in plaintext."
+        );
+    }
 
+    // Initialize the thread-pools
     init_global_rayon_pool(&config);
 
     let rt = init_tokio_rt(&config);

--- a/binaries/cuprated/src/main.rs
+++ b/binaries/cuprated/src/main.rs
@@ -71,6 +71,14 @@ fn main_inner() -> anyhow::Result<ExitCode> {
     //Printing configuration
     info!("{config}");
 
+    // Warn if log redaction is disabled.
+    if !config.tracing.redact {
+        tracing::warn!(
+            "log redaction is disabled: transaction hashes and peer addresses will be \
+             written to logs in plaintext."
+        );
+    }
+
     // Initialize the thread-pools
     init_global_rayon_pool(&config)?;
 

--- a/binaries/cuprated/src/rpc/server.rs
+++ b/binaries/cuprated/src/rpc/server.rs
@@ -28,6 +28,8 @@ use crate::{
 /// - the server(s) could not be started
 /// - unrestricted RPC is started on non-local
 ///   address without override option
+/// - log redaction is disabled while RPC is bound to a
+///   non-local address without override option
 pub fn init_rpc_servers(launch_ctx: &LaunchContext, tx_handler: IncomingTxHandler) {
     let config = &launch_ctx.config.rpc;
     for ((enable, addr, port, request_byte_limit), restricted) in [
@@ -66,6 +68,23 @@ pub fn init_rpc_servers(launch_ctx: &LaunchContext, tx_handler: IncomingTxHandle
                 );
             } else {
                 panic!("Refusing to start unrestricted RPC on a non-local address ({addr})");
+            }
+        }
+
+        if !cuprate_helper::net::ip_is_local(addr) && !launch_ctx.config.tracing.redact {
+            if launch_ctx
+                .config
+                .tracing
+                .i_know_what_im_doing_allow_unredacted_public_logs
+            {
+                warn!(
+                    address = %addr,
+                    "Starting RPC on non-local address with log redaction disabled, this is dangerous!"
+                );
+            } else {
+                panic!(
+                    "Refusing to start RPC on a non-local address ({addr}) with log redaction disabled"
+                );
             }
         }
 

--- a/binaries/cuprated/src/rpc/server.rs
+++ b/binaries/cuprated/src/rpc/server.rs
@@ -37,8 +37,9 @@ const RPC_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
 /// # Errors
 ///
 /// This function will return an [`Err`] if unrestricted RPC is started on a
-/// non-local address without the override option, or if an RPC listener cannot
-/// be bound.
+/// non-local address without the override option, if log redaction is disabled
+/// while RPC is bound to a non-local address without the override option, or if
+/// an RPC listener cannot be bound.
 pub(crate) async fn init_rpc_servers(
     launch_ctx: &LaunchContext,
     tx_handler: IncomingTxHandler,
@@ -80,6 +81,23 @@ pub(crate) async fn init_rpc_servers(
                 );
             } else {
                 anyhow::bail!("Refusing to start unrestricted RPC on a non-local address ({addr})");
+            }
+        }
+
+        if !ip_is_local(addr) && !launch_ctx.config.tracing.redact {
+            if launch_ctx
+                .config
+                .tracing
+                .i_know_what_im_doing_allow_unredacted_public_logs
+            {
+                warn!(
+                    address = %addr,
+                    "Starting RPC on non-local address with log redaction disabled, this is dangerous!"
+                );
+            } else {
+                anyhow::bail!(
+                    "Refusing to start RPC on a non-local address ({addr}) with log redaction disabled"
+                );
             }
         }
 

--- a/binaries/cuprated/src/rpc/server.rs
+++ b/binaries/cuprated/src/rpc/server.rs
@@ -37,9 +37,8 @@ const RPC_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
 /// # Errors
 ///
 /// This function will return an [`Err`] if unrestricted RPC is started on a
-/// non-local address without the override option, if log redaction is disabled
-/// while RPC is bound to a non-local address without the override option, or if
-/// an RPC listener cannot be bound.
+/// non-local address without the override option, or if an RPC listener cannot
+/// be bound.
 pub(crate) async fn init_rpc_servers(
     launch_ctx: &LaunchContext,
     tx_handler: IncomingTxHandler,
@@ -81,23 +80,6 @@ pub(crate) async fn init_rpc_servers(
                 );
             } else {
                 anyhow::bail!("Refusing to start unrestricted RPC on a non-local address ({addr})");
-            }
-        }
-
-        if !ip_is_local(addr) && !launch_ctx.config.tracing.redact {
-            if launch_ctx
-                .config
-                .tracing
-                .i_know_what_im_doing_allow_unredacted_public_logs
-            {
-                warn!(
-                    address = %addr,
-                    "Starting RPC on non-local address with log redaction disabled, this is dangerous!"
-                );
-            } else {
-                anyhow::bail!(
-                    "Refusing to start RPC on a non-local address ({addr}) with log redaction disabled"
-                );
             }
         }
 

--- a/binaries/cuprated/src/rpc/service/address_book.rs
+++ b/binaries/cuprated/src/rpc/service/address_book.rs
@@ -9,7 +9,7 @@ use cuprate_helper::{cast::usize_to_u64, map::u32_from_ipv4};
 use cuprate_p2p_core::{
     services::{AddressBookRequest, AddressBookResponse, ZoneSpecificPeerListEntryBase},
     types::{BanState, ConnectionId},
-    AddressBook, NetworkZone,
+    AddressBook, NetZoneAddress, NetworkZone,
 };
 use cuprate_rpc_types::misc::ConnectionInfo;
 use cuprate_types::rpc::Peer;
@@ -59,7 +59,7 @@ pub async fn connection_info<Z: NetworkZone>(
             };
 
             ConnectionInfo {
-                address: info.address.to_string(),
+                address: info.address.to_addr_string(),
                 address_type: info.address_type,
                 avg_download: info.avg_download,
                 avg_upload: info.avg_upload,
@@ -193,7 +193,7 @@ pub async fn peerlist<Z: NetworkZone>(
                     rpc_credits_per_hash,
                 } = peer;
 
-                let host = adr.to_string();
+                let host = adr.to_addr_string();
 
                 let (ip, port) = if let Ok(socket_addr) = host.parse::<SocketAddrV4>() {
                     (u32_from_ipv4(*socket_addr.ip()), socket_addr.port())

--- a/binaries/cuprated/src/rpc/service/address_book.rs
+++ b/binaries/cuprated/src/rpc/service/address_book.rs
@@ -41,7 +41,7 @@ pub(crate) async fn connection_info<Z: NetworkZone>(
             };
 
             ConnectionInfo {
-                address: info.address.to_addr_string(),
+                address: info.address.display_unredacted().to_string(),
                 address_type: info.address_type,
                 avg_download: info.avg_download,
                 avg_upload: info.avg_upload,
@@ -157,7 +157,7 @@ pub(crate) async fn peerlist<Z: NetworkZone>(
                     rpc_credits_per_hash,
                 } = peer;
 
-                let host = adr.to_addr_string();
+                let host = adr.display_unredacted().to_string();
 
                 let (ip, port) = if let Ok(socket_addr) = host.parse::<SocketAddrV4>() {
                     (u32_from_ipv4(*socket_addr.ip()), socket_addr.port())

--- a/binaries/cuprated/src/rpc/service/address_book.rs
+++ b/binaries/cuprated/src/rpc/service/address_book.rs
@@ -9,7 +9,7 @@ use cuprate_helper::map::u32_from_ipv4;
 use cuprate_p2p_core::{
     services::{AddressBookRequest, AddressBookResponse, ZoneSpecificPeerListEntryBase},
     types::{BanState, ConnectionId},
-    AddressBook, NetworkZone,
+    AddressBook, NetZoneAddress, NetworkZone,
 };
 use cuprate_rpc_types::misc::ConnectionInfo;
 use cuprate_types::rpc::Peer;
@@ -41,7 +41,7 @@ pub(crate) async fn connection_info<Z: NetworkZone>(
             };
 
             ConnectionInfo {
-                address: info.address.to_string(),
+                address: info.address.to_addr_string(),
                 address_type: info.address_type,
                 avg_download: info.avg_download,
                 avg_upload: info.avg_upload,
@@ -157,7 +157,7 @@ pub(crate) async fn peerlist<Z: NetworkZone>(
                     rpc_credits_per_hash,
                 } = peer;
 
-                let host = adr.to_string();
+                let host = adr.to_addr_string();
 
                 let (ip, port) = if let Ok(socket_addr) = host.parse::<SocketAddrV4>() {
                     (u32_from_ipv4(*socket_addr.ip()), socket_addr.port())

--- a/binaries/cuprated/src/rpc/service/address_book.rs
+++ b/binaries/cuprated/src/rpc/service/address_book.rs
@@ -59,7 +59,7 @@ pub async fn connection_info<Z: NetworkZone>(
             };
 
             ConnectionInfo {
-                address: info.address.to_addr_string(),
+                address: info.address.display_unredacted().to_string(),
                 address_type: info.address_type,
                 avg_download: info.avg_download,
                 avg_upload: info.avg_upload,
@@ -193,7 +193,7 @@ pub async fn peerlist<Z: NetworkZone>(
                     rpc_credits_per_hash,
                 } = peer;
 
-                let host = adr.to_addr_string();
+                let host = adr.display_unredacted().to_string();
 
                 let (ip, port) = if let Ok(socket_addr) = host.parse::<SocketAddrV4>() {
                     (u32_from_ipv4(*socket_addr.ip()), socket_addr.port())

--- a/binaries/cuprated/src/rpc/service/blockchain_manager.rs
+++ b/binaries/cuprated/src/rpc/service/blockchain_manager.rs
@@ -5,7 +5,7 @@ use monero_oxide::block::Block;
 use tower::{Service, ServiceExt};
 
 use cuprate_helper::cast::{u64_to_usize, usize_to_u64};
-use cuprate_p2p_core::{types::ConnectionId, NetworkZone};
+use cuprate_p2p_core::{types::ConnectionId, NetZoneAddress, NetworkZone};
 use cuprate_pruning::PruningSeed;
 use cuprate_rpc_types::misc::Span;
 use cuprate_types::BlockTemplate;
@@ -185,7 +185,7 @@ pub async fn spans<Z: NetworkZone>(
             connection_id: String::from(ConnectionId::DEFAULT_STR),
             nblocks: span.nblocks,
             rate: span.rate,
-            remote_address: span.remote_address.to_string(),
+            remote_address: span.remote_address.to_addr_string(),
             size: span.size,
             speed: span.speed,
             start_block_height: span.start_block_height,

--- a/binaries/cuprated/src/rpc/service/blockchain_manager.rs
+++ b/binaries/cuprated/src/rpc/service/blockchain_manager.rs
@@ -185,7 +185,7 @@ pub async fn spans<Z: NetworkZone>(
             connection_id: String::from(ConnectionId::DEFAULT_STR),
             nblocks: span.nblocks,
             rate: span.rate,
-            remote_address: span.remote_address.to_addr_string(),
+            remote_address: span.remote_address.display_unredacted().to_string(),
             size: span.size,
             speed: span.speed,
             start_block_height: span.start_block_height,

--- a/binaries/cuprated/src/txpool/incoming_tx.rs
+++ b/binaries/cuprated/src/txpool/incoming_tx.rs
@@ -228,7 +228,7 @@ async fn handle_incoming_txs(
         // Maybe we should remember these invalid txs for some time to prevent them getting repeatedly sent.
         if let Err(e) = check_tx_relay_rules(&tx, context) {
             if drop_relay_rule_errors {
-                tracing::debug!(err = %e, tx = hex::encode(tx.tx_hash), "Tx failed relay check, skipping.");
+                tracing::debug!(err = %e, tx = %safelog::sensitive(hex::encode(tx.tx_hash)), "Tx failed relay check, skipping.");
                 continue;
             }
 
@@ -236,7 +236,7 @@ async fn handle_incoming_txs(
         }
 
         tracing::debug!(
-            tx = hex::encode(tx.tx_hash),
+            tx = %safelog::sensitive(hex::encode(tx.tx_hash)),
             "passing tx to tx-pool manager"
         );
 

--- a/binaries/cuprated/src/txpool/incoming_tx.rs
+++ b/binaries/cuprated/src/txpool/incoming_tx.rs
@@ -224,7 +224,7 @@ async fn handle_incoming_txs(
         // Maybe we should remember these invalid txs for some time to prevent them getting repeatedly sent.
         if let Err(e) = check_tx_relay_rules(&tx, context) {
             if drop_relay_rule_errors {
-                tracing::debug!(err = %e, tx = hex::encode(tx.tx_hash), "Tx failed relay check, skipping.");
+                tracing::debug!(err = %e, tx = %safelog::sensitive(hex::encode(tx.tx_hash)), "Tx failed relay check, skipping.");
                 continue;
             }
 
@@ -232,7 +232,7 @@ async fn handle_incoming_txs(
         }
 
         tracing::debug!(
-            tx = hex::encode(tx.tx_hash),
+            tx = %safelog::sensitive(hex::encode(tx.tx_hash)),
             "passing tx to tx-pool manager"
         );
 

--- a/binaries/cuprated/src/txpool/manager.rs
+++ b/binaries/cuprated/src/txpool/manager.rs
@@ -283,7 +283,7 @@ impl TxpoolManager {
     /// # Panics
     ///
     /// This function will panic if the tx is not in the tx-pool manager.
-    #[instrument(level = "debug", skip_all, fields(tx_id = hex::encode(tx)))]
+    #[instrument(level = "debug", skip_all, fields(tx_id = %safelog::sensitive(hex::encode(tx))))]
     async fn remove_tx_from_pool(&mut self, tx: [u8; 32], remove_from_db: bool) {
         tracing::debug!("removing tx from pool");
 
@@ -323,7 +323,7 @@ impl TxpoolManager {
     /// # Panics
     ///
     /// This function will panic if the tx is not in the tx-pool.
-    #[instrument(level = "debug", skip_all, fields(tx_id = hex::encode(tx)))]
+    #[instrument(level = "debug", skip_all, fields(tx_id = %safelog::sensitive(hex::encode(tx))))]
     async fn rerelay_tx(&mut self, tx: [u8; 32]) {
         tracing::debug!("re-relaying tx to network");
 
@@ -350,7 +350,7 @@ impl TxpoolManager {
 
     /// Handles a transaction timeout, be either rebroadcasting or dropping the tx from the pool.
     /// If a rebroadcast happens, this function will handle adding another timeout to the queue.
-    #[instrument(level = "debug", skip_all, fields(tx_id = hex::encode(tx)))]
+    #[instrument(level = "debug", skip_all, fields(tx_id = %safelog::sensitive(hex::encode(tx))))]
     async fn handle_tx_timeout(&mut self, tx: [u8; 32]) {
         let Some(tx_info) = self.current_txs.get(&tx) else {
             tracing::warn!("tx timed out, but tx not in pool");
@@ -385,7 +385,7 @@ impl TxpoolManager {
     }
 
     /// Adds a tx to the tx-pool manager.
-    #[instrument(level = "trace", skip_all, fields(tx_id = hex::encode(tx)))]
+    #[instrument(level = "trace", skip_all, fields(tx_id = %safelog::sensitive(hex::encode(tx))))]
     fn track_tx(&mut self, tx: [u8; 32], weight: usize, fee: u64, private: bool) {
         let now = current_unix_timestamp();
 
@@ -415,7 +415,7 @@ impl TxpoolManager {
     }
 
     /// Handles an incoming tx, adding it to the pool and routing it.
-    #[instrument(level = "debug", skip_all, fields(tx_id = hex::encode(tx.tx_hash), state))]
+    #[instrument(level = "debug", skip_all, fields(tx_id = %safelog::sensitive(hex::encode(tx.tx_hash)), state))]
     async fn handle_incoming_tx(
         &mut self,
         tx: TransactionVerificationData,
@@ -445,7 +445,7 @@ impl TxpoolManager {
 
         if let Some(tx_hash) = double_spend {
             tracing::debug!(
-                double_spent = hex::encode(tx_hash),
+                double_spent = %safelog::sensitive(hex::encode(tx_hash)),
                 "transaction is a double spend, ignoring"
             );
             return;
@@ -469,7 +469,7 @@ impl TxpoolManager {
     }
 
     /// Promote a tx to the public pool.
-    #[instrument(level = "debug", skip_all, fields(tx_id = hex::encode(tx)))]
+    #[instrument(level = "debug", skip_all, fields(tx_id = %safelog::sensitive(hex::encode(tx))))]
     async fn promote_tx(&mut self, tx: [u8; 32]) {
         let Some(tx_info) = self.current_txs.get_mut(&tx) else {
             tracing::debug!("not promoting tx, tx not in pool");

--- a/binaries/cuprated/src/txpool/manager.rs
+++ b/binaries/cuprated/src/txpool/manager.rs
@@ -289,7 +289,7 @@ impl TxpoolManager {
     /// # Panics
     ///
     /// This function will panic if the tx is not in the tx-pool manager.
-    #[instrument(level = "debug", skip_all, fields(tx_id = hex::encode(tx)))]
+    #[instrument(level = "debug", skip_all, fields(tx_id = %safelog::sensitive(hex::encode(tx))))]
     async fn remove_tx_from_pool(
         &mut self,
         tx: [u8; 32],
@@ -333,7 +333,7 @@ impl TxpoolManager {
     /// # Panics
     ///
     /// This function will panic if the tx is not in the tx-pool.
-    #[instrument(level = "debug", skip_all, fields(tx_id = hex::encode(tx)))]
+    #[instrument(level = "debug", skip_all, fields(tx_id = %safelog::sensitive(hex::encode(tx))))]
     async fn rerelay_tx(&mut self, tx: [u8; 32]) -> Result<(), FatalError> {
         tracing::debug!("re-relaying tx to network");
 
@@ -356,7 +356,7 @@ impl TxpoolManager {
 
     /// Handles a transaction timeout, be either rebroadcasting or dropping the tx from the pool.
     /// If a rebroadcast happens, this function will handle adding another timeout to the queue.
-    #[instrument(level = "debug", skip_all, fields(tx_id = hex::encode(tx)))]
+    #[instrument(level = "debug", skip_all, fields(tx_id = %safelog::sensitive(hex::encode(tx))))]
     async fn handle_tx_timeout(&mut self, tx: [u8; 32]) -> Result<(), FatalError> {
         let Some(tx_info) = self.current_txs.get(&tx) else {
             tracing::warn!("tx timed out, but tx not in pool");
@@ -393,7 +393,7 @@ impl TxpoolManager {
     }
 
     /// Adds a tx to the tx-pool manager.
-    #[instrument(level = "trace", skip_all, fields(tx_id = hex::encode(tx)))]
+    #[instrument(level = "trace", skip_all, fields(tx_id = %safelog::sensitive(hex::encode(tx))))]
     fn track_tx(&mut self, tx: [u8; 32], weight: usize, fee: u64, private: bool) {
         let now = current_unix_timestamp();
 
@@ -423,7 +423,7 @@ impl TxpoolManager {
     }
 
     /// Handles an incoming tx, adding it to the pool and routing it.
-    #[instrument(level = "debug", skip_all, fields(tx_id = hex::encode(tx.tx_hash), state))]
+    #[instrument(level = "debug", skip_all, fields(tx_id = %safelog::sensitive(hex::encode(tx.tx_hash)), state))]
     async fn handle_incoming_tx(
         &mut self,
         tx: TransactionVerificationData,
@@ -451,7 +451,7 @@ impl TxpoolManager {
 
         if let Some(tx_hash) = double_spend {
             tracing::debug!(
-                double_spent = hex::encode(tx_hash),
+                double_spent = %safelog::sensitive(hex::encode(tx_hash)),
                 "transaction is a double spend, ignoring"
             );
             return Ok(());
@@ -475,7 +475,7 @@ impl TxpoolManager {
     }
 
     /// Promote a tx to the public pool.
-    #[instrument(level = "debug", skip_all, fields(tx_id = hex::encode(tx)))]
+    #[instrument(level = "debug", skip_all, fields(tx_id = %safelog::sensitive(hex::encode(tx))))]
     async fn promote_tx(&mut self, tx: [u8; 32]) -> Result<(), FatalError> {
         let Some(tx_info) = self.current_txs.get_mut(&tx) else {
             tracing::debug!("not promoting tx, tx not in pool");

--- a/p2p/address-book/src/book.rs
+++ b/p2p/address-book/src/book.rs
@@ -189,7 +189,7 @@ impl<Z: BorshNetworkZone> AddressBook<Z> {
 
         if let Some(connected_peers_with_ban_id) = self.connected_peers_ban_id.get(&addr.ban_id()) {
             for peer in connected_peers_with_ban_id.iter().map(|addr| {
-                tracing::debug!("Banning peer: {}, for: {:?}", addr.as_log(), time);
+                tracing::debug!("Banning peer: {}, for: {:?}", addr.to_addr_string(), time);
 
                 self.connected_peers
                     .get(&InternalPeerID::KnownAddr(*addr))

--- a/p2p/address-book/src/book.rs
+++ b/p2p/address-book/src/book.rs
@@ -189,7 +189,7 @@ impl<Z: BorshNetworkZone> AddressBook<Z> {
 
         if let Some(connected_peers_with_ban_id) = self.connected_peers_ban_id.get(&addr.ban_id()) {
             for peer in connected_peers_with_ban_id.iter().map(|addr| {
-                tracing::debug!("Banning peer: {}, for: {:?}", addr, time);
+                tracing::debug!("Banning peer: {}, for: {:?}", addr.as_log(), time);
 
                 self.connected_peers
                     .get(&InternalPeerID::KnownAddr(*addr))
@@ -214,11 +214,14 @@ impl<Z: BorshNetworkZone> AddressBook<Z> {
     /// adds a peer to the gray list.
     fn add_peer_to_gray_list(&mut self, mut peer: ZoneSpecificPeerListEntryBase<Z::Addr>) {
         if self.white_list.contains_peer(&peer.adr) {
-            tracing::trace!("Peer {} is already in white list skipping.", peer.adr);
+            tracing::trace!(
+                "Peer {} is already in white list skipping.",
+                peer.adr.as_log()
+            );
             return;
         }
         if !self.gray_list.contains_peer(&peer.adr) {
-            tracing::trace!("Adding peer {} to gray list.", peer.adr);
+            tracing::trace!("Adding peer {} to gray list.", peer.adr.as_log());
             peer.last_seen = 0;
             self.gray_list.add_new_peer(peer);
         }

--- a/p2p/address-book/src/book.rs
+++ b/p2p/address-book/src/book.rs
@@ -189,7 +189,11 @@ impl<Z: BorshNetworkZone> AddressBook<Z> {
 
         if let Some(connected_peers_with_ban_id) = self.connected_peers_ban_id.get(&addr.ban_id()) {
             for peer in connected_peers_with_ban_id.iter().map(|addr| {
-                tracing::debug!("Banning peer: {}, for: {:?}", addr.to_addr_string(), time);
+                tracing::debug!(
+                    "Banning peer: {}, for: {:?}",
+                    addr.display_unredacted(),
+                    time
+                );
 
                 self.connected_peers
                     .get(&InternalPeerID::KnownAddr(*addr))
@@ -216,12 +220,12 @@ impl<Z: BorshNetworkZone> AddressBook<Z> {
         if self.white_list.contains_peer(&peer.adr) {
             tracing::trace!(
                 "Peer {} is already in white list skipping.",
-                peer.adr.as_log()
+                peer.adr.display_redacted()
             );
             return;
         }
         if !self.gray_list.contains_peer(&peer.adr) {
-            tracing::trace!("Adding peer {} to gray list.", peer.adr.as_log());
+            tracing::trace!("Adding peer {} to gray list.", peer.adr.display_redacted());
             peer.last_seen = 0;
             self.gray_list.add_new_peer(peer);
         }

--- a/p2p/p2p-core/Cargo.toml
+++ b/p2p/p2p-core/Cargo.toml
@@ -23,6 +23,7 @@ async-trait = { workspace = true }
 tower = { workspace = true, features = ["util", "tracing", "make"] }
 
 cfg-if = { workspace = true }
+safelog = { workspace = true }
 thiserror = { workspace = true }
 rand = { workspace = true, features = ["std", "std_rng"] }
 tracing = { workspace = true, features = ["std", "attributes"] }

--- a/p2p/p2p-core/src/client.rs
+++ b/p2p/p2p-core/src/client.rs
@@ -19,7 +19,8 @@ use cuprate_wire::{BasicNodeData, CoreSyncData};
 
 use crate::{
     handles::{ConnectionGuard, ConnectionHandle},
-    ConnectionDirection, NetworkZone, PeerError, PeerRequest, PeerResponse, SharedError,
+    ConnectionDirection, NetZoneAddress, NetworkZone, PeerError, PeerRequest, PeerResponse,
+    SharedError,
 };
 
 mod connection;
@@ -37,7 +38,7 @@ pub use weak::{WeakBroadcastClient, WeakClient};
 
 /// An internal identifier for a given peer, will be their address if known
 /// or a random u128 if not.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
 pub enum InternalPeerID<A> {
     /// A known address.
     KnownAddr(A),
@@ -45,11 +46,23 @@ pub enum InternalPeerID<A> {
     Unknown([u8; 16]),
 }
 
-impl<A: Display> Display for InternalPeerID<A> {
+impl<A: NetZoneAddress> Display for InternalPeerID<A> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::KnownAddr(addr) => addr.fmt(f),
-            Self::Unknown(id) => f.write_str(&format!("Unknown, ID: {}", hex::encode(id))),
+            Self::KnownAddr(addr) => write!(f, "{}", addr.as_log()),
+            Self::Unknown(id) => write!(f, "Unknown, ID: {}", hex::encode(id)),
+        }
+    }
+}
+
+impl<A: Debug> Debug for InternalPeerID<A> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::KnownAddr(addr) => f
+                .debug_tuple("KnownAddr")
+                .field(&safelog::sensitive(addr))
+                .finish(),
+            Self::Unknown(id) => f.debug_tuple("Unknown").field(&hex::encode(id)).finish(),
         }
     }
 }

--- a/p2p/p2p-core/src/client.rs
+++ b/p2p/p2p-core/src/client.rs
@@ -16,7 +16,8 @@ use cuprate_wire::{BasicNodeData, CoreSyncData};
 
 use crate::{
     handles::{ConnectionGuard, ConnectionHandle},
-    BroadcastMessage, ConnectionDirection, NetworkZone, PeerError, PeerRequest, PeerResponse,
+    BroadcastMessage, ConnectionDirection, NetZoneAddress, NetworkZone, PeerError, PeerRequest,
+    PeerResponse,
 };
 
 mod connection;
@@ -32,7 +33,7 @@ pub use sync_callback::PeerSyncCallback;
 
 /// An internal identifier for a given peer, will be their address if known
 /// or a random u128 if not.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
 pub enum InternalPeerID<A> {
     /// A known address.
     KnownAddr(A),
@@ -40,11 +41,23 @@ pub enum InternalPeerID<A> {
     Unknown([u8; 16]),
 }
 
-impl<A: Display> Display for InternalPeerID<A> {
+impl<A: NetZoneAddress> Display for InternalPeerID<A> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::KnownAddr(addr) => addr.fmt(f),
-            Self::Unknown(id) => f.write_str(&format!("Unknown, ID: {}", hex::encode(id))),
+            Self::KnownAddr(addr) => write!(f, "{}", addr.as_log()),
+            Self::Unknown(id) => write!(f, "Unknown, ID: {}", hex::encode(id)),
+        }
+    }
+}
+
+impl<A: Debug> Debug for InternalPeerID<A> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::KnownAddr(addr) => f
+                .debug_tuple("KnownAddr")
+                .field(&safelog::sensitive(addr))
+                .finish(),
+            Self::Unknown(id) => f.debug_tuple("Unknown").field(&hex::encode(id)).finish(),
         }
     }
 }

--- a/p2p/p2p-core/src/client.rs
+++ b/p2p/p2p-core/src/client.rs
@@ -44,7 +44,7 @@ pub enum InternalPeerID<A> {
 impl<A: NetZoneAddress> Display for InternalPeerID<A> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::KnownAddr(addr) => write!(f, "{}", addr.as_log()),
+            Self::KnownAddr(addr) => write!(f, "{}", addr.display_redacted()),
             Self::Unknown(id) => write!(f, "Unknown, ID: {}", hex::encode(id)),
         }
     }

--- a/p2p/p2p-core/src/client.rs
+++ b/p2p/p2p-core/src/client.rs
@@ -49,7 +49,7 @@ pub enum InternalPeerID<A> {
 impl<A: NetZoneAddress> Display for InternalPeerID<A> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::KnownAddr(addr) => write!(f, "{}", addr.as_log()),
+            Self::KnownAddr(addr) => write!(f, "{}", addr.display_redacted()),
             Self::Unknown(id) => write!(f, "Unknown, ID: {}", hex::encode(id)),
         }
     }

--- a/p2p/p2p-core/src/client/connector.rs
+++ b/p2p/p2p-core/src/client/connector.rs
@@ -16,7 +16,7 @@ use tower::{Service, ServiceExt};
 
 use crate::{
     client::{handshaker::HandShaker, Client, DoHandshakeRequest, HandshakeError, InternalPeerID},
-    AddressBook, BroadcastMessage, ConnectionDirection, CoreSyncSvc, NetworkZone,
+    AddressBook, BroadcastMessage, ConnectionDirection, CoreSyncSvc, NetZoneAddress, NetworkZone,
     ProtocolRequestHandlerMaker, Transport,
 };
 
@@ -68,7 +68,7 @@ where
     }
 
     fn call(&mut self, req: ConnectRequest<Z>) -> Self::Future {
-        tracing::debug!("Connecting to peer: {}", req.addr);
+        tracing::debug!("Connecting to peer: {}", req.addr.as_log());
         let mut handshaker = self.handshaker.clone();
 
         async move {

--- a/p2p/p2p-core/src/client/connector.rs
+++ b/p2p/p2p-core/src/client/connector.rs
@@ -68,7 +68,7 @@ where
     }
 
     fn call(&mut self, req: ConnectRequest<Z>) -> Self::Future {
-        tracing::debug!("Connecting to peer: {}", req.addr.as_log());
+        tracing::debug!("Connecting to peer: {}", req.addr.display_redacted());
         let mut handshaker = self.handshaker.clone();
 
         async move {

--- a/p2p/p2p-core/src/lib.rs
+++ b/p2p/p2p-core/src/lib.rs
@@ -107,7 +107,6 @@ pub enum ConnectionDirection {
 pub trait NetZoneAddress:
     TryFrom<NetworkAddress, Error = NetworkAddressIncorrectZone>
     + Into<NetworkAddress>
-    + std::fmt::Display
     + Hash
     + Eq
     + Copy
@@ -135,6 +134,12 @@ pub trait NetZoneAddress:
     fn ban_id(&self) -> Self::BanID;
 
     fn should_add_to_peer_list(&self) -> bool;
+
+    /// Returns a redacted view of this address for logging.
+    fn as_log(&self) -> impl std::fmt::Display + '_;
+
+    /// Returns the unredacted address as a string.
+    fn to_addr_string(&self) -> String;
 }
 
 /// An abstraction over a network zone (tor/i2p/clear)

--- a/p2p/p2p-core/src/lib.rs
+++ b/p2p/p2p-core/src/lib.rs
@@ -135,11 +135,11 @@ pub trait NetZoneAddress:
 
     fn should_add_to_peer_list(&self) -> bool;
 
-    /// Returns a redacted view of this address for logging.
-    fn as_log(&self) -> impl std::fmt::Display + '_;
+    /// Returns a redacted view of this address, for logging.
+    fn display_redacted(&self) -> impl std::fmt::Display + '_;
 
-    /// Returns the unredacted address as a string.
-    fn to_addr_string(&self) -> String;
+    /// Returns the full, unredacted address.
+    fn display_unredacted(&self) -> impl std::fmt::Display + '_;
 }
 
 /// An abstraction over a network zone (tor/i2p/clear)

--- a/p2p/p2p-core/src/network_zones/clear.rs
+++ b/p2p/p2p-core/src/network_zones/clear.rs
@@ -22,6 +22,14 @@ impl NetZoneAddress for SocketAddr {
         // TODO
         true
     }
+
+    fn as_log(&self) -> impl std::fmt::Display + '_ {
+        safelog::Redactable::redacted(self)
+    }
+
+    fn to_addr_string(&self) -> String {
+        self.to_string()
+    }
 }
 
 #[derive(Clone, Copy)]

--- a/p2p/p2p-core/src/network_zones/clear.rs
+++ b/p2p/p2p-core/src/network_zones/clear.rs
@@ -23,12 +23,12 @@ impl NetZoneAddress for SocketAddr {
         true
     }
 
-    fn as_log(&self) -> impl std::fmt::Display + '_ {
+    fn display_redacted(&self) -> impl std::fmt::Display + '_ {
         safelog::Redactable::redacted(self)
     }
 
-    fn to_addr_string(&self) -> String {
-        self.to_string()
+    fn display_unredacted(&self) -> impl std::fmt::Display + '_ {
+        self
     }
 }
 

--- a/p2p/p2p-core/src/network_zones/tor.rs
+++ b/p2p/p2p-core/src/network_zones/tor.rs
@@ -36,6 +36,14 @@ impl NetZoneAddress for OnionAddr {
         // Validation of the onion address has been done at the type construction...
         true
     }
+
+    fn as_log(&self) -> impl std::fmt::Display + '_ {
+        safelog::sensitive(*self)
+    }
+
+    fn to_addr_string(&self) -> String {
+        self.to_string()
+    }
 }
 
 #[derive(Clone, Copy)]

--- a/p2p/p2p-core/src/network_zones/tor.rs
+++ b/p2p/p2p-core/src/network_zones/tor.rs
@@ -37,12 +37,12 @@ impl NetZoneAddress for OnionAddr {
         true
     }
 
-    fn as_log(&self) -> impl std::fmt::Display + '_ {
+    fn display_redacted(&self) -> impl std::fmt::Display + '_ {
         safelog::sensitive(*self)
     }
 
-    fn to_addr_string(&self) -> String {
-        self.to_string()
+    fn display_unredacted(&self) -> impl std::fmt::Display + '_ {
+        self
     }
 }
 

--- a/p2p/p2p-transport/src/socks.rs
+++ b/p2p/p2p-transport/src/socks.rs
@@ -47,13 +47,22 @@ pub async fn is_socks5_proxy(addr: SocketAddr) -> bool {
 #[derive(Debug, Clone, Copy, Default)]
 pub struct Socks;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct SocksClientConfig {
     /// Proxy address
     pub proxy: SocketAddr,
 
     /// According to RFC 1929, if authentication is enabled, both username and password fields MUST NOT be empty.
     pub authentication: Option<(String, String)>,
+}
+
+impl std::fmt::Debug for SocksClientConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // skip authentication info
+        f.debug_struct("SocksClientConfig")
+            .field("proxy", &self.proxy)
+            .finish_non_exhaustive()
+    }
 }
 
 //---------------------------------------------------------------------------------------------------- Transport

--- a/p2p/p2p-transport/src/socks.rs
+++ b/p2p/p2p-transport/src/socks.rs
@@ -58,7 +58,7 @@ pub struct SocksClientConfig {
 
 impl std::fmt::Debug for SocksClientConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        // skip authentication info
+        // skip authentication info in debug output
         f.debug_struct("SocksClientConfig")
             .field("proxy", &self.proxy)
             .finish_non_exhaustive()

--- a/p2p/p2p-transport/src/socks.rs
+++ b/p2p/p2p-transport/src/socks.rs
@@ -59,8 +59,13 @@ pub struct SocksClientConfig {
 impl std::fmt::Debug for SocksClientConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         // skip authentication info in debug output
+        let Self {
+            proxy,
+            authentication: _,
+        } = self;
+
         f.debug_struct("SocksClientConfig")
-            .field("proxy", &self.proxy)
+            .field("proxy", proxy)
             .finish_non_exhaustive()
     }
 }

--- a/p2p/p2p/src/connection_maintainer.rs
+++ b/p2p/p2p/src/connection_maintainer.rs
@@ -17,7 +17,7 @@ use tracing::{instrument, Instrument, Span};
 use cuprate_p2p_core::{
     client::{Client, ConnectRequest, HandshakeError, PeerSyncCallback},
     services::{AddressBookRequest, AddressBookResponse},
-    AddressBook, NetworkZone,
+    AddressBook, NetZoneAddress, NetworkZone,
 };
 
 use crate::{
@@ -115,7 +115,7 @@ where
         let mut handshake_futs = JoinSet::new();
 
         for seed in seeds {
-            tracing::info!("Getting peers from seed node: {}", seed);
+            tracing::info!("Getting peers from seed node: {}", seed.as_log());
 
             let addr = *seed;
             let fut = timeout(
@@ -131,11 +131,11 @@ where
                 async move {
                     match fut.await {
                         Err(_) => {
-                            tracing::warn!("Timed out connecting to seed node: {addr}");
+                            tracing::warn!("Timed out connecting to seed node: {}", addr.as_log());
                             false
                         }
                         Ok(Err(e)) => {
-                            tracing::warn!("Failed to connect to seed node {addr}: {e}");
+                            tracing::warn!("Failed to connect to seed node {}: {e}", addr.as_log());
                             false
                         }
                         Ok(Ok(_)) => true,

--- a/p2p/p2p/src/connection_maintainer.rs
+++ b/p2p/p2p/src/connection_maintainer.rs
@@ -115,7 +115,10 @@ where
         let mut handshake_futs = JoinSet::new();
 
         for seed in seeds {
-            tracing::info!("Getting peers from seed node: {}", seed.display_redacted());
+            tracing::info!(
+                "Getting peers from seed node: {}",
+                seed.display_unredacted()
+            );
 
             let addr = *seed;
             let fut = timeout(
@@ -133,14 +136,14 @@ where
                         Err(_) => {
                             tracing::warn!(
                                 "Timed out connecting to seed node: {}",
-                                addr.display_redacted()
+                                addr.display_unredacted()
                             );
                             false
                         }
                         Ok(Err(e)) => {
                             tracing::warn!(
                                 "Failed to connect to seed node {}: {e}",
-                                addr.display_redacted()
+                                addr.display_unredacted()
                             );
                             false
                         }

--- a/p2p/p2p/src/connection_maintainer.rs
+++ b/p2p/p2p/src/connection_maintainer.rs
@@ -115,7 +115,7 @@ where
         let mut handshake_futs = JoinSet::new();
 
         for seed in seeds {
-            tracing::info!("Getting peers from seed node: {}", seed.as_log());
+            tracing::info!("Getting peers from seed node: {}", seed.display_redacted());
 
             let addr = *seed;
             let fut = timeout(
@@ -131,11 +131,17 @@ where
                 async move {
                     match fut.await {
                         Err(_) => {
-                            tracing::warn!("Timed out connecting to seed node: {}", addr.as_log());
+                            tracing::warn!(
+                                "Timed out connecting to seed node: {}",
+                                addr.display_redacted()
+                            );
                             false
                         }
                         Ok(Err(e)) => {
-                            tracing::warn!("Failed to connect to seed node {}: {e}", addr.as_log());
+                            tracing::warn!(
+                                "Failed to connect to seed node {}: {e}",
+                                addr.display_redacted()
+                            );
                             false
                         }
                         Ok(Ok(_)) => true,

--- a/rpc/types/src/from.rs
+++ b/rpc/types/src/from.rs
@@ -55,7 +55,7 @@ impl<A: NetZoneAddress> From<ConnectionInfo<A>> for crate::misc::ConnectionInfo 
         };
 
         Self {
-            address: x.address.to_string(),
+            address: x.address.to_addr_string(),
             address_type: x.address_type,
             avg_download: x.avg_download,
             avg_upload: x.avg_upload,

--- a/rpc/types/src/from.rs
+++ b/rpc/types/src/from.rs
@@ -55,7 +55,7 @@ impl<A: NetZoneAddress> From<ConnectionInfo<A>> for crate::misc::ConnectionInfo 
         };
 
         Self {
-            address: x.address.to_addr_string(),
+            address: x.address.display_unredacted().to_string(),
             address_type: x.address_type,
             avg_download: x.avg_download,
             avg_upload: x.avg_upload,

--- a/test-utils/src/test_netzone.rs
+++ b/test-utils/src/test_netzone.rs
@@ -31,6 +31,14 @@ impl NetZoneAddress for TestNetZoneAddr {
     fn should_add_to_peer_list(&self) -> bool {
         true
     }
+
+    fn as_log(&self) -> impl std::fmt::Display + '_ {
+        *self
+    }
+
+    fn to_addr_string(&self) -> String {
+        self.to_string()
+    }
 }
 
 impl std::fmt::Display for TestNetZoneAddr {

--- a/test-utils/src/test_netzone.rs
+++ b/test-utils/src/test_netzone.rs
@@ -32,12 +32,12 @@ impl NetZoneAddress for TestNetZoneAddr {
         true
     }
 
-    fn as_log(&self) -> impl std::fmt::Display + '_ {
-        *self
+    fn display_redacted(&self) -> impl std::fmt::Display + '_ {
+        self
     }
 
-    fn to_addr_string(&self) -> String {
-        self.to_string()
+    fn display_unredacted(&self) -> impl std::fmt::Display + '_ {
+        self
     }
 }
 


### PR DESCRIPTION
### What
Redacts sensitive data (transaction hashes, peer + onion addresses, Tor/SOCKS proxy auth) from logs, on by default.

Closes #540

### Why
Prevent log files from being a target

### Where
cuprated, p2p

### How
Add `NetZoneAddress::as_log() -> impl Display` for a redacted view and `to_addr_string()` for the unredacted string.

Clearnet uses `safelog::Redactable` (partial IP), Tor uses `safelog::sensitive` (full scrub).

Drop the `Display` bound from the trait so an address can't be logged in the clear by accident - log sites now go through `.as_log()`, tx hashes through `safelog::sensitive`.

Hand-written `Debug` impls for `TorDaemonConfig`, `SocksClientConfig` and `InternalPeerID` keep config dumps and debug logs from leaking onion inbound addresses and proxy credentials.

Toggle via `tracing.redact` (default `true`) or `--no-log-redact`.
When off, `init_logging` calls `safelog::disable_safe_logging()`.