### PR TITLE
cuprated: allow onion addresses to be specified as seed nodes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1477,6 +1477,7 @@ dependencies = [
  "cuprate-types",
  "hex",
  "proptest",
+ "serde",
  "thiserror 2.0.18",
 ]
 

--- a/binaries/cuprated/Cargo.toml
+++ b/binaries/cuprated/Cargo.toml
@@ -47,7 +47,7 @@ cuprate-rpc-types         = { workspace = true, features = ["from"] }
 cuprate-test-utils        = { workspace = true }
 cuprate-txpool            = { workspace = true }
 cuprate-types             = { workspace = true, features = ["json"] }
-cuprate-wire              = { workspace = true }
+cuprate-wire              = { workspace = true, features = ["serde"] }
 
 # TODO: after v1.0.0, remove unneeded dependencies.
 axum                  = { workspace = true, features = ["tokio", "http1", "http2"] }

--- a/binaries/cuprated/src/args.rs
+++ b/binaries/cuprated/src/args.rs
@@ -1,11 +1,35 @@
-use std::{io::Write, net::SocketAddr, path::PathBuf, process::exit};
+use std::{io::Write, net::SocketAddr, path::PathBuf, process::exit, str::FromStr};
 
 use clap::builder::TypedValueParser;
 use serde_json::Value;
 
 use cuprate_helper::network::Network;
+use cuprate_wire::OnionAddr;
 
 use cuprated::{config::Config, version::CupratedVersionInfo};
+
+#[derive(Debug, Clone)]
+pub(crate) enum SeedNodeArg {
+    Clear(SocketAddr),
+    Tor(OnionAddr),
+}
+
+impl FromStr for SeedNodeArg {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if let Ok(addr) = s.parse::<SocketAddr>() {
+            Ok(Self::Clear(addr))
+        } else if let Ok(addr) = s.parse::<OnionAddr>() {
+            Ok(Self::Tor(addr))
+        } else {
+            Err(format!(
+                "'{s}' is not a valid seed node address; expected either \
+                     an \"ip:port\" or \"<56-character onion domain>.onion:port\" address"
+            ))
+        }
+    }
+}
 
 /// Cuprate Args.
 #[derive(clap::Parser, Debug)]
@@ -50,10 +74,14 @@ pub struct Args {
     /// An extra seed node to connect to on startup, in addition to the
     /// network's built-in seeds.
     ///
+    /// Accepts either a clearnet "ip:port" address, or a Tor
+    /// "<56-character onion domain>.onion:port" address; the former is added
+    /// to the clearnet seed list, the latter to the Tor seed list.
+    ///
     /// Can be passed multiple times. `FakeChain` has no built-in seeds, so
     /// this is how a regtest or otherwise isolated network is bootstrapped.
-    #[arg(long, value_name = "IP:PORT")]
-    pub seed_node: Vec<SocketAddr>,
+    #[arg(long, value_name = "IP:PORT|ONION:PORT")]
+    pub seed_node: Vec<SeedNodeArg>,
 
     /// The PATH of the `cuprated` config file.
     #[arg(long)]
@@ -121,11 +149,12 @@ impl Args {
             config.p2p.clear_net.outbound_connections = outbound_connections;
         }
 
-        config
-            .p2p
-            .clear_net
-            .seed_nodes
-            .extend_from_slice(&self.seed_node);
+        for seed_node in &self.seed_node {
+            match seed_node {
+                SeedNodeArg::Clear(addr) => config.p2p.clear_net.seed_nodes.push(*addr),
+                SeedNodeArg::Tor(addr) => config.p2p.tor_net.seed_nodes.push(*addr),
+            }
+        }
 
         config
     }

--- a/binaries/cuprated/src/config.rs
+++ b/binaries/cuprated/src/config.rs
@@ -329,7 +329,11 @@ impl Config {
 
         cuprate_p2p::P2PConfig {
             network: self.network,
-            seeds: p2p::tor_net_seed_nodes(self.network),
+            seeds: {
+                let mut seeds = p2p::tor_net_seed_nodes(self.network);
+                seeds.extend_from_slice(&self.p2p.tor_net.seed_nodes);
+                seeds
+            },
             offline: self.offline,
             outbound_connections: self.p2p.tor_net.outbound_connections,
             extra_outbound_connections: self.p2p.tor_net.extra_outbound_connections,

--- a/binaries/cuprated/src/config/p2p.rs
+++ b/binaries/cuprated/src/config/p2p.rs
@@ -276,6 +276,14 @@ config_struct! {
         /// Valid values | false, true
         /// Examples     | false
         pub inbound_onion: bool,
+
+        #[comment_out = true]
+        /// Extra Tor seed nodes to connect to on startup, in addition to the
+        /// built-in seeds. Given as onion addresses.
+        ///
+        /// Type     | Array of onion addresses
+        /// Examples | "zbjkbsxc5munw3qusl7j2hpcmikhqocdf4pqhnhtpzw5nt5jrmofptid.onion:18083"
+        pub seed_nodes: Vec<OnionAddr>,
     }
 }
 
@@ -335,6 +343,7 @@ impl Default for TorNetConfig {
         Self {
             enabled: false,
             inbound_onion: false,
+            seed_nodes: Vec::new(),
             p2p_port: DefaultOrCustom::Default,
             outbound_connections: 12,
             extra_outbound_connections: 2,

--- a/net/wire/Cargo.toml
+++ b/net/wire/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/SyntheticBird45/cuprate/tree/main/net/monero-wi
 [features]
 default = []
 tracing = ["cuprate-levin/tracing"]
+serde = ["dep:serde"]
 
 [dependencies]
 cuprate-levin           = { workspace = true }
@@ -23,6 +24,7 @@ bytes                   = { workspace = true, features = ["std"] }
 thiserror               = { workspace = true }
 
 arbitrary = { workspace = true, features = ["derive"], optional = true }
+serde     = { workspace = true, features = ["alloc"], optional = true }
 
 [dev-dependencies]
 hex                     = { workspace = true, features = ["std"]}

--- a/net/wire/src/network_address/onion_addr.rs
+++ b/net/wire/src/network_address/onion_addr.rs
@@ -161,6 +161,27 @@ impl From<OnionAddr> for NetworkAddress {
     }
 }
 
+#[cfg(feature = "serde")]
+impl serde::Serialize for OnionAddr {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.collect_str(self)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for OnionAddr {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = <String as serde::Deserialize>::deserialize(deserializer)?;
+        s.parse().map_err(serde::de::Error::custom)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use proptest::{collection::vec, prelude::*};


### PR DESCRIPTION
### What

Allows `.onion` addresses to be specified as seed nodes, both in the `--seed_node` command-line argument, and in the config file.

### Why

This would be useful to have as an option.

### Where

`cuprated`, `net/wire/`

### How

Implements some `serde` traits for onion addresses, then adds them to the config code.