### PR TITLE
P2P: fix address book panic when banning a peer

### DIFF
--- a/p2p/address-book/src/book.rs
+++ b/p2p/address-book/src/book.rs
@@ -58,7 +58,6 @@ pub struct AddressBook<Z: BorshNetworkZone> {
     anchor_list: HashSet<Z::Addr>,
     /// The currently connected peers.
     connected_peers: HashMap<InternalPeerID<Z::Addr>, ConnectionPeerEntry<Z>>,
-    connected_peers_ban_id: HashMap<<Z::Addr as NetZoneAddress>::BanID, HashSet<Z::Addr>>,
 
     banned_peers: HashMap<<Z::Addr as NetZoneAddress>::BanID, Instant>,
     banned_peers_queue: DelayQueue<<Z::Addr as NetZoneAddress>::BanID>,
@@ -94,7 +93,6 @@ impl<Z: BorshNetworkZone> AddressBook<Z> {
             gray_list,
             anchor_list,
             connected_peers,
-            connected_peers_ban_id: HashMap::new(),
             banned_peers,
             banned_peers_queue,
             peer_save_task_handle: None,
@@ -164,51 +162,57 @@ impl<Z: BorshNetworkZone> AddressBook<Z> {
         }
 
         for disconnected_addr in internal_addr_disconnected {
-            self.connected_peers.remove(&disconnected_addr);
-            if let InternalPeerID::KnownAddr(addr) = disconnected_addr {
-                // remove the peer from the connected peers with this ban ID.
-                self.connected_peers_ban_id
-                    .get_mut(&addr.ban_id())
-                    .unwrap()
-                    .remove(&addr);
-
-                // If the amount of peers with this ban id is 0 remove the whole set.
-                if self.connected_peers_ban_id[&addr.ban_id()].is_empty() {
-                    self.connected_peers_ban_id.remove(&addr.ban_id());
+            let peer = self.connected_peers.remove(&disconnected_addr);
+            // The anchor list is keyed by the address we can reach the peer on, and we can
+            // hold more than one connection to it.
+            if let Some(addr) = peer.and_then(|peer| peer.addr) {
+                if !self
+                    .connected_peers
+                    .values()
+                    .any(|peer| peer.addr == Some(addr))
+                {
+                    self.anchor_list.remove(&addr);
                 }
-                // remove the peer from the anchor list.
-                self.anchor_list.remove(&addr);
             }
         }
     }
 
     fn ban_peer(&mut self, addr: Z::Addr, time: Duration) {
-        if self.banned_peers.contains_key(&addr.ban_id()) {
+        let ban_id = addr.ban_id();
+
+        if self.banned_peers.contains_key(&ban_id) {
             tracing::error!("Tried to ban peer twice, this shouldn't happen.");
         }
 
-        if let Some(connected_peers_with_ban_id) = self.connected_peers_ban_id.get(&addr.ban_id()) {
-            for peer in connected_peers_with_ban_id.iter().map(|addr| {
-                tracing::debug!("Banning peer: {}, for: {:?}", addr, time);
+        let peers_with_ban_id = self
+            .connected_peers
+            .iter()
+            .filter_map(|(internal_peer_id, peer)| match internal_peer_id {
+                InternalPeerID::KnownAddr(addr) if addr.ban_id() == ban_id => {
+                    Some((*addr, peer.addr, peer.handle.clone()))
+                }
+                InternalPeerID::KnownAddr(_) | InternalPeerID::Unknown(_) => None,
+            })
+            .collect::<Vec<_>>();
 
-                self.connected_peers
-                    .get(&InternalPeerID::KnownAddr(*addr))
-                    .expect("Peer must be in connected list if in connected_peers_with_ban_id")
-            }) {
-                // The peer will get removed from our connected list once we disconnect
-                peer.handle.send_close_signal();
-                // Remove the peer now from anchors so we don't accidentally persist a bad anchor peer to disk.
-                self.anchor_list.remove(&addr);
+        for (addr, reachable_addr, handle) in peers_with_ban_id {
+            tracing::debug!("Banning peer: {}, for: {:?}", addr, time);
+
+            // The peer will get removed from our connected list once we disconnect
+            handle.send_close_signal();
+            // Remove the peer now from anchors so we don't accidentally persist a bad anchor peer to disk.
+            if let Some(reachable_addr) = reachable_addr {
+                self.anchor_list.remove(&reachable_addr);
             }
         }
 
-        self.white_list.remove_peers_with_ban_id(&addr.ban_id());
-        self.gray_list.remove_peers_with_ban_id(&addr.ban_id());
+        self.white_list.remove_peers_with_ban_id(&ban_id);
+        self.gray_list.remove_peers_with_ban_id(&ban_id);
 
         let unban_at = Instant::now() + time;
 
-        self.banned_peers_queue.insert_at(addr.ban_id(), unban_at);
-        self.banned_peers.insert(addr.ban_id(), unban_at);
+        self.banned_peers_queue.insert_at(ban_id, unban_at);
+        self.banned_peers.insert(ban_id, unban_at);
     }
 
     /// adds a peer to the gray list.
@@ -335,11 +339,6 @@ impl<Z: BorshNetworkZone> AddressBook<Z> {
             if self.is_peer_banned(addr) {
                 return Err(AddressBookError::PeerIsBanned);
             }
-            // although the peer may not be reachable still add it to the connected peers with ban ID.
-            self.connected_peers_ban_id
-                .entry(addr.ban_id())
-                .or_default()
-                .insert(*addr);
         }
 
         // if the address is Some that means we can reach it from our node.

--- a/p2p/address-book/src/book/tests.rs
+++ b/p2p/address-book/src/book/tests.rs
@@ -1,13 +1,16 @@
-use std::{path::PathBuf, time::Duration};
+use std::{net::SocketAddr, path::PathBuf, time::Duration};
 
 use futures::StreamExt;
 use tokio::time::interval;
 
-use cuprate_p2p_core::{handles::HandleBuilder, NetworkZone};
+use cuprate_p2p_core::{handles::HandleBuilder, ClearNet, NetworkZone};
 use cuprate_pruning::PruningSeed;
 
 use super::{AddressBook, ConnectionPeerEntry, InternalPeerID};
-use crate::{peer_list::tests::make_fake_peer_list, AddressBookConfig, AddressBookError};
+use crate::{
+    peer_list::tests::make_fake_peer_list, peer_list::PeerList, AddressBookConfig,
+    AddressBookError, BorshNetworkZone,
+};
 
 use cuprate_test_utils::test_netzone::{TestNetZone, TestNetZoneAddr};
 
@@ -21,21 +24,25 @@ fn test_cfg<Z: NetworkZone>() -> AddressBookConfig<Z> {
     }
 }
 
-fn make_fake_address_book(numb_white: u32, numb_gray: u32) -> AddressBook<TestNetZone<true>> {
-    let white_list = make_fake_peer_list(0, numb_white);
-    let gray_list = make_fake_peer_list(numb_white, numb_gray);
-
+fn empty_address_book<Z: BorshNetworkZone>() -> AddressBook<Z> {
     AddressBook {
-        white_list,
-        gray_list,
+        white_list: PeerList::new(vec![]),
+        gray_list: PeerList::new(vec![]),
         anchor_list: Default::default(),
         connected_peers: Default::default(),
-        connected_peers_ban_id: Default::default(),
         banned_peers: Default::default(),
         banned_peers_queue: Default::default(),
         peer_save_task_handle: None,
         peer_save_interval: interval(Duration::from_secs(60)),
         cfg: test_cfg(),
+    }
+}
+
+fn make_fake_address_book(numb_white: u32, numb_gray: u32) -> AddressBook<TestNetZone<true>> {
+    AddressBook {
+        white_list: make_fake_peer_list(0, numb_white),
+        gray_list: make_fake_peer_list(numb_white, numb_gray),
+        ..empty_address_book()
     }
 }
 
@@ -142,4 +149,178 @@ async fn banned_peer_removed_from_peer_lists() {
             .into_inner(),
         TestNetZoneAddr(1)
     );
+}
+
+#[tokio::test]
+async fn ban_peer_after_failed_connection() {
+    let mut book = empty_address_book::<ClearNet>();
+
+    let dialled: SocketAddr = "1.2.3.4:18080".parse().unwrap();
+    let other: SocketAddr = "1.2.3.4:45678".parse().unwrap();
+
+    let entry = |handle, pruning_seed| ConnectionPeerEntry {
+        addr: Some(dialled),
+        id: 0,
+        handle,
+        pruning_seed,
+        rpc_port: 0,
+        rpc_credits_per_hash: 0,
+    };
+
+    let (_guard, handle) = HandleBuilder::default().build();
+    book.handle_new_connection(
+        InternalPeerID::KnownAddr(dialled),
+        entry(handle.clone(), PruningSeed::NotPruned),
+    )
+    .unwrap();
+
+    handle.send_close_signal();
+    book.poll_connected_peers();
+
+    let (_guard, handle) = HandleBuilder::default().build();
+    assert_eq!(
+        book.handle_new_connection(
+            InternalPeerID::KnownAddr(dialled),
+            entry(handle, PruningSeed::decompress(385).unwrap()),
+        ),
+        Err(AddressBookError::PeersDataChanged("Pruning seed"))
+    );
+
+    let (_guard, handle) = HandleBuilder::default().build();
+    book.handle_new_connection(
+        InternalPeerID::KnownAddr(other),
+        ConnectionPeerEntry {
+            addr: None,
+            id: 0,
+            handle,
+            pruning_seed: PruningSeed::NotPruned,
+            rpc_port: 0,
+            rpc_credits_per_hash: 0,
+        },
+    )
+    .unwrap();
+
+    book.ban_peer(other, Duration::from_secs(1));
+    assert_eq!(book.banned_peers.len(), 1);
+}
+
+#[tokio::test]
+async fn ban_peer_closes_all_with_ban_id() {
+    let mut book = empty_address_book::<ClearNet>();
+
+    let first: SocketAddr = "1.2.3.4:18080".parse().unwrap();
+    let second: SocketAddr = "1.2.3.4:45678".parse().unwrap();
+    let unrelated: SocketAddr = "5.6.7.8:18080".parse().unwrap();
+
+    let mut handles = Vec::new();
+    for addr in [first, second, unrelated] {
+        let (guard, handle) = HandleBuilder::default().build();
+        book.handle_new_connection(
+            InternalPeerID::KnownAddr(addr),
+            ConnectionPeerEntry {
+                addr: Some(addr),
+                id: 0,
+                handle: handle.clone(),
+                pruning_seed: PruningSeed::NotPruned,
+                rpc_port: 0,
+                rpc_credits_per_hash: 0,
+            },
+        )
+        .unwrap();
+        handles.push((addr, guard, handle));
+    }
+
+    assert_eq!(book.anchor_list.len(), 3);
+
+    book.ban_peer(first, Duration::from_secs(1));
+
+    for (addr, _guard, handle) in &handles {
+        if addr.ip() == first.ip() {
+            assert!(handle.is_closed(), "{addr} shares the ban ID, should close");
+            assert!(!book.anchor_list.contains(addr));
+        } else {
+            assert!(!handle.is_closed(), "{addr} should be untouched");
+            assert!(book.anchor_list.contains(addr));
+        }
+    }
+}
+
+#[tokio::test]
+async fn anchor_removed_for_inbound_peer() {
+    let mut book = empty_address_book::<ClearNet>();
+
+    let source: SocketAddr = "1.2.3.4:45678".parse().unwrap();
+    let reachable: SocketAddr = "1.2.3.4:18080".parse().unwrap();
+
+    let connect = |book: &mut AddressBook<ClearNet>, handle| {
+        book.handle_new_connection(
+            InternalPeerID::KnownAddr(source),
+            ConnectionPeerEntry {
+                addr: Some(reachable),
+                id: 0,
+                handle,
+                pruning_seed: PruningSeed::NotPruned,
+                rpc_port: 0,
+                rpc_credits_per_hash: 0,
+            },
+        )
+        .unwrap();
+    };
+
+    let (_guard, handle) = HandleBuilder::default().build();
+    connect(&mut book, handle);
+    assert!(book.anchor_list.contains(&reachable));
+
+    book.ban_peer(source, Duration::from_secs(1));
+    assert!(book.anchor_list.is_empty());
+
+    book.poll_connected_peers();
+    book.banned_peers.clear();
+    assert!(book.connected_peers.is_empty());
+
+    let (_guard, handle) = HandleBuilder::default().build();
+    connect(&mut book, handle.clone());
+    assert!(book.anchor_list.contains(&reachable));
+
+    handle.send_close_signal();
+    book.poll_connected_peers();
+    assert!(book.anchor_list.is_empty());
+    assert!(book.connected_peers.is_empty());
+}
+
+#[tokio::test]
+async fn anchor_kept_while_another_connection_remains() {
+    let mut book = empty_address_book::<ClearNet>();
+
+    let reachable: SocketAddr = "1.2.3.4:18080".parse().unwrap();
+    let inbound_source: SocketAddr = "1.2.3.4:45678".parse().unwrap();
+
+    let mut handles = Vec::new();
+    for internal_addr in [reachable, inbound_source] {
+        let (guard, handle) = HandleBuilder::default().build();
+        book.handle_new_connection(
+            InternalPeerID::KnownAddr(internal_addr),
+            ConnectionPeerEntry {
+                addr: Some(reachable),
+                id: 0,
+                handle: handle.clone(),
+                pruning_seed: PruningSeed::NotPruned,
+                rpc_port: 0,
+                rpc_credits_per_hash: 0,
+            },
+        )
+        .unwrap();
+        handles.push((guard, handle));
+    }
+    assert!(book.anchor_list.contains(&reachable));
+
+    handles[0].1.send_close_signal();
+    book.poll_connected_peers();
+    assert_eq!(book.connected_peers.len(), 1);
+    assert!(book.anchor_list.contains(&reachable));
+
+    handles[1].1.send_close_signal();
+    book.poll_connected_peers();
+    assert!(book.connected_peers.is_empty());
+    assert!(book.anchor_list.is_empty());
 }


### PR DESCRIPTION
`handle_new_connection` inserted into `connected_peers_ban_id` before `update_white_list_peer_entry`, which fails when a peer already in the white list connects advertising a different pruning seed. The index then kept an entry for a connection never added to `connected_peers`, and eviction only walks `connected_peers`, so it stayed.

`ban_peer` looked those entries back up in `connected_peers` and `expect`ed them to be there, so banning any peer sharing that ban ID ended the process, as the workspace sets `panic = "abort"`.

Remove `connected_peers_ban_id` rather than reorder the insert: it only answered which connected peers share a ban ID, which is a filter over `connected_peers` that cannot disagree with it. This also drops the two lookups in the disconnect handling that assumed they agreed.

Anchor removal was wrong in three ways. `ban_peer` bound the iterated address inside a closure, so the removal in the loop body used the banned address instead of each closed peer's. Both it and the disconnect path keyed off the connection address, while the anchor list is keyed by the address the peer is reachable on, which differs for inbound peers. And the disconnect path dropped the entry even when another connection to that address was still open. Both now key off the reachable address, and the disconnect path waits for the last connection to close.
