### PR TITLE
cuprated: get_info, syncer improvements

### DIFF
--- a/binaries/cuprated/src/blockchain/syncer.rs
+++ b/binaries/cuprated/src/blockchain/syncer.rs
@@ -147,6 +147,7 @@ impl Syncer {
                         drop(sync_permit);
                         sync_permit = Arc::new(Arc::clone(&semaphore).acquire_owned().await?);
 
+                        self.notify_syncer.notify_one();
                         break;
                     }
                     batch = block_batch_stream.next() => {
@@ -244,15 +245,17 @@ impl SyncerHandle {
     pub fn callback(&self, blockchain: &BlockchainInterface) -> PeerSyncCallback {
         let context_svc = blockchain.context_svc();
         let blockchain_manager = blockchain.manager();
-        let handle = self.clone();
-        PeerSyncCallback::new(move |peer_csd: &CoreSyncData| {
+        let sync_handle = self.clone();
+        let disconnect_handle = self.clone();
+
+        let on_sync = move |peer_csd: &CoreSyncData| {
             let ctx = context_svc.blockchain_context_snapshot();
 
             // If we are synced and the syncer hasn't yet set the node to synced, wake the syncer.
             if peer_csd.cumulative_difficulty() == ctx.cumulative_difficulty
-                && handle.synced.peek().is_none()
+                && sync_handle.synced.peek().is_none()
             {
-                handle.notify_syncer.notify_one();
+                sync_handle.notify_syncer.notify_one();
             }
 
             // If we are behind the peer, and we aren't just one block behind with the blockchain manager handling the block, wake the syncer.
@@ -260,8 +263,12 @@ impl SyncerHandle {
                 && !(peer_csd.current_height.saturating_sub(1) == ctx.chain_height as u64
                     && blockchain_manager.is_block_being_handled(&peer_csd.top_id))
             {
-                handle.notify_syncer.notify_one();
+                sync_handle.notify_syncer.notify_one();
             }
-        })
+        };
+
+        let on_disconnect = move || disconnect_handle.notify_syncer.notify_one();
+
+        PeerSyncCallback::new(on_sync, on_disconnect)
     }
 }

--- a/binaries/cuprated/src/rpc/handlers/json_rpc.rs
+++ b/binaries/cuprated/src/rpc/handlers/json_rpc.rs
@@ -488,9 +488,6 @@ pub(super) async fn get_info(
         (String::new(), false)
     };
 
-    let target_height = state.syncer_handle.target_height();
-    let busy_syncing = target_height > 0;
-
     let (cumulative_difficulty, cumulative_difficulty_top64) =
         split_u128_into_low_high_bits(cumulative_difficulty);
 
@@ -545,6 +542,8 @@ pub(super) async fn get_info(
         state.start_instant_unix
     };
 
+    let target_height = state.syncer_handle.target_height();
+    let busy_syncing = target_height > 0;
     let synchronized = !busy_syncing;
     let target = c.current_hf.block_time().as_secs();
     let top_block_hash = Hex(c.top_hash);

--- a/binaries/cuprated/src/rpc/handlers/json_rpc.rs
+++ b/binaries/cuprated/src/rpc/handlers/json_rpc.rs
@@ -488,7 +488,8 @@ pub(super) async fn get_info(
         (String::new(), false)
     };
 
-    let busy_syncing = state.syncer_handle.target_height() > 0;
+    let target_height = state.syncer_handle.target_height();
+    let busy_syncing = target_height > 0;
 
     let (cumulative_difficulty, cumulative_difficulty_top64) =
         split_u128_into_low_high_bits(cumulative_difficulty);
@@ -543,8 +544,8 @@ pub(super) async fn get_info(
     } else {
         state.start_instant_unix
     };
-    let target_height = state.syncer_handle.target_height();
-    let synchronized = target_height == 0;
+
+    let synchronized = !busy_syncing;
     let target = c.current_hf.block_time().as_secs();
     let top_block_hash = Hex(c.top_hash);
 

--- a/p2p/p2p-core/src/client/handshaker.rs
+++ b/p2p/p2p-core/src/client/handshaker.rs
@@ -516,6 +516,11 @@ where
         on_peer_sync: on_peer_sync.clone(),
     };
 
+    let connection_guard = match on_peer_sync.clone() {
+        Some(callback) => connection_guard.with_on_close(move || callback.disconnected()),
+        None => connection_guard,
+    };
+
     let connection = Connection::<Z, T, _, _, _, _>::new(
         peer_sink,
         client_rx,

--- a/p2p/p2p-core/src/client/sync_callback.rs
+++ b/p2p/p2p-core/src/client/sync_callback.rs
@@ -5,19 +5,33 @@ use std::{
 
 use cuprate_wire::CoreSyncData;
 
-/// A callback invoked with a peer's [`CoreSyncData`].
+/// Callbacks invoked when a peer's sync data changes or the peer disconnects.
 #[derive(Clone)]
-pub struct PeerSyncCallback(Arc<dyn Fn(&CoreSyncData) + Send + Sync>);
+pub struct PeerSyncCallback {
+    on_sync: Arc<dyn Fn(&CoreSyncData) + Send + Sync>,
+    on_disconnect: Arc<dyn Fn() + Send + Sync>,
+}
 
 impl PeerSyncCallback {
     /// Create a new [`PeerSyncCallback`].
-    pub fn new(f: impl Fn(&CoreSyncData) + Send + Sync + 'static) -> Self {
-        Self(Arc::new(f))
+    pub fn new(
+        on_sync: impl Fn(&CoreSyncData) + Send + Sync + 'static,
+        on_disconnect: impl Fn() + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            on_sync: Arc::new(on_sync),
+            on_disconnect: Arc::new(on_disconnect),
+        }
     }
 
     /// Call the callback with the peer's [`CoreSyncData`].
     pub fn call(&self, data: &CoreSyncData) {
-        (self.0)(data);
+        (self.on_sync)(data);
+    }
+
+    /// Notify the callback that the peer disconnected.
+    pub(crate) fn disconnected(&self) {
+        (self.on_disconnect)();
     }
 }
 

--- a/p2p/p2p-core/src/handles.rs
+++ b/p2p/p2p-core/src/handles.rs
@@ -38,6 +38,7 @@ impl HandleBuilder {
         (
             ConnectionGuard {
                 token: token.clone(),
+                on_close: None,
                 _permit: self.permit,
             },
             ConnectionHandle {
@@ -55,6 +56,7 @@ pub struct BanPeer(pub Duration);
 /// A struct given to the connection task.
 pub struct ConnectionGuard {
     token: CancellationToken,
+    on_close: Option<Box<dyn FnOnce() + Send>>,
     _permit: Option<OwnedSemaphorePermit>,
 }
 
@@ -69,11 +71,21 @@ impl ConnectionGuard {
     pub fn connection_closed(&self) {
         self.token.cancel();
     }
+    /// Sets a callback to run when the connection closes.
+    #[must_use]
+    pub(crate) fn with_on_close(mut self, callback: impl FnOnce() + Send + 'static) -> Self {
+        self.on_close = Some(Box::new(callback));
+        self
+    }
 }
 
 impl Drop for ConnectionGuard {
     fn drop(&mut self) {
         self.token.cancel();
+
+        if let Some(callback) = self.on_close.take() {
+            callback();
+        }
     }
 }
 


### PR DESCRIPTION
### What
Improves sync-status updates and fixes a race in get_info

### Why
The previous implementation had a couple shortcomings:

1. `get_info` read the target height separately for `busy_syncing` and `target_height`, so an update between those reads could produce a conflicting response.
2. When an invalid block caused the blockchain manager to stop the downloader, the syncer returned to waiting instead of rechecking immediately.
3. Disconnecting the peer with the highest cumulative difficulty could leave the sync status stuck on an old target height.

`monerod` also performs separate sync-state reads in get_info (race prone), so we avoid it by reading `target_height` once at the top, then derive `busy_syncing` and `synchronized` from it.

### Where
`cuprated`, `p2p-core`

### How
1. Re-notify the syncer immediately after a stop signal is received
2. Read `target_height` once at the top, `busy_syncing` and `synchronized` become derivatives of it
3. Add a peer disconnect callback, that notifies the syncer and re-checks state if a peer disconnects