### PR TITLE
RPC: Stream timeout (hardening pt.1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1544,6 +1544,8 @@ dependencies = [
  "futures",
  "hex",
  "hex-literal 1.1.0",
+ "hyper",
+ "hyper-util",
  "indexmap 2.14.0",
  "mimalloc",
  "monero-address",
@@ -1551,6 +1553,7 @@ dependencies = [
  "nu-ansi-term",
  "paste",
  "pin-project",
+ "pin-project-lite",
  "pretty_assertions",
  "rand 0.8.7",
  "rand_distr",
@@ -2670,9 +2673,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -5188,7 +5191,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -6648,6 +6651,7 @@ dependencies = [
  "http-body-util",
  "percent-encoding",
  "pin-project-lite",
+ "tokio",
  "tower-layer",
  "tower-service",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -182,6 +182,8 @@ fjall                 = { version = "3.1.7", default-features = false }
 futures               = { version = "0.3", default-features = false }
 hex                   = { version = "0.4", default-features = false }
 hex-literal           = { version = "1", default-features = false }
+hyper                 = { version = "1.11.0", default-features = false }
+hyper-util            = { version = "0.1.20", default-features = false }
 indexmap              = { version = "2", default-features = false }
 mimalloc              = { version = "0.1", default-features = false }
 monero-address        = { git = "https://github.com/monero-oxide/monero-oxide.git", rev = "946ec5f", default-features = false }
@@ -189,6 +191,7 @@ monero-oxide          = { git = "https://github.com/monero-oxide/monero-oxide.gi
 nu-ansi-term          = { version = "0.50", default-features = false }
 paste                 = { version = "1", default-features = false }
 pin-project           = { version = "1", default-features = false }
+pin-project-lite      = { version = "0.2.17", default-features = false }
 randomx-rs            = { git = "https://github.com/Cuprate/randomx-rs.git", rev = "76c2385", default-features = false }
 rand                  = { version = "0.8", default-features = false }
 rand_distr            = { version = "0.4", default-features = false }

--- a/binaries/cuprated/Cargo.toml
+++ b/binaries/cuprated/Cargo.toml
@@ -50,7 +50,7 @@ cuprate-types             = { workspace = true, features = ["json"] }
 cuprate-wire              = { workspace = true, features = ["serde"] }
 
 # TODO: after v1.0.0, remove unneeded dependencies.
-axum                  = { workspace = true, features = ["tokio", "http1", "http2"] }
+axum                  = { workspace = true, features = ["tokio", "http1"] }
 anyhow                = { workspace = true }
 arti-client           = { workspace = true, features = ["tokio", "rustls", "onion-service-client", "onion-service-service", "static"], optional = true }
 async-trait           = { workspace = true }
@@ -71,6 +71,8 @@ fjall                 = { workspace = true }
 futures               = { workspace = true }
 hex                   = { workspace = true }
 hex-literal           = { workspace = true }
+hyper                 = { workspace = true }
+hyper-util            = { workspace = true }
 indexmap              = { workspace = true }
 mimalloc              = { workspace = true, optional = true }
 monero-address        = { workspace = true }
@@ -78,6 +80,7 @@ monero-oxide          = { workspace = true, features = ["std", "compile-time-gen
 nu-ansi-term          = { workspace = true }
 paste                 = { workspace = true }
 pin-project           = { workspace = true }
+pin-project-lite      = { workspace = true }
 randomx-rs            = { workspace = true }
 rand                  = { workspace = true }
 rand_distr            = { workspace = true }
@@ -99,7 +102,7 @@ tor-hsservice         = { workspace = true, optional = true }
 tor-persist           = { workspace = true, optional = true }
 tor-rtcompat          = { workspace = true, optional = true }
 tower                 = { workspace = true, features = ["limit"] }
-tower-http            = { workspace = true, features = ["limit", "trace"] }
+tower-http            = { workspace = true, features = ["limit", "timeout", "trace"] }
 tracing-appender      = { workspace = true }
 tracing-subscriber    = { workspace = true, features = ["std", "fmt", "default"] }
 tracing               = { workspace = true, features = ["default"] }
@@ -118,4 +121,3 @@ serde_json  = { workspace = true, features = ["std"] }
 
 [lints]
 workspace = true
-

--- a/binaries/cuprated/src/config/rpc.rs
+++ b/binaries/cuprated/src/config/rpc.rs
@@ -58,6 +58,28 @@ config_struct! {
         /// Examples     | 0 (no limit), 5242880 (5MB), 10485760 (10MB)
         pub request_byte_limit: usize,
 
+        /// The time period during which the node can try sending data.
+        /// If a send operation do not complete within this Duration,
+        /// the connection is dropped.
+        ///
+        /// Type     | Duration
+        /// Examples | { secs = 10, nanos = 0 }, { secs = 29, nanos = 123 }
+        pub send_timeout: Duration,
+
+        /// The maximum time allowed to receive an HTTP/1 request header.
+        /// Receiving progress does not restart this deadline.
+        ///
+        /// Type     | Duration
+        /// Examples | { secs = 10, nanos = 0 }, { secs = 29, nanos = 123 }
+        pub header_read_timeout: Duration,
+
+        /// The maximum wall-clock time allowed to consume an HTTP request body.
+        /// Receiving progress does not restart this deadline.
+        ///
+        /// Type     | Duration
+        /// Examples | { secs = 10, nanos = 0 }, { secs = 29, nanos = 123 }
+        pub body_read_timeout: Duration,
+
         // TODO: <https://github.com/Cuprate/cuprate/issues/445>
     }
 
@@ -101,6 +123,9 @@ impl Default for UnrestrictedRpcConfig {
             port: DefaultOrCustom::Default,
             enable: true,
             request_byte_limit: 0,
+            send_timeout: Duration::from_secs(5),
+            header_read_timeout: Duration::from_secs(30),
+            body_read_timeout: Duration::from_secs(5),
         }
     }
 }
@@ -115,6 +140,9 @@ impl Default for RestrictedRpcConfig {
             // 1 megabyte.
             // <https://github.com/monero-project/monero/blob/3b01c490953fe92f3c6628fa31d280a4f0490d28/src/cryptonote_config.h#L134>
             request_byte_limit: 1024 * 1024,
+            send_timeout: Duration::from_secs(5),
+            header_read_timeout: Duration::from_secs(30),
+            body_read_timeout: Duration::from_secs(5),
         }
     }
 }

--- a/binaries/cuprated/src/rpc.rs
+++ b/binaries/cuprated/src/rpc.rs
@@ -7,6 +7,7 @@ mod handlers;
 mod rpc_handler;
 mod server;
 mod service;
+mod timeout;
 
 pub use rpc_handler::CupratedRpcHandler;
 pub use server::init_rpc_servers;

--- a/binaries/cuprated/src/rpc/server.rs
+++ b/binaries/cuprated/src/rpc/server.rs
@@ -1,25 +1,47 @@
 //! RPC server initialization and main loop.
 
 use std::{
+    cell::{Cell, UnsafeCell},
+    collections::HashMap,
     net::{IpAddr, SocketAddr},
+    num::NonZeroUsize,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
     time::Duration,
 };
 
 use anyhow::Error;
-use tokio::net::TcpListener;
-use tokio_util::sync::CancellationToken;
-use tower::limit::rate::RateLimitLayer;
-use tower_http::limit::RequestBodyLimitLayer;
-use tracing::{info, warn};
+use axum::Router;
+use hyper::{body::Incoming, server::conn::http1, Request};
+use hyper_util::{
+    rt::{TokioExecutor, TokioIo, TokioTimer},
+    service::TowerToHyperService,
+};
+use tokio::{
+    net::{TcpListener, TcpStream},
+    task::JoinSet,
+    time::timeout,
+};
+use tokio_util::{sync::CancellationToken, time::FutureExt};
+use tower::{limit::rate::RateLimitLayer, Service};
+use tower_http::{limit::RequestBodyLimitLayer, timeout::RequestBodyDeadlineLayer};
+use tracing::{debug, error, info, warn};
 
+use cuprate_helper::net::ip_is_local;
 use cuprate_rpc_interface::RouterBuilder;
 
 use crate::{
-    config::{restricted_rpc_port, unrestricted_rpc_port},
-    rpc::CupratedRpcHandler,
+    config::{restricted_rpc_port, unrestricted_rpc_port, RpcConfig},
+    rpc::{timeout::WriteTimeout, CupratedRpcHandler},
     txpool::IncomingTxHandler,
     LaunchContext,
 };
+
+/// The maximum amount of time we wait for connections to gracefully close
+/// after shutdown signal.
+const RPC_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Initialize the RPC server(s).
 ///
@@ -55,7 +77,7 @@ pub fn init_rpc_servers(launch_ctx: &LaunchContext, tx_handler: IncomingTxHandle
             continue;
         }
 
-        if !restricted && !cuprate_helper::net::ip_is_local(addr) {
+        if !restricted && !ip_is_local(addr) {
             if config
                 .unrestricted
                 .i_know_what_im_doing_allow_public_unrestricted_rpc
@@ -69,41 +91,59 @@ pub fn init_rpc_servers(launch_ctx: &LaunchContext, tx_handler: IncomingTxHandle
             }
         }
 
+        let (rpc_send_timeout, rpc_header_read_timeout, rpc_body_read_timeout) = if restricted {
+            (
+                config.restricted.send_timeout,
+                config.restricted.header_read_timeout,
+                config.restricted.body_read_timeout,
+            )
+        } else {
+            (
+                config.unrestricted.send_timeout,
+                config.unrestricted.header_read_timeout,
+                config.unrestricted.body_read_timeout,
+            )
+        };
+
+        // Initialize RPC handler service.
         let rpc_handler = CupratedRpcHandler::new(restricted, tx_handler.clone(), launch_ctx);
 
+        // Initialize Axum RPC router.
+        let rpc_router = init_rpc_router(rpc_handler, request_byte_limit, rpc_body_read_timeout);
+
+        // Build the RPC server.
+        let rpc_server = RpcServer::new(
+            SocketAddr::new(addr, port),
+            rpc_send_timeout,
+            rpc_header_read_timeout,
+            rpc_router,
+        );
+
+        info!(
+            restricted,
+            address = %addr,
+            "Starting RPC server"
+        );
+
+        // Launch RPC server.
         let shutdown_token = launch_ctx.task_executor.cancellation_token();
         launch_ctx.task_executor.spawn(async move {
-            run_rpc_server(
-                rpc_handler,
-                restricted,
-                SocketAddr::new(addr, port),
-                request_byte_limit,
-                shutdown_token,
-            )
-            .await
-            .unwrap();
+            if let Err(e) = rpc_server.run(shutdown_token).await {
+                error!(restricted, "RPC server error: {e:#}");
+            }
+
             info!(restricted, "RPC server shut down.");
         });
     }
 }
 
-/// This initializes and runs an RPC server.
-///
-/// The function will only return when the server itself returns or an error occurs.
-async fn run_rpc_server(
+/// Initialize the Axum router of the RPC server.
+fn init_rpc_router(
     rpc_handler: CupratedRpcHandler,
-    restricted: bool,
-    address: SocketAddr,
     request_byte_limit: usize,
-    shutdown_token: CancellationToken,
-) -> Result<(), Error> {
-    info!(
-        restricted,
-        address = %address,
-        "Starting RPC server"
-    );
-
-    let router = RouterBuilder::new()
+    body_read_timeout: Duration,
+) -> Router {
+    let mut router = RouterBuilder::new()
         .json_rpc()
         //
         .other_get_info()
@@ -136,21 +176,129 @@ async fn run_rpc_server(
     // Add restrictive layers if restricted RPC.
     //
     // TODO: <https://github.com/Cuprate/cuprate/issues/445>
-    let router = if request_byte_limit != 0 {
-        router.layer(RequestBodyLimitLayer::new(request_byte_limit))
-    } else {
-        router
-    };
+    if request_byte_limit != 0 {
+        router = router.layer(RequestBodyLimitLayer::new(request_byte_limit));
+    }
 
-    let router = router.layer(tower_http::trace::TraceLayer::new_for_http());
+    router
+        .layer(RequestBodyDeadlineLayer::new(body_read_timeout))
+        .layer(tower_http::trace::TraceLayer::new_for_http())
+}
 
-    // Start the server.
-    //
-    // TODO: impl custom server code, don't use axum.
-    let listener = TcpListener::bind(address).await?;
-    axum::serve(listener, router)
-        .with_graceful_shutdown(shutdown_token.cancelled_owned())
-        .await?;
+/// An RPC server capable of listening to new connections and serving RPC requests.
+struct RpcServer {
+    /// The RPC Axum router.
+    rpc: Router,
+    listening_address: SocketAddr,
+    // Socket timeouts
+    send_timeout: Duration,
+    header_read_timeout: Duration,
+    rpc_tasks: JoinSet<SocketAddr>,
+}
 
-    Ok(())
+impl RpcServer {
+    /// Build a new RPC server.
+    fn new(
+        listening_address: SocketAddr,
+        send_timeout: Duration,
+        header_read_timeout: Duration,
+        rpc: Router,
+    ) -> Self {
+        Self {
+            rpc,
+            listening_address,
+            send_timeout,
+            header_read_timeout,
+            rpc_tasks: JoinSet::new(),
+        }
+    }
+
+    /// Consume this server and start serving to incoming connections.
+    /// This method only returns errors is unable to listen on its address:port.
+    async fn run(mut self, shutdown_token: CancellationToken) -> Result<(), Error> {
+        // Start the listener.
+        let listener = TcpListener::bind(self.listening_address).await?;
+
+        loop {
+            tokio::select! {
+                res = listener.accept() => {
+                    let (socket, remote_addr) = match res {
+                        Ok(res) => res,
+                        Err(e) => {
+                            // A failed accept can be caused by reaching resource limits.
+                            // We should not attempt to accept a new connection immediately.
+                            warn!("Failed to accept RPC connection: {e}");
+                            tokio::time::sleep(Duration::from_millis(40)).await;
+                            continue
+                        }
+                    };
+
+                    self.serve(socket, remote_addr, shutdown_token.clone());
+                },
+                Some(Err(err)) = self.rpc_tasks.join_next() => {
+                    debug!("RPC serving task failed: {err:#}");
+                }
+                () = shutdown_token.cancelled() => {
+                    break;
+                }
+            }
+        }
+
+        // Graceful shutdown of all connections for up to 5 seconds.
+        if timeout(RPC_SHUTDOWN_TIMEOUT, async move {
+            while let Some(res) = self.rpc_tasks.join_next().await {
+                if let Err(err) = res {
+                    warn!("RPC serving task failed: {err:#}");
+                }
+            }
+        })
+        .await
+        .is_err()
+        {
+            warn!("RPC tasks survived shutdown signal for more than {} seconds... Dropping connections anyway.", RPC_SHUTDOWN_TIMEOUT.as_secs());
+        }
+
+        Ok(())
+    }
+
+    fn serve(
+        &mut self,
+        socket: TcpStream,
+        remote_addr: SocketAddr,
+        shutdown_token: CancellationToken,
+    ) {
+        let rpc = self.rpc.clone();
+        let send_timeout = self.send_timeout;
+        let header_read_timeout = self.header_read_timeout;
+
+        self.rpc_tasks.spawn(async move {
+            let socket = WriteTimeout::new(socket, send_timeout);
+
+            let mut builder = http1::Builder::new();
+            builder
+                .timer(TokioTimer::new())
+                .header_read_timeout(header_read_timeout);
+
+            let connection =
+                builder.serve_connection(TokioIo::new(socket), TowerToHyperService::new(rpc));
+            tokio::pin!(connection);
+
+            tokio::select! {
+                result = &mut connection => {
+                    if let Err(err) = result {
+                        debug!("Failed to serve RPC connection: {err:#}");
+                    }
+                }
+                () = shutdown_token.cancelled() => {
+                    connection.as_mut().graceful_shutdown();
+
+                    if let Err(err) = connection.await {
+                        debug!("Failed to shut down RPC connection: {err:#}");
+                    }
+                }
+            }
+
+            remote_addr
+        });
+    }
 }

--- a/binaries/cuprated/src/rpc/timeout.rs
+++ b/binaries/cuprated/src/rpc/timeout.rs
@@ -1,0 +1,310 @@
+//! IO Timeout Wrapper
+//!
+//! This module implements a wrapper around [`AsyncRead`]/[`AsyncWrite`] types to return a
+//! `TimedOut` error when a write does not complete after a period of time. Reads are passed through.
+//!
+//! This is used as a denial of service mitigation mechanism against connections that read slowly.
+//!
+use std::{
+    future::Future,
+    io::{Error, ErrorKind},
+    pin::Pin,
+    task::{Context, Poll},
+    time::Duration,
+};
+
+use pin_project_lite::pin_project;
+use tokio::{
+    io::{AsyncRead, AsyncWrite},
+    time::{sleep_until, Instant, Sleep},
+};
+
+/// A pinned timeout state with a specified duration.
+pub struct TimeoutState {
+    timeout: Duration,
+    refresh: bool,
+    sleep: Pin<Box<Sleep>>,
+}
+
+impl TimeoutState
+where
+    Self: Unpin,
+{
+    /// Create a new [`TimeoutState`] with the given timeout type.
+    pub fn new(timeout: Duration) -> Self {
+        Self {
+            timeout,
+            refresh: true,
+            sleep: Box::pin(sleep_until(Instant::now())),
+        }
+    }
+
+    /// Poll inner [`Sleep`] for completion. Update its deadline on first use and return
+    /// `Poll::Ready(Error::from(ErrorKind::TimedOut))` on completion, `Poll::Pending` otherwise
+    pub fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Error> {
+        let mut proj = self;
+
+        // On first poll after refresh activate couldown.
+        if proj.refresh {
+            proj.refresh = false;
+            let timeout = proj.timeout;
+            proj.sleep.as_mut().reset(Instant::now() + timeout);
+        }
+
+        proj.sleep
+            .as_mut()
+            .poll(cx)
+            .map(|()| Error::from(ErrorKind::TimedOut))
+    }
+}
+
+// Helper macros for reducing redundancy. This main logic is present in every poll.
+macro_rules! poll_or_timeout {
+    ($self:ident::$io:ident..$timeout:ident => $poll:ident, $cx:ident, $arg:expr, $len:expr) => {{
+        let proj = $self.project();
+        let len = $len;
+
+        if len == 0 {
+            proj.$io.$poll($cx, $arg)
+        } else if let Poll::Ready(error) = proj.$timeout.as_mut().poll($cx) {
+            Poll::Ready(Err(error))
+        } else {
+            match proj.$io.$poll($cx, $arg) {
+                Poll::Ready(Ok(written)) => {
+                    if written == len {
+                        proj.$timeout.refresh = true;
+                    }
+                    Poll::Ready(Ok(written))
+                }
+                Poll::Ready(Err(error)) => {
+                    proj.$timeout.refresh = true;
+                    Poll::Ready(Err(error))
+                }
+                Poll::Pending => Poll::Pending,
+            }
+        }
+    }};
+    ($self:ident::$io:ident..$timeout:ident => $poll:ident, $cx:ident) => {{
+        let proj = $self.project();
+
+        match proj.$io.$poll($cx) {
+            Poll::Pending => proj.$timeout.as_mut().poll($cx).map(Err),
+            Poll::Ready(r) => {
+                proj.$timeout.refresh = true;
+                Poll::Ready(r)
+            }
+        }
+    }};
+}
+
+pin_project! {
+    /// A write timeout wrapper around an [`AsyncRead`] + [`AsyncWrite`] implemented type.
+    ///
+    /// Returns a `TimedOut` error unless a call to `poll_write` accepts the complete supplied
+    /// buffer within the timeout duration.
+    pub struct WriteTimeout<S> {
+        #[pin]
+        stream: S,
+        write_timeout: Pin<Box<TimeoutState>>,
+    }
+}
+
+impl<S: AsyncWrite + AsyncRead> WriteTimeout<S> {
+    /// Create a new [`WriteTimeout`] with the given write timeout.
+    pub fn new(stream: S, write_timeout: Duration) -> Self {
+        Self {
+            stream,
+            write_timeout: Box::pin(TimeoutState::new(write_timeout)),
+        }
+    }
+}
+
+impl<S: AsyncWrite + AsyncRead> AsyncWrite for WriteTimeout<S> {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<Result<usize, Error>> {
+        poll_or_timeout!(self::stream..write_timeout => poll_write, cx, buf, buf.len())
+    }
+
+    fn poll_write_vectored(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[std::io::IoSlice<'_>],
+    ) -> Poll<Result<usize, Error>> {
+        let buf_len: usize = buf.iter().map(|buf| buf.len()).sum();
+        poll_or_timeout!(self::stream..write_timeout => poll_write_vectored, cx, buf, buf_len)
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Error>> {
+        poll_or_timeout!(self::stream..write_timeout => poll_flush, cx)
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Error>> {
+        poll_or_timeout!(self::stream..write_timeout => poll_shutdown, cx)
+    }
+
+    fn is_write_vectored(&self) -> bool {
+        self.stream.is_write_vectored()
+    }
+}
+
+impl<S: AsyncRead + AsyncWrite> AsyncRead for WriteTimeout<S> {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        self.project().stream.poll_read(cx, buf)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::{
+        future::Future,
+        io::ErrorKind,
+        net::{IpAddr, Ipv4Addr, SocketAddr},
+        time::Duration,
+    };
+
+    use tokio::{
+        io::{duplex, AsyncReadExt, AsyncWriteExt},
+        net::{TcpListener, TcpStream},
+        select,
+        task::JoinSet,
+        time::{sleep, timeout},
+    };
+
+    use crate::rpc::timeout::WriteTimeout;
+
+    #[cfg(target_os = "macos")]
+    const TEST_TIMEOUT: Duration = Duration::from_secs(2);
+    #[cfg(not(target_os = "macos"))]
+    const TEST_TIMEOUT: Duration = Duration::from_secs(10);
+
+    fn within_current_thread_runtime(future: impl Future) {
+        // Start tokio runtime
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(4)
+            .enable_all()
+            .build()
+            .unwrap();
+
+        runtime.block_on(future);
+    }
+
+    // Common setup used between TCP tests.
+    async fn spawn_tcp_setup<C, L, R1, R2>(port: u16, client_test: C, listener_test: L)
+    where
+        R1: Future<Output = ()> + Send + 'static,
+        R2: Future<Output = ()> + Send + 'static,
+        C: Fn(TcpStream) -> R1 + Send + 'static,
+        L: Fn(TcpStream) -> R2 + Send + 'static,
+    {
+        let socketaddr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port);
+
+        let listener = TcpListener::bind(socketaddr)
+            .await
+            .expect("Unable to bind TCP Listener");
+
+        let mut set = JoinSet::new();
+
+        // Spawn Listener
+        set.spawn(async move {
+            let connection = listener
+                .accept()
+                .await
+                .expect("Unable to accept incoming connection");
+
+            listener_test(connection.0).await;
+        });
+
+        // Spawn client
+        set.spawn(async move {
+            let Ok(stream) = timeout(TEST_TIMEOUT, TcpStream::connect(socketaddr))
+                .await
+                .expect("Unable to connect listener")
+            else {
+                panic!("No connection has been made to the listener!");
+            };
+
+            client_test(stream).await;
+        });
+
+        set.join_all().await;
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[test]
+    fn tcp_stream_write_timeout_err() {
+        within_current_thread_runtime(spawn_tcp_setup(
+            60036,
+            async |_stream: TcpStream| {
+                sleep(TEST_TIMEOUT + Duration::from_secs(1)).await;
+            },
+            async |stream: TcpStream| {
+                // Wrap stream into StreamTimeout
+                let mut stream = WriteTimeout::new(stream, TEST_TIMEOUT);
+
+                // Try to write
+                let buf = vec![1_u8; 64 * 1024_usize.pow(2)]; // 16MiB
+                select! {
+                    r = stream.write_all(&buf) => {
+                        if let Err(err) = r {
+                            assert_eq!(err.kind(), ErrorKind::TimedOut);
+                        } else {
+                            panic!("Buffer have been successfully flushed. This test needs to updated.")
+                        }
+                    }
+                    () = sleep(TEST_TIMEOUT * 2) => {
+                        panic!("No error has been returned after <timeout duration>+1 seconds.")
+                    }
+                }
+            },
+        ));
+    }
+
+    #[test]
+    fn partial_write_progress_does_not_restart_timeout() {
+        within_current_thread_runtime(async {
+            const WRITE_TIMEOUT: Duration = Duration::from_millis(150);
+
+            let (mut peer, stream) = duplex(64);
+            let mut stream = WriteTimeout::new(stream, WRITE_TIMEOUT);
+
+            let reader = tokio::spawn(async move {
+                let mut byte = [0];
+                loop {
+                    if peer.read_exact(&mut byte).await.is_err() {
+                        break;
+                    }
+                    sleep(Duration::from_millis(40)).await;
+                }
+            });
+
+            let error = timeout(Duration::from_secs(2), stream.write_all(&vec![1; 1024]))
+                .await
+                .expect("write timeout did not fire")
+                .expect_err("slow write unexpectedly completed");
+
+            reader.abort();
+            assert_eq!(error.kind(), ErrorKind::TimedOut);
+        });
+    }
+
+    #[test]
+    fn complete_write_resets_timeout() {
+        within_current_thread_runtime(async {
+            const WRITE_TIMEOUT: Duration = Duration::from_millis(150);
+
+            let (_peer, stream) = duplex(64);
+            let mut stream = WriteTimeout::new(stream, WRITE_TIMEOUT);
+
+            stream.write_all(&[1]).await.unwrap();
+            sleep(WRITE_TIMEOUT * 2).await;
+            stream.write_all(&[2]).await.unwrap();
+        });
+    }
+}


### PR DESCRIPTION
> [!NOTE]
> This PR has been split. Some of the reviews reference code that has been removed from the branch.

# What

This PR replace the `axum::serve` usage in `cuprated` by a custom hyper serving loop under an `RpcServer` struct. By doing so we can wrap connection's `TcpStream` into a timeount wrapper struct called `WriteTimeout`. This allows us to kick connections to which we cannot send bytes after a configurable amount of time.

This PR also introduce a header read and body read timeout. The first will abort the connection. The latter will first respond with a `400 Bad Request` response and then abort the connection.

This is an important mitigation against inactive/keep-alive/unidirectional spamming connections.