### PR TITLE
cuprated: Dockerfile + Alpine, FreeBSD, OpenBSD support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+target/
+books/
+Dockerfile
+.dockerignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,7 @@ jobs:
     strategy:
       matrix:
         os:
-        - { image: alpine:latest, commands: "apk update && apk add alpine-sdk cmake curl bash monero && ln -sf /usr/bin/monerod monerod" } # Alpine is a special case due to it's musl libc
+        - { image: alpine:latest, commands: "apk update && apk add alpine-sdk cmake curl bash monero && ln -sf /usr/bin/monerod monerod" } # Alpine is a special case due to its musl libc
         - { image: archlinux:latest, commands: "pacman -Syyu --noconfirm base-devel git cmake openssl" }
         - { image: debian:stable, commands: "apt update && apt -y install build-essential curl cmake git pkg-config libssl-dev" }
         - { image: fedora:latest, commands: "dnf install --assumeyes @development-tools gcc gcc-c++ cmake git openssl-devel perl-core" }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,8 +148,7 @@ jobs:
     strategy:
       matrix:
         os:
-        # TODO: support musl <https://github.com/Cuprate/cuprate/issues/336>
-        # - { image: alpine:latest, commands: "apk update && apk add alpine-sdk cmake curl bash" }
+        - { image: alpine:latest, commands: "apk update && apk add alpine-sdk cmake curl bash monero && ln -sf /usr/bin/monerod monerod" } # Alpine is a special case due to it's musl libc
         - { image: archlinux:latest, commands: "pacman -Syyu --noconfirm base-devel git cmake openssl" }
         - { image: debian:stable, commands: "apt update && apt -y install build-essential curl cmake git pkg-config libssl-dev" }
         - { image: fedora:latest, commands: "dnf install --assumeyes @development-tools gcc gcc-c++ cmake git openssl-devel perl-core" }
@@ -176,6 +175,7 @@ jobs:
           components: clippy
 
       - name: Download monerod
+        if: matrix.os.image != 'alpine:latest'
         uses: ./.github/actions/monerod-download
 
       - name: Documentation

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4209,7 +4209,7 @@ dependencies = [
 [[package]]
 name = "randomx-rs"
 version = "1.4.1"
-source = "git+https://github.com/Cuprate/randomx-rs.git?rev=a876ab6#a876ab61f9116139077a711d91ef053e6bb3de9f"
+source = "git+https://github.com/Cuprate/randomx-rs.git?rev=76c2385#76c2385771ca5aca941e0991ebd822e6edb8d94d"
 dependencies = [
  "bitflags 1.3.2",
  "cc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4208,10 +4208,11 @@ dependencies = [
 
 [[package]]
 name = "randomx-rs"
-version = "1.4.0"
-source = "git+https://github.com/Cuprate/randomx-rs.git?rev=567bdca#567bdcade871f2391dc67eb90d38efaa78c24003"
+version = "1.4.1"
+source = "git+https://github.com/Cuprate/randomx-rs.git?rev=a876ab6#a876ab61f9116139077a711d91ef053e6bb3de9f"
 dependencies = [
  "bitflags 1.3.2",
+ "cc",
  "cmake",
  "libc",
  "thiserror 1.0.69",
@@ -5199,7 +5200,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -189,7 +189,7 @@ monero-oxide          = { git = "https://github.com/monero-oxide/monero-oxide.gi
 nu-ansi-term          = { version = "0.50", default-features = false }
 paste                 = { version = "1", default-features = false }
 pin-project           = { version = "1", default-features = false }
-randomx-rs            = { git = "https://github.com/Cuprate/randomx-rs.git", rev = "a876ab6", default-features = false }
+randomx-rs            = { git = "https://github.com/Cuprate/randomx-rs.git", rev = "76c2385", default-features = false }
 rand                  = { version = "0.8", default-features = false }
 rand_distr            = { version = "0.4", default-features = false }
 rayon                 = { version = "1", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -189,7 +189,7 @@ monero-oxide          = { git = "https://github.com/monero-oxide/monero-oxide.gi
 nu-ansi-term          = { version = "0.50", default-features = false }
 paste                 = { version = "1", default-features = false }
 pin-project           = { version = "1", default-features = false }
-randomx-rs            = { git = "https://github.com/Cuprate/randomx-rs.git", rev = "567bdca", default-features = false }
+randomx-rs            = { git = "https://github.com/Cuprate/randomx-rs.git", rev = "a876ab6", default-features = false }
 rand                  = { version = "0.8", default-features = false }
 rand_distr            = { version = "0.4", default-features = false }
 rayon                 = { version = "1", default-features = false }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,43 @@
+# Build stage
+FROM rust:1.97-alpine AS builder
+
+RUN apk add --no-cache alpine-sdk cmake git ca-certificates
+
+WORKDIR /cuprate
+COPY . .
+
+ARG FEATURES="jemalloc"
+
+# Persist the registry and target file across builds. See: https://docs.docker.com/build/cache/optimize/#use-cache-mounts
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/cuprate/target \
+    cargo build --release --locked --bin cuprated --features "$FEATURES" \
+    && cp target/release/cuprated /usr/local/bin/cuprated
+
+RUN mkdir -p /skel/.local/share/cuprate \
+             /skel/.config/cuprate \
+             /skel/.cache/cuprate \
+    && echo 'cuprate:x:1000:1000::/home/cuprate:/sbin/nologin' > /passwd \
+    && echo 'cuprate:x:1000:' > /group
+
+# Runtime stage
+FROM scratch
+
+LABEL org.opencontainers.image.source="https://github.com/Cuprate/cuprate"
+
+COPY --from=builder /passwd /etc/passwd
+COPY --from=builder /group  /etc/group
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=builder /usr/local/bin/cuprated /usr/local/bin/cuprated
+COPY --from=builder --chown=1000:1000 /skel /home/cuprate
+
+USER 1000:1000
+WORKDIR /home/cuprate
+ENV HOME=/home/cuprate
+
+# P2P ports
+EXPOSE 18080/tcp 28080/tcp 38080/tcp
+# Restricted RPC ports
+EXPOSE 18089/tcp 28089/tcp 38089/tcp
+
+ENTRYPOINT ["/usr/local/bin/cuprated"]


### PR DESCRIPTION
### What
Dockerfile, but alpine

Depends on #658 and blocked by Cuprate/randomx-rs#7. Without fixing static linking support, the musl binary will segfault due to mixed static/dynamic libs

### Why
Closes #432, and fixes #557, #465 by bumping the randomx-rs version

### Where
`cuprated`

### How
Since Alpine uses `musl` instead of `glibc`, the downloaded binary won't work reliably with tests, even with the gcompat layer. So the workaround is to sidestep the Actions download, and rely on Alpine's own provided `monero` package, and just symlink the binary. We also skip the download step on `alpine:latest` due to that.