### PR TITLE
CI: Fix doc

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -41,7 +41,7 @@ jobs:
         key: doc
 
     - name: Documentation
-      run: cargo +nightly doc --workspace --all-features
+      run: cargo +nightly doc --workspace --all-features --no-deps
 
     - name: Upload documentation
       uses: actions/upload-pages-artifact@v3

--- a/p2p/p2p-core/src/lib.rs
+++ b/p2p/p2p-core/src/lib.rs
@@ -188,7 +188,7 @@ pub trait Transport<Z: NetworkZone>: Clone + Send + 'static {
     ///
     /// <div class="warning">
     ///
-    /// This does not complete a handshake with the peer, to do that see the [crate](crate) docs.
+    /// This does not complete a handshake with the peer, to do that see the [crate] docs.
     ///
     /// </div>
     ///


### PR DESCRIPTION
Some of our deps docs do not build so I have just made it so the doc CI only creates docs for our crates. This does mean type links to other crates stuff doesn't work but there isn't another way to fix this.