### PR TITLE
chore: replace native-tls backend for arti crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -253,18 +253,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-native-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37dd6b179962fe4048a6f81d4c0d7ed419a21fdf49204b4c6b04971693358e79"
-dependencies = [
- "futures-util",
- "native-tls",
- "thiserror 2.0.18",
- "url",
-]
-
-[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2327,6 +2315,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "futures-rustls"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f2f12607f92c69b12ed746fabf9ca4f5c482cba46679c1a75b874ed7c26adb"
+dependencies = [
+ "futures-io",
+ "rustls",
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -6536,7 +6535,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcd7a4ff4898044b3ec693c0bf098251accf13c58741c44ed9364ce5faa89287"
 dependencies = [
  "amplify",
- "async-native-tls",
  "async-trait",
  "async_executors",
  "asynchronous-codec",
@@ -6547,11 +6545,15 @@ dependencies = [
  "dyn-clone",
  "educe",
  "futures",
+ "futures-rustls",
  "hex",
  "libc",
  "native-tls",
  "paste",
  "pin-project",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-webpki",
  "socket2",
  "thiserror 2.0.18",
  "tokio",

--- a/binaries/cuprated/Cargo.toml
+++ b/binaries/cuprated/Cargo.toml
@@ -49,7 +49,7 @@ cuprate-wire              = { workspace = true }
 # TODO: after v1.0.0, remove unneeded dependencies.
 axum                  = { workspace = true, features = ["tokio", "http1", "http2"] }
 anyhow                = { workspace = true }
-arti-client           = { workspace = true, features = ["tokio", "native-tls", "onion-service-client", "onion-service-service", "static"], optional = true }
+arti-client           = { workspace = true, features = ["tokio", "rustls", "onion-service-client", "onion-service-service", "static"], optional = true }
 async-trait           = { workspace = true }
 bitflags              = { workspace = true }
 borsh                 = { workspace = true }

--- a/p2p/p2p-transport/Cargo.toml
+++ b/p2p/p2p-transport/Cargo.toml
@@ -18,7 +18,7 @@ futures = { workspace = true }
 tokio = { workspace = true, features = ["net"] }
 tokio-socks   = { workspace = true, features = ["tokio"] }
 tokio-util = { workspace = true, features = ["codec"] }
-arti-client = { workspace = true, features = ["tokio", "native-tls", "onion-service-client", "onion-service-service", "experimental-api", "static-sqlite"], optional = true }
+arti-client = { workspace = true, features = ["tokio", "rustls", "onion-service-client", "onion-service-service", "experimental-api", "static-sqlite"], optional = true }
 tor-config-path = { workspace = true, optional = true }
 tor-cell        = { workspace = true, optional = true }
 tor-hsservice   = { workspace = true, optional = true }


### PR DESCRIPTION
### What

Replaces the `native-tls` backend used for Arti with `rustls`.

### Why

This reduces the total number of crates by ~20.

### Where

`cuprated`, `cuprate-p2p-transport`

### How

Tweaks some feature flags.