### PR TITLE
cuprated: expand CI and release targets

### DIFF
--- a/.github/actions/monerod-download/action.yml
+++ b/.github/actions/monerod-download/action.yml
@@ -23,6 +23,12 @@ inputs:
     description: "Version to download"
     required: false
     default: v0.18.3.3
+  os:
+    description: "Operating system of the binary"
+    required: true
+  arch:
+    description: "Architecture of the binary"
+    required: true
 
 runs:
   using: "composite"
@@ -34,27 +40,28 @@ runs:
         path: |
           monerod
           monerod.exe
-        key: monerod-${{ runner.os }}-${{ runner.arch }}-${{ inputs.version }}
+        key: monerod-${{ inputs.os }}-${{ inputs.arch }}-${{ inputs.version }}
 
     - name: Download the Monero Daemon
       if: steps.cache-monerod.outputs.cache-hit != 'true'
       shell: bash
       run: |
-        OS=${{ runner.os }}
-        ARCH=${{ runner.arch }}
+        OS=${{ inputs.os }}
+        ARCH=${{ inputs.arch }}
 
         case "$OS $ARCH" in
-          "Windows X64") FILE=monero-win-x64-${{ inputs.version }}.zip ;;
-          "Windows X86") FILE=monero-win-x86-${{ inputs.version }}.zip ;;
-          "Linux X64") FILE=monero-linux-x64-${{ inputs.version }}.tar.bz2 ;;
-          "Linux X86") FILE=monero-linux-x86-${{ inputs.version }}.tar.bz2 ;;
-          "Linux ARM64") FILE=monero-linux-armv8-${{ inputs.version }}.tar.bz2 ;;
-          "macOS X64") FILE=monero-mac-x64-${{ inputs.version }}.tar.bz2 ;;
-          "macOS ARM64") FILE=monero-mac-armv8-${{ inputs.version }}.tar.bz2 ;;
+          "windows x86_64") FILE=monero-win-x64-${{ inputs.version }}.zip ;;
+          "windows x86") FILE=monero-win-x86-${{ inputs.version }}.zip ;;
+          "linux x86_64") FILE=monero-linux-x64-${{ inputs.version }}.tar.bz2 ;;
+          "linux x86") FILE=monero-linux-x86-${{ inputs.version }}.tar.bz2 ;;
+          "linux aarch64") FILE=monero-linux-armv8-${{ inputs.version }}.tar.bz2 ;;
+          "macos x86_64") FILE=monero-mac-x64-${{ inputs.version }}.tar.bz2 ;;
+          "macos aarch64") FILE=monero-mac-armv8-${{ inputs.version }}.tar.bz2 ;;
+          "freebsd x86_64") FILE=monero-freebsd-x64-${{ inputs.version }}.tar.bz2 ;;
           *) exit 1 ;;
         esac
         curl -O -L https://downloads.getmonero.org/cli/$FILE
-        if [[ ${{ runner.os }} == Windows ]]; then
+        if [[ "$FILE" == *.zip ]]; then
           unzip $FILE
           mv */monerod.exe monerod.exe
         else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,15 +88,15 @@ jobs:
 
   # CI, runs on GitHub provided OSs.
   ci:
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.os.runner }}
 
     strategy:
       matrix:
         os: [
-            windows-2022, # EOL = 2026-10-13 | <https://endoflife.date/windows-server>
-            macos-15,     # EOL = 2027-09-16 | <https://endoflife.date/macos>
-            ubuntu-24.04, # EOL = 2029-05-31 | <https://endoflife.date/ubuntu>
-            ubuntu-24.04-arm,
+            { runner: windows-2022, name: windows, architecture: x86_64 }, # EOL = 2026-10-13 | <https://endoflife.date/windows-server>
+            { runner: macos-15, name: macos, architecture: aarch64 },      # EOL = 2027-09-16 | <https://endoflife.date/macos>
+            { runner: ubuntu-24.04, name: linux, architecture: x86_64 },   # EOL = 2029-05-31 | <https://endoflife.date/ubuntu>
+            { runner: ubuntu-24.04-arm, name: linux, architecture: aarch64 },
         ]
 
     steps:
@@ -115,13 +115,16 @@ jobs:
         uses: actions/cache@v4
         with:
           path: target
-          key: ${{ matrix.os }}
+          key: ${{ matrix.os.runner }}
 
       - name: Download monerod
         uses: ./.github/actions/monerod-download
+        with:
+          os: ${{ matrix.os.name }}
+          arch: ${{ matrix.os.architecture }}
 
       - name: Install dependencies (Windows)
-        if: matrix.os == 'windows-2022'
+        if: matrix.os.runner == 'windows-2022'
         uses: lukka/get-cmake@v3.31.6 # Needed for `randomx-rs`
 
       - name: Documentation
@@ -177,6 +180,9 @@ jobs:
       - name: Download monerod
         if: matrix.os.image != 'alpine:latest'
         uses: ./.github/actions/monerod-download
+        with:
+          os: linux
+          arch: x86_64
 
       - name: Documentation
         run: ${{ env.CMD_DOC }}
@@ -192,3 +198,4 @@ jobs:
 
       - name: Hack Check
         run: ${{ env.CMD_HACK }}
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,6 +213,7 @@ jobs:
       matrix:
         os: [
           { name: freebsd, architecture: x86_64, version: "15.1", dependencies: "cmake curl git gmake" },
+          { name: openbsd, architecture: x86_64, version: "7.9", dependencies: "cmake git gmake rust rust-clippy" },
         ]
 
     defaults:
@@ -226,6 +227,7 @@ jobs:
           submodules: recursive
 
       - name: Download monerod
+        if: matrix.os.name != 'openbsd' # There is no prebuilt monerod for OpenBSD
         uses: ./.github/actions/monerod-download
         with:
           os: ${{ matrix.os.name }}
@@ -244,10 +246,18 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo pkg install -y ${{ matrix.os.dependencies }}
-          sudo pkg clean -y
+          case "${{ matrix.os.name }}" in
+            openbsd)
+              sudo pkg_add ${{ matrix.os.dependencies }}
+              ;;
+            freebsd)
+              sudo pkg install -y ${{ matrix.os.dependencies }}
+              sudo pkg clean -y
+              ;;
+          esac
 
       - name: Install Rust
+        if: matrix.os.name == 'freebsd'
         run: |
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --component clippy
           sudo ln -s "$HOME"/.cargo/bin/* /usr/local/bin/
@@ -263,11 +273,30 @@ jobs:
         run: ${{ env.CMD_CLIPPY }}
 
       - name: Test
-        run: ${{ env.CMD_TEST }}
+        run: |
+          case "${{ matrix.os.name }}" in
+            openbsd)
+              ulimit -Sd 4194304
+              cargo test --all-features --workspace --exclude cuprate-p2p-core
+              cargo test --all-features --package cuprate-p2p-core --lib --tests -- --skip monerod
+              ;;
+            *)
+              ${{ env.CMD_TEST }}
+              ;;
+          esac
 
       - name: Build
         run: ${{ env.CMD_BUILD }}
 
       - name: Hack Check
-        run: ${{ env.CMD_HACK }}
+        run: |
+          case "${{ matrix.os.name }}" in
+            openbsd)
+              cargo install cargo-hack --locked
+              cargo hack check --feature-powerset --no-dev-deps --workspace --exclude cuprate-fuzz
+              ;;
+            *)
+              ${{ env.CMD_HACK }}
+              ;;
+          esac
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,3 +199,75 @@ jobs:
       - name: Hack Check
         run: ${{ env.CMD_HACK }}
 
+  # CI, runs in virtual machines.
+  ci-vm:
+    runs-on: ubuntu-latest
+
+    env:
+      CARGO_INCREMENTAL: "0"
+      CARGO_PROFILE_DEV_DEBUG: "0"
+      CARGO_PROFILE_TEST_DEBUG: "0"
+      CARGO_PROFILE_DEV_BUILD_OVERRIDE_DEBUG: "0"
+
+    strategy:
+      matrix:
+        os: [
+          { name: freebsd, architecture: x86_64, version: "15.1", dependencies: "cmake curl git gmake" },
+        ]
+
+    defaults:
+      run:
+        shell: cpa.sh {0} --sync-files none
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Download monerod
+        uses: ./.github/actions/monerod-download
+        with:
+          os: ${{ matrix.os.name }}
+          arch: ${{ matrix.os.architecture }}
+
+      - name: Start VM
+        uses: cross-platform-actions/action@v1.3.0
+        with:
+          operating_system: ${{ matrix.os.name }}
+          architecture: ${{ matrix.os.architecture }}
+          version: ${{ matrix.os.version }}
+          memory: 6G
+          cpu_count: 4
+          sync_files: runner-to-vm
+          environment_variables: CARGO_TERM_COLOR RUST_BACKTRACE RUST_MIN_STACK RUSTDOCFLAGS CARGO_PROFILE_DEV_BUILD_OVERRIDE_DEBUG CARGO_INCREMENTAL CARGO_PROFILE_DEV_DEBUG CARGO_PROFILE_TEST_DEBUG
+
+      - name: Install dependencies
+        run: |
+          sudo pkg install -y ${{ matrix.os.dependencies }}
+          sudo pkg clean -y
+
+      - name: Install Rust
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --component clippy
+          sudo ln -s "$HOME"/.cargo/bin/* /usr/local/bin/
+
+      - name: Documentation
+        run: |
+          ${{ env.CMD_DOC }}
+          cargo clean --doc
+          rm -rf "$HOME/.cargo/registry/cache"
+          rm -rf "$HOME/.cargo/git/db"
+
+      - name: Clippy (fail on warnings)
+        run: ${{ env.CMD_CLIPPY }}
+
+      - name: Test
+        run: ${{ env.CMD_TEST }}
+
+      - name: Build
+        run: ${{ env.CMD_BUILD }}
+
+      - name: Hack Check
+        run: ${{ env.CMD_HACK }}
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -300,3 +300,53 @@ jobs:
               ;;
           esac
 
+  # CI, runs cross-compiled targets under emulation.
+  ci-cross:
+    runs-on: ubuntu-latest
+
+    env:
+      PROPTEST_TIMEOUT: 0
+
+    strategy:
+      matrix:
+        target: [
+            riscv64gc-unknown-linux-gnu,
+        ]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+          components: clippy
+
+      - name: Install cross toolchain
+        uses: taiki-e/setup-cross-toolchain-action@v1
+        with:
+          target: ${{ matrix.target }}
+
+      - name: Cache
+        uses: actions/cache@v4
+        with:
+          path: target
+          key: ${{ matrix.target }}
+
+      - name: Documentation
+        run: ${{ env.CMD_DOC }}
+
+      - name: Clippy (fail on warnings)
+        run: ${{ env.CMD_CLIPPY }}
+
+      # There is no prebuilt monerod for RISC-V, so the tests that require it are skipped.
+      - name: Test
+        run: |
+          cargo test --all-features --workspace --exclude cuprate-p2p-core
+          cargo test --all-features --package cuprate-p2p-core --lib --tests -- --skip monerod
+
+      - name: Build
+        run: ${{ env.CMD_BUILD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -206,3 +206,66 @@ jobs:
           compression-level: 0
           path: ${{ env.ARCHIVE }}/**
 
+  build-cross:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        os: [
+            { name: linux-riscv64-gnu, target: riscv64gc-unknown-linux-gnu },
+        ]
+
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          ref: ${{ inputs.commit }}
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+
+      - name: Install cross toolchain
+        uses: taiki-e/setup-cross-toolchain-action@v1
+        with:
+          target: ${{ matrix.os.target }}
+
+      - name: Build
+        run: cargo build --release --package cuprated
+
+      - name: Generate config
+        run: cargo run --release --package cuprated -- --generate-config > Cuprated.toml
+
+      - name: Generate Archive
+        run: |
+          set -e -o pipefail # Exit on failures
+          umask 0077         # 700 permissions
+          export TZ=UTC      # UTC timezone
+
+          # Reset archive directory in-case.
+          rm -rf ${{ env.ARCHIVE }}
+          mkdir -p ${{ env.ARCHIVE }}
+
+          readonly ARCHIVE=$(realpath ${{ env.ARCHIVE }})
+          readonly VERSION=$(grep '^version = ' binaries/cuprated/Cargo.toml | cut -d'"' -f2)
+          readonly OUT="target/$CARGO_BUILD_TARGET/release"
+          readonly ASSET="cuprated-$VERSION-$CARGO_BUILD_TARGET.tar.gz"
+
+          # Generate archives for Linux.
+          cp LICENSE-AGPL "$OUT/LICENSE"
+          cp binaries/cuprated/cuprated.service "$OUT"
+          mv Cuprated.toml "$OUT"
+          tar -czpf "$ARCHIVE/$ASSET" -C "$OUT" cuprated LICENSE Cuprated.toml cuprated.service
+
+      - name: Archive
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.os.name }}
+          compression-level: 0
+          path: ${{ env.ARCHIVE }}/**

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,3 +111,78 @@ jobs:
           compression-level: 0
           path: ${{ env.ARCHIVE }}/**
 
+  build-vm:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        os: [
+            { name: freebsd, architecture: x86_64, version: "15.1" },
+        ]
+
+    defaults:
+      run:
+        shell: cpa.sh {0} --sync-files none
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          ref: ${{ inputs.commit }}
+
+      - name: Start VM
+        uses: cross-platform-actions/action@v1.3.0
+        with:
+          operating_system: ${{ matrix.os.name }}
+          architecture: ${{ matrix.os.architecture }}
+          version: ${{ matrix.os.version }}
+          memory: 6G
+          cpu_count: 4
+          sync_files: runner-to-vm
+          environment_variables: CARGO_TERM_COLOR
+
+      - name: Install dependencies
+        run: sudo pkg install -y cmake curl git gmake
+
+      - name: Install Rust
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal
+          sudo ln -s "$HOME"/.cargo/bin/* /usr/local/bin/
+
+      - name: Build
+        run: cargo build --release --package cuprated
+
+      - name: Generate Archive
+        shell: cpa.sh {0} --sync-files vm-to-runner
+        run: |
+          set -e            # Exit on failures
+          umask 0077        # 700 permissions
+          export TZ=UTC     # UTC timezone
+
+          # Reset archive directory in-case.
+          rm -rf ${{ env.ARCHIVE }}
+          mkdir -p ${{ env.ARCHIVE }}
+
+          readonly ARCHIVE=$(realpath ${{ env.ARCHIVE }})
+          readonly VERSION=$(grep '^version = ' binaries/cuprated/Cargo.toml | cut -d'"' -f2)
+
+          # Generate the asset name.
+          readonly TARGET=$(rustc -vV | sed -n 's/^host: //p')
+          readonly ASSET="cuprated-$VERSION-$TARGET.tar.gz"
+
+          # Generate archive for BSD.
+          cp LICENSE-AGPL target/release/LICENSE
+          target/release/cuprated --generate-config > target/release/Cuprated.toml
+          tar -czpf "$ARCHIVE/$ASSET" -C target/release cuprated LICENSE Cuprated.toml
+
+          # Only sync the finished archive back to the runner.
+          rm -rf target
+
+      - name: Archive
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.os.name }}-${{ matrix.os.architecture }}
+          compression-level: 0
+          path: ${{ env.ARCHIVE }}/**
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,6 +118,7 @@ jobs:
       matrix:
         os: [
             { name: freebsd, architecture: x86_64, version: "15.1" },
+            { name: openbsd, architecture: x86_64, version: "7.9" },
         ]
 
     defaults:
@@ -143,15 +144,26 @@ jobs:
           environment_variables: CARGO_TERM_COLOR
 
       - name: Install dependencies
-        run: sudo pkg install -y cmake curl git gmake
+        run: |
+          case "${{ matrix.os.name }}" in
+            openbsd)
+              sudo pkg_add cmake git gmake rust
+              ;;
+            freebsd)
+              sudo pkg install -y cmake curl git gmake
+              ;;
+          esac
 
       - name: Install Rust
+        if: matrix.os.name == 'freebsd'
         run: |
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal
           sudo ln -s "$HOME"/.cargo/bin/* /usr/local/bin/
 
       - name: Build
-        run: cargo build --release --package cuprated
+        run: |
+          [ "${{ matrix.os.name }}" != openbsd ] || ulimit -Sd 4194304
+          cargo build --release --package cuprated
 
       - name: Generate Archive
         shell: cpa.sh {0} --sync-files vm-to-runner
@@ -169,7 +181,15 @@ jobs:
 
           # Generate the asset name.
           readonly TARGET=$(rustc -vV | sed -n 's/^host: //p')
-          readonly ASSET="cuprated-$VERSION-$TARGET.tar.gz"
+          case "${{ matrix.os.name }}" in
+            # OpenBSD does not keep binary compatibility between releases.
+            openbsd)
+              readonly ASSET="cuprated-$VERSION-${TARGET}$(uname -r).tar.gz"
+              ;;
+            *)
+              readonly ASSET="cuprated-$VERSION-$TARGET.tar.gz"
+              ;;
+          esac
 
           # Generate archive for BSD.
           cp LICENSE-AGPL target/release/LICENSE

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,19 +19,26 @@ jobs:
     strategy:
       matrix:
         os: [
-            windows-2022, # EOL = 2026-10-13 | <https://endoflife.date/windows-server>
-            macos-15,     # EOL = 2027-09-16 | <https://endoflife.date/macos>
-            ubuntu-24.04, # EOL = 2029-05-31 | <https://endoflife.date/ubuntu>
-            ubuntu-24.04-arm,
+            { name: windows-x86_64, runner: windows-2022 },      # EOL = 2026-10-13 | <https://endoflife.date/windows-server>
+            { name: macos-aarch64, runner: macos-15 },          # EOL = 2027-09-16 | <https://endoflife.date/macos>
+            { name: linux-x86_64-gnu, runner: ubuntu-24.04 },   # EOL = 2029-05-31 | <https://endoflife.date/ubuntu>
+            { name: linux-aarch64-gnu, runner: ubuntu-24.04-arm },
+            { name: linux-x86_64-musl, runner: ubuntu-24.04, container: alpine:latest, features: jemalloc },
         ]
 
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.os.runner }}
+    container: ${{ matrix.os.container }}
 
     defaults:
       run:
         shell: bash
 
     steps:
+      - name: Install Alpine dependencies
+        if: matrix.os.container == 'alpine:latest'
+        shell: sh
+        run: apk add --no-cache alpine-sdk bash cmake curl
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
@@ -44,7 +51,7 @@ jobs:
           toolchain: stable
 
       - name: Build
-        run: cargo build --release --package cuprated
+        run: cargo build --release --package cuprated --features "${{ matrix.os.features }}"
 
       - name: Generate Archives
         run: |
@@ -74,8 +81,7 @@ jobs:
           fi
 
           # Generate the asset name.
-          TARGET=($(rustup show | grep "Default"))
-          readonly TARGET=${TARGET[2]}
+          readonly TARGET=$(rustc -vV | sed -n 's/^host: //p')
           readonly ASSET="cuprated-$VERSION-$TARGET.$EXTENSION"
 
           # Generate archives for Linux.
@@ -101,6 +107,7 @@ jobs:
       - name: Archive
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.os }}
+          name: ${{ matrix.os.name }}
           compression-level: 0
           path: ${{ env.ARCHIVE }}/**
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1559,7 +1559,7 @@ dependencies = [
  "serde_bytes",
  "serde_json",
  "strum",
- "sysinfo 0.39.6",
+ "sysinfo",
  "tempfile",
  "thiserror 2.0.18",
  "thread_local",
@@ -5162,20 +5162,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sysinfo"
-version = "0.39.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2071df9448915b71c4fe6d25deaf1c22f12bd234f01540b77312bb8e41361e6"
-dependencies = [
- "libc",
- "memchr",
- "ntapi",
- "objc2-core-foundation",
- "objc2-io-kit",
- "windows",
-]
-
-[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6301,7 +6287,7 @@ dependencies = [
  "serde",
  "slotmap-careful",
  "static_assertions",
- "sysinfo 0.38.4",
+ "sysinfo",
  "thiserror 2.0.18",
  "tor-async-utils",
  "tor-basic-utils",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -198,7 +198,7 @@ serde_bytes           = { version = "0.11", default-features = false }
 serde_json            = { version = "1", default-features = false }
 serde                 = { version = "1", default-features = false }
 strum                 = { version = "0.28", default-features = false }
-sysinfo               = { version = "0.39", default-features = false }
+sysinfo               = { version = "0.38.4", default-features = false }
 tapes                 = { git = "https://github.com/Cuprate/Tapes.git", rev = "f28b6fb" }
 thiserror             = { version = "2", default-features = false }
 thread_local          = { version = "1", default-features = false }

--- a/books/user/src/platform.md
+++ b/books/user/src/platform.md
@@ -30,6 +30,7 @@ Tier 2 targets can be thought of as "guaranteed to build".
 |------------------------------|--------|
 | `x86_64-pc-windows-msvc`    | x64 Windows (MSVC, Windows Server 2022+)
 | `x86_64-unknown-linux-musl`  | x64 Linux (musl 1.2.3)
+| `x86_64-unknown-freebsd` 	   | x64 FreeBSD
 
 ## Tier 3
 
@@ -40,6 +41,5 @@ Official builds are not available, but may eventually be planned.
 | Target                       | Notes  |
 |------------------------------|--------|
 | `aarch64-unknown-linux-musl` | ARM64 Linux (musl 1.2.3)
-| `x86_64-unknown-freebsd` 	   | x64 FreeBSD
 | `aarch64-unknown-freebsd`    | ARM64 FreeBSD
 | `aarch64-pc-windows-msvc`    | ARM64 Windows (MSVC, Windows Server 2022+)

--- a/books/user/src/platform.md
+++ b/books/user/src/platform.md
@@ -32,6 +32,7 @@ Tier 2 targets can be thought of as "guaranteed to build".
 | `x86_64-unknown-linux-musl`  | x64 Linux (musl 1.2.3)
 | `x86_64-unknown-freebsd` 	   | x64 FreeBSD
 | `x86_64-unknown-openbsd`     | x64 OpenBSD (7.9+)
+| `riscv64gc-unknown-linux-gnu`  | RISC-V 64 Linux (glibc 2.36+)
 
 ## Tier 3
 
@@ -44,3 +45,4 @@ Official builds are not available, but may eventually be planned.
 | `aarch64-unknown-linux-musl` | ARM64 Linux (musl 1.2.3)
 | `aarch64-unknown-freebsd`    | ARM64 FreeBSD
 | `aarch64-pc-windows-msvc`    | ARM64 Windows (MSVC, Windows Server 2022+)
+| `riscv64gc-unknown-linux-musl` | RISC-V 64 Linux (musl 1.2.3)

--- a/books/user/src/platform.md
+++ b/books/user/src/platform.md
@@ -26,9 +26,10 @@ Tier 1 targets can be thought of as "guaranteed to work".
 
 Tier 2 targets can be thought of as "guaranteed to build".
 
-| Target                      | Notes  |
-|-----------------------------|--------|
+| Target                       | Notes  |
+|------------------------------|--------|
 | `x86_64-pc-windows-msvc`    | x64 Windows (MSVC, Windows Server 2022+)
+| `x86_64-unknown-linux-musl`  | x64 Linux (musl 1.2.3)
 
 ## Tier 3
 
@@ -38,7 +39,6 @@ Official builds are not available, but may eventually be planned.
 
 | Target                       | Notes  |
 |------------------------------|--------|
-| `x86_64-unknown-linux-musl`  | x64 Linux (musl 1.2.3)
 | `aarch64-unknown-linux-musl` | ARM64 Linux (musl 1.2.3)
 | `x86_64-unknown-freebsd` 	   | x64 FreeBSD
 | `aarch64-unknown-freebsd`    | ARM64 FreeBSD

--- a/books/user/src/platform.md
+++ b/books/user/src/platform.md
@@ -31,6 +31,7 @@ Tier 2 targets can be thought of as "guaranteed to build".
 | `x86_64-pc-windows-msvc`    | x64 Windows (MSVC, Windows Server 2022+)
 | `x86_64-unknown-linux-musl`  | x64 Linux (musl 1.2.3)
 | `x86_64-unknown-freebsd` 	   | x64 FreeBSD
+| `x86_64-unknown-openbsd`     | x64 OpenBSD (7.9+)
 
 ## Tier 3
 

--- a/books/user/src/platform.md
+++ b/books/user/src/platform.md
@@ -21,6 +21,7 @@ Tier 1 targets can be thought of as "guaranteed to work".
 | `x86_64-unknown-linux-gnu`  | x64 Linux (glibc 2.36+)
 | `aarch64-unknown-linux-gnu` | ARM64 Linux (glibc 2.36+)
 | `aarch64-apple-darwin`      | ARM64 macOS (11.0+)
+| `x86_64-pc-windows-msvc`    | x64 Windows (MSVC, Windows Server 2022+)
 
 ## Tier 2
 
@@ -28,7 +29,6 @@ Tier 2 targets can be thought of as "guaranteed to build".
 
 | Target                       | Notes  |
 |------------------------------|--------|
-| `x86_64-pc-windows-msvc`    | x64 Windows (MSVC, Windows Server 2022+)
 | `x86_64-unknown-linux-musl`  | x64 Linux (musl 1.2.3)
 | `x86_64-unknown-freebsd` 	   | x64 FreeBSD
 | `x86_64-unknown-openbsd`     | x64 OpenBSD (7.9+)
@@ -42,7 +42,7 @@ Official builds are not available, but may eventually be planned.
 
 | Target                       | Notes  |
 |------------------------------|--------|
-| `aarch64-unknown-linux-musl` | ARM64 Linux (musl 1.2.3)
-| `aarch64-unknown-freebsd`    | ARM64 FreeBSD
-| `aarch64-pc-windows-msvc`    | ARM64 Windows (MSVC, Windows Server 2022+)
+| `aarch64-unknown-freebsd`      | ARM64 FreeBSD
+| `aarch64-pc-windows-msvc`      | ARM64 Windows (MSVC, Windows 11+)
+| `aarch64-unknown-linux-musl`   | ARM64 Linux (musl 1.2.3)
 | `riscv64gc-unknown-linux-musl` | RISC-V 64 Linux (musl 1.2.3)


### PR DESCRIPTION
### What
Expand CI and release targets - add support for OpenBSD 7.9, FreeBSD, RISC-V Linux, x86 MUSL Linux. Part of #472 

### Why
More platforms = gud

### Where
`cuprated`

### How
- In both CI and release workflows, add jobs that build *BSD in virtual machines (`cross-platform-actions`), RISC-V via cross-compilation (`taiki-e/setup-cross-toolchain-action`), and x64 musl in an Alpine container.
- musl builds with `jemalloc`
- `monerod-download` action takes `os`/`arch` inputs now - `runner.*` describes the host, which didnt work for VM/cross jobs. OpenBSD and RISC-V have no monerod, so we skip those tests.
- Pinned `sysinfo` to 0.38.4 to lower the MSRV for OpenBSD.
- Update `platform.md`