### PR TITLE
cuprated: Fix network arg

### DIFF
--- a/binaries/cuprated/src/args.rs
+++ b/binaries/cuprated/src/args.rs
@@ -15,7 +15,7 @@ pub struct Args {
     #[arg(
         long,
         value_parser = clap::builder::PossibleValuesParser::new(["mainnet", "testnet", "stagenet", "fakechain"])
-            .map(|s| Some(s.parse::<Network>().unwrap())),
+            .map(|s| s.parse::<Network>().unwrap()),
     )]
     pub network: Option<Network>,
 


### PR DESCRIPTION
This broke at some point, if you try start cuprated on a different network it'll panic.