### PR TITLE
Cuprated: make toml errors nice again

### DIFF
--- a/binaries/cuprated/src/main.rs
+++ b/binaries/cuprated/src/main.rs
@@ -170,11 +170,11 @@ async fn shutdown_signal() {
 fn load_config(args: &Args) -> Config {
     let config = if let Some(config_file) = &args.config_file {
         Config::read_from_path(config_file).unwrap_or_else(|e| {
-            eprintln_red(&format!("Failed to read config from file: {e}"));
+            eprintln_red(&format!("Failed to read config from file: {e:#}"));
             std::process::exit(1);
         })
     } else if let Some(config) = find_config().unwrap_or_else(|e| {
-        eprintln_red(&format!("Failed to read config: {e}"));
+        eprintln_red(&format!("Failed to read config: {e:#}"));
         std::process::exit(1);
     }) {
         config


### PR DESCRIPTION
before: 
```
Failed to read config: Failed to parse config file at: ###
```

after:

```
: TOML parse error at line 19, column 1
   |                                                                                                                                                                                           
19 | networ = "Mainnet"                                                                                                                                                                        
   | ^^^^^^                                                                                                                                                                                    
unknown field `networ`, expected one of `network`, `offline`, `fast_sync`, `fixed_difficulty`, `target_max_memory`, `tracing`, `tokio`, `rayon`, `p2p`, `tor`, `rpc`, `storage`, `fs`  
```