### PR TITLE
cuprated: add seed node config option and --seed-node argument

### DIFF
--- a/binaries/cuprated/src/args.rs
+++ b/binaries/cuprated/src/args.rs
@@ -1,4 +1,4 @@
-use std::{io::Write, path::PathBuf, process::exit};
+use std::{io::Write, net::SocketAddr, path::PathBuf, process::exit};
 
 use clap::builder::TypedValueParser;
 use serde_json::Value;
@@ -47,6 +47,14 @@ pub struct Args {
     #[arg(long)]
     pub outbound_connections: Option<usize>,
 
+    /// An extra seed node to connect to on startup, in addition to the
+    /// network's built-in seeds.
+    ///
+    /// Can be passed multiple times. `FakeChain` has no built-in seeds, so
+    /// this is how a regtest or otherwise isolated network is bootstrapped.
+    #[arg(long, value_name = "IP:PORT")]
+    pub seed_node: Vec<SocketAddr>,
+
     /// The PATH of the `cuprated` config file.
     #[arg(long)]
     pub config_file: Option<PathBuf>,
@@ -94,7 +102,7 @@ impl Args {
     /// Apply the [`Args`] to the given [`Config`].
     ///
     /// This may exit the program if a config value was set that requires an early exit.
-    pub const fn apply_args(&self, mut config: Config) -> Config {
+    pub fn apply_args(&self, mut config: Config) -> Config {
         if let Some(network) = self.network {
             config.network = network;
         }
@@ -112,6 +120,12 @@ impl Args {
         if let Some(outbound_connections) = self.outbound_connections {
             config.p2p.clear_net.outbound_connections = outbound_connections;
         }
+
+        config
+            .p2p
+            .clear_net
+            .seed_nodes
+            .extend_from_slice(&self.seed_node);
 
         config
     }

--- a/binaries/cuprated/src/config.rs
+++ b/binaries/cuprated/src/config.rs
@@ -280,7 +280,11 @@ impl Config {
     pub fn clearnet_p2p_config(&self) -> cuprate_p2p::P2PConfig<ClearNet> {
         cuprate_p2p::P2PConfig {
             network: self.network,
-            seeds: p2p::clear_net_seed_nodes(self.network),
+            seeds: {
+                let mut seeds = p2p::clear_net_seed_nodes(self.network);
+                seeds.extend_from_slice(&self.p2p.clear_net.seed_nodes);
+                seeds
+            },
             offline: self.offline,
             outbound_connections: self.p2p.clear_net.outbound_connections,
             extra_outbound_connections: self.p2p.clear_net.extra_outbound_connections,

--- a/binaries/cuprated/src/config/p2p.rs
+++ b/binaries/cuprated/src/config/p2p.rs
@@ -234,6 +234,17 @@ config_struct! {
         /// Valid values | "Tor", "socks5://ip:port", "socks5://user:pass@ip:port"
         /// Examples     | "Tor", "socks5://127.0.0.1:9050"
         pub proxy: ProxySettings,
+
+        #[comment_out = true]
+        /// Extra seed nodes to connect to on startup, in addition to the
+        /// network's built-in seeds. Given as "ip:port" socket addresses.
+        ///
+        /// FakeChain/regtest ships no built-in seeds, so a private or isolated
+        /// network relies entirely on this list to bootstrap.
+        ///
+        /// Type     | Array of socket addresses
+        /// Examples | "1.2.3.4:18080", "5.6.7.8:18080"
+        pub seed_nodes: Vec<SocketAddr>,
     }
 
     /// The config values for P2P tor.
@@ -309,6 +320,7 @@ impl Default for ClearNetConfig {
             enable_inbound_v6: false,
             listen_on_v6: Ipv6Addr::UNSPECIFIED,
             proxy: ProxySettings::Disabled,
+            seed_nodes: Vec::new(),
             outbound_connections: 32,
             extra_outbound_connections: 8,
             max_inbound_connections: 128,


### PR DESCRIPTION
## Problem

`Network::FakeChain` has no built-in seed nodes — `clear_net_seed_nodes()` returns `[]` for it — and there is currently no way to supply any.

A single `cuprated --regtest` node is fine, but as soon as you want two or more to find each other there is no mechanism to point them at anything, and a node with an empty address book panics in `connection_maintainer`:

```
No seed nodes available to get peers from
```

So multi-node regtest isn't reachable today without editing the hardcoded seed table and rebuilding.

## Change

Two commits, either of which stands alone:

1. **`p2p.clear_net.seed_nodes`** — an optional config field, a list of socket addresses appended to the network's built-in seeds.
2. **`--seed-node <IP:PORT>`** — a repeatable CLI argument that appends to the same list, following the existing `--outbound-connections` override pattern, so a regtest network needs no config file at all:

   ```console
   $ cuprated --regtest --seed-node 127.0.0.1:18080
   ```

- Defaults to empty and is `#[comment_out = true]`, so Mainnet/Testnet/Stagenet behaviour is unchanged.
- Appended to, not replacing, the built-in seeds.
- ~36 lines, no new dependencies.
- One thing worth a reviewer's eye: `Args::apply_args` loses its `const` qualifier, since extending a `Vec` is not a const operation. Happy to drop the second commit if you'd rather keep it `const` and stay config-only.

## Why it's useful

- multi-node regtest, locally and in CI
- private / isolated networks
- network simulation — this is the one patch I needed to run `cuprated` under the [Shadow](https://shadow.github.io/) discrete-event network simulator alongside `monerod`

## Testing

`cargo fmt --all --check`, `cargo clippy -p cuprated --all-targets -- -D warnings`, `RUSTDOCFLAGS='-D warnings' cargo doc -p cuprated`, and `cargo test -p cuprated` all pass locally — including the `documented_config` round-trip test, which the new field satisfies.

Runtime check: `cuprated --regtest` with `seed_nodes` set loads the value, dials the configured address and completes a handshake.

Exercised at scale: a 306-node FakeChain network (180 `cuprated`, 126 `monerod`) bootstrapped entirely through this option under Shadow, reaching full block and transaction propagation across both implementations. That run was on the `0.0.9` base carrying this same patch; it is being re-run on this base now.
