### PR TITLE
RPC: Block endpoints semaphore access (hardening pt.4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1544,6 +1544,8 @@ dependencies = [
  "futures",
  "hex",
  "hex-literal 1.1.0",
+ "hyper",
+ "hyper-util",
  "indexmap 2.14.0",
  "mimalloc",
  "monero-address",
@@ -1551,6 +1553,7 @@ dependencies = [
  "nu-ansi-term",
  "paste",
  "pin-project",
+ "pin-project-lite",
  "pretty_assertions",
  "rand 0.8.7",
  "rand_distr",
@@ -2670,9 +2673,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -5188,7 +5191,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -182,6 +182,8 @@ fjall                 = { version = "3.1.7", default-features = false }
 futures               = { version = "0.3", default-features = false }
 hex                   = { version = "0.4", default-features = false }
 hex-literal           = { version = "1", default-features = false }
+hyper                 = { version = "1.11.0", default-features = false }
+hyper-util            = { version = "0.1.20", default-features = false }
 indexmap              = { version = "2", default-features = false }
 mimalloc              = { version = "0.1", default-features = false }
 monero-address        = { git = "https://github.com/monero-oxide/monero-oxide.git", rev = "946ec5f", default-features = false }
@@ -189,6 +191,7 @@ monero-oxide          = { git = "https://github.com/monero-oxide/monero-oxide.gi
 nu-ansi-term          = { version = "0.50", default-features = false }
 paste                 = { version = "1", default-features = false }
 pin-project           = { version = "1", default-features = false }
+pin-project-lite      = { version = "0.2.17", default-features = false }
 randomx-rs            = { git = "https://github.com/Cuprate/randomx-rs.git", rev = "76c2385", default-features = false }
 rand                  = { version = "0.8", default-features = false }
 rand_distr            = { version = "0.4", default-features = false }

--- a/binaries/cuprated/Cargo.toml
+++ b/binaries/cuprated/Cargo.toml
@@ -50,7 +50,7 @@ cuprate-types             = { workspace = true, features = ["json"] }
 cuprate-wire              = { workspace = true, features = ["serde"] }
 
 # TODO: after v1.0.0, remove unneeded dependencies.
-axum                  = { workspace = true, features = ["tokio", "http1", "http2"] }
+axum                  = { workspace = true, features = ["tokio", "http1", "http2", "matched-path"] }
 anyhow                = { workspace = true }
 arti-client           = { workspace = true, features = ["tokio", "rustls", "onion-service-client", "onion-service-service", "static"], optional = true }
 async-trait           = { workspace = true }

--- a/binaries/cuprated/Cargo.toml
+++ b/binaries/cuprated/Cargo.toml
@@ -71,6 +71,8 @@ fjall                 = { workspace = true }
 futures               = { workspace = true }
 hex                   = { workspace = true }
 hex-literal           = { workspace = true }
+hyper                 = { workspace = true }
+hyper-util            = { workspace = true, features = ["server-auto"] }
 indexmap              = { workspace = true }
 mimalloc              = { workspace = true, optional = true }
 monero-address        = { workspace = true }
@@ -78,6 +80,7 @@ monero-oxide          = { workspace = true, features = ["std", "compile-time-gen
 nu-ansi-term          = { workspace = true }
 paste                 = { workspace = true }
 pin-project           = { workspace = true }
+pin-project-lite      = { workspace = true }
 randomx-rs            = { workspace = true }
 rand                  = { workspace = true }
 rand_distr            = { workspace = true }
@@ -118,4 +121,3 @@ serde_json  = { workspace = true, features = ["std"] }
 
 [lints]
 workspace = true
-

--- a/binaries/cuprated/src/config/rpc.rs
+++ b/binaries/cuprated/src/config/rpc.rs
@@ -109,6 +109,54 @@ config_struct! {
         /// Examples | "", "127.0.0.1", "192.168.1.50"
         pub excluded_ips_connection_limit: Vec<IpAddr>,
 
+        #[comment_out = true]
+        /// The maximum size budget of a single IP address, in bytes.
+        ///
+        /// Every IP address has a size budget, the size of each
+        /// response it receives is subtracted from it, and it is
+        /// refilled by `income_size` every second. Requests received
+        /// while this budget is exhausted are rejected with
+        /// `429 Too Many Requests`.
+        ///
+        /// Type         | Number (bytes)
+        /// Valid values | >= 0 (0 rejects all requests)
+        /// Examples     | 536870912 (512MiB), 1073741824 (1GiB)
+        pub max_budget_size: u64,
+
+        #[comment_out = true]
+        /// The amount of bytes per second refilled to the size
+        /// budget of every IP address, capped at `max_budget_size`.
+        ///
+        /// Type         | Number (bytes per second)
+        /// Valid values | >= 0 (0 means no restriction)
+        /// Examples     | 33554432 (32MiB/s), 67108864 (64MiB/s)
+        pub income_size: u64,
+
+        #[comment_out = true]
+        /// The maximum processing time budget of a single IP address,
+        /// in milliseconds.
+        ///
+        /// Every IP address has a processing time budget: the processing
+        /// time of each of its requests is subtracted from it, and it is
+        /// refilled by `income_time` every second. Requests received
+        /// while this budget is exhausted are rejected with
+        /// `429 Too Many Requests`.
+        ///
+        /// Type         | Number (milliseconds)
+        /// Valid values | >= 0 (0 means no restrictions)
+        /// Examples     | 30000 (30s), 60000 (1m)
+        pub max_budget_time: u64,
+
+        #[comment_out = true]
+        /// The amount of milliseconds of processing time refilled per sec
+        /// to the processing time budget of every IP address, capped
+        /// at `max_budget_time`.
+        ///
+        /// Type         | Number (milliseconds per second)
+        /// Valid values | >= 0
+        /// Examples     | 250, 500
+        pub income_time: u64,
+
         /// The time period during which the node can try sending data.
         /// If a send operation do not complete within this Duration,
         /// the connection is dropped.
@@ -173,6 +221,10 @@ impl Default for UnrestrictedRpcConfig {
             loopback_connection_limit: 0,
             total_connection_limit: 0,
             excluded_ips_connection_limit: Vec::new(),
+            max_budget_size: i64::MAX as u64,
+            income_size: i64::MAX as u64,
+            max_budget_time: i64::MAX as u64,
+            income_time: i64::MAX as u64,
             send_timeout: Duration::from_secs(5),
             read_timeout: Duration::from_secs(30),
         }
@@ -194,6 +246,10 @@ impl Default for RestrictedRpcConfig {
             loopback_connection_limit: 50,
             total_connection_limit: 100,
             excluded_ips_connection_limit: Vec::new(),
+            max_budget_size: 512 * 1024 * 1024,
+            income_size: 32 * 1024 * 1024,
+            max_budget_time: 30_000,
+            income_time: 250,
             send_timeout: Duration::from_secs(5),
             read_timeout: Duration::from_secs(30),
         }

--- a/binaries/cuprated/src/config/rpc.rs
+++ b/binaries/cuprated/src/config/rpc.rs
@@ -58,6 +58,22 @@ config_struct! {
         /// Examples     | 0 (no limit), 5242880 (5MB), 10485760 (10MB)
         pub request_byte_limit: usize,
 
+        /// The time period during which the node can try sending data.
+        /// If a send operation do not complete within this Duration,
+        /// the connection is dropped.
+        ///
+        /// Type     | Duration
+        /// Examples | { secs = 10, nanos = 0 }, { secs = 29, nano = 123 }
+        pub send_timeout: Duration,
+
+        /// The time period during which the node wait receiving data.
+        /// If a receive operation do not complete within this Duration,
+        /// the connection is dropped.
+        ///
+        /// Type     | Duration
+        /// Examples | { secs = 10, nanos = 0 }, { secs = 29, nano = 123 }
+        pub read_timeout: Duration,
+
         // TODO: <https://github.com/Cuprate/cuprate/issues/445>
     }
 
@@ -101,6 +117,8 @@ impl Default for UnrestrictedRpcConfig {
             port: DefaultOrCustom::Default,
             enable: true,
             request_byte_limit: 0,
+            send_timeout: Duration::from_secs(5),
+            read_timeout: Duration::from_secs(30),
         }
     }
 }
@@ -115,6 +133,8 @@ impl Default for RestrictedRpcConfig {
             // 1 megabyte.
             // <https://github.com/monero-project/monero/blob/3b01c490953fe92f3c6628fa31d280a4f0490d28/src/cryptonote_config.h#L134>
             request_byte_limit: 1024 * 1024,
+            send_timeout: Duration::from_secs(5),
+            read_timeout: Duration::from_secs(30),
         }
     }
 }

--- a/binaries/cuprated/src/config/rpc.rs
+++ b/binaries/cuprated/src/config/rpc.rs
@@ -157,6 +157,32 @@ config_struct! {
         /// Examples     | 250, 500
         pub income_time: u64,
 
+        #[comment_out = true]
+        /// Maximum amount of blocks endpoint requests handled simultaneously.
+        ///
+        /// The blocks endpoints are `/get_blocks.bin`, `/get_blocks_by_height.bin`
+        /// (and their aliases), and `/json_rpc`'s `get_block` method.
+        ///
+        /// Additional requests are put on hold for up to
+        /// `blocks_semaphore_queue_wait` milliseconds before being rejected
+        /// with `503 Service Unavailable` and a `Retry-After` header.
+        ///
+        /// Setting this to `0` will disable the limit.
+        ///
+        /// Type         | Number
+        /// Valid values | >= 0
+        /// Examples     | 0 (no limit), 4, 16
+        pub blocks_semaphore_limit: u64,
+
+        #[comment_out = true]
+        /// The maximum amount of time, in milliseconds, a blocks endpoint
+        /// request is put on hold waiting for a concurrency slot before
+        /// being rejected with `503 Service Unavailable`.
+        ///
+        /// Type     | Duration
+        /// Examples | { secs = 10, nanos = 0 }, { secs = 29, nano = 123 }
+        pub blocks_semaphore_queue_wait: Duration,
+
         /// The time period during which the node can try sending data.
         /// If a send operation do not complete within this Duration,
         /// the connection is dropped.
@@ -225,6 +251,8 @@ impl Default for UnrestrictedRpcConfig {
             income_size: i64::MAX as u64,
             max_budget_time: i64::MAX as u64,
             income_time: i64::MAX as u64,
+            blocks_semaphore_limit: 0,
+            blocks_semaphore_queue_wait: Duration::from_secs(0),
             send_timeout: Duration::from_secs(5),
             read_timeout: Duration::from_secs(30),
         }
@@ -250,6 +278,8 @@ impl Default for RestrictedRpcConfig {
             income_size: 32 * 1024 * 1024,
             max_budget_time: 30_000,
             income_time: 250,
+            blocks_semaphore_limit: 30, // 6GB
+            blocks_semaphore_queue_wait: Duration::from_secs(1),
             send_timeout: Duration::from_secs(5),
             read_timeout: Duration::from_secs(30),
         }

--- a/binaries/cuprated/src/config/rpc.rs
+++ b/binaries/cuprated/src/config/rpc.rs
@@ -58,6 +58,57 @@ config_struct! {
         /// Examples     | 0 (no limit), 5242880 (5MB), 10485760 (10MB)
         pub request_byte_limit: usize,
 
+        #[comment_out = true]
+        /// Maximum amount of RPC connections allowed by a single public IP address.
+        ///
+        /// Setting this to `0` will disable the limit.
+        ///
+        /// Type         | Number
+        /// Valid values | >= 0
+        /// Examples     | 0 (no limit), 2, 4
+        pub public_ip_connection_limit: usize,
+
+        #[comment_out = true]
+        /// Maximum amount of RPC connections allowed by a single private IP address.
+        ///
+        /// Setting this to `0` will disable the limit.
+        ///
+        /// Type         | Number
+        /// Valid values | >= 0
+        /// Examples     | 0 (no limit), 16, 100
+        pub private_ip_connection_limit: usize,
+
+        #[comment_out = true]
+        /// Maximum amount of RPC connections allowed by a loopback address.
+        ///
+        /// Setting this to `0` will disable the limit.
+        ///
+        /// Type         | Number
+        /// Valid values | >= 0
+        /// Examples     | 0 (no limit), 67
+        pub loopback_connection_limit: usize,
+
+        #[comment_out = true]
+        /// Maximum amount of RPC connections allowed globally.
+        ///
+        /// Setting this to `0` will disable the limit.
+        ///
+        /// Type         | Number
+        /// Valid values | >= 0
+        /// Examples     | 0 (no limit), 16, 300
+        pub total_connection_limit: usize,
+
+        #[comment_out = true]
+        /// The list of IP addresses that are excluded from
+        /// all RPC connection limits.
+        ///
+        /// This can be useful if you are using a reverse proxy
+        /// in front of this node.
+        ///
+        /// Type     | IPv4/IPv6 address
+        /// Examples | "", "127.0.0.1", "192.168.1.50"
+        pub excluded_ips_connection_limit: Vec<IpAddr>,
+
         /// The time period during which the node can try sending data.
         /// If a send operation do not complete within this Duration,
         /// the connection is dropped.
@@ -117,6 +168,11 @@ impl Default for UnrestrictedRpcConfig {
             port: DefaultOrCustom::Default,
             enable: true,
             request_byte_limit: 0,
+            public_ip_connection_limit: 0,
+            private_ip_connection_limit: 0,
+            loopback_connection_limit: 0,
+            total_connection_limit: 0,
+            excluded_ips_connection_limit: Vec::new(),
             send_timeout: Duration::from_secs(5),
             read_timeout: Duration::from_secs(30),
         }
@@ -133,6 +189,11 @@ impl Default for RestrictedRpcConfig {
             // 1 megabyte.
             // <https://github.com/monero-project/monero/blob/3b01c490953fe92f3c6628fa31d280a4f0490d28/src/cryptonote_config.h#L134>
             request_byte_limit: 1024 * 1024,
+            public_ip_connection_limit: 3,
+            private_ip_connection_limit: 25,
+            loopback_connection_limit: 50,
+            total_connection_limit: 100,
+            excluded_ips_connection_limit: Vec::new(),
             send_timeout: Duration::from_secs(5),
             read_timeout: Duration::from_secs(30),
         }

--- a/binaries/cuprated/src/rpc.rs
+++ b/binaries/cuprated/src/rpc.rs
@@ -4,6 +4,7 @@
 
 mod constants;
 mod handlers;
+mod ratelimit;
 mod rpc_handler;
 mod server;
 mod service;

--- a/binaries/cuprated/src/rpc.rs
+++ b/binaries/cuprated/src/rpc.rs
@@ -6,6 +6,7 @@ mod constants;
 mod handlers;
 mod ratelimit;
 mod rpc_handler;
+mod semaphore;
 mod server;
 mod service;
 mod timeout;

--- a/binaries/cuprated/src/rpc.rs
+++ b/binaries/cuprated/src/rpc.rs
@@ -7,6 +7,7 @@ mod handlers;
 mod rpc_handler;
 mod server;
 mod service;
+mod timeout;
 
 pub use rpc_handler::CupratedRpcHandler;
 pub use server::init_rpc_servers;

--- a/binaries/cuprated/src/rpc/ratelimit.rs
+++ b/binaries/cuprated/src/rpc/ratelimit.rs
@@ -1,0 +1,347 @@
+//! Rate Limit service
+//!
+//! Per-IP size-time-budget rate limiting for the RPC server.
+//!
+//! Every IP address (from the connection info inserted into the request extensions
+//! by [`Router::into_make_service_with_connect_info`], see [`crate::rpc::server`]) holds
+//! two budgets:
+//!
+//! - a size budget (bytes), debited by the size of every response it receives,
+//! - a time budget (milliseconds), debited by the processing time of every
+//!   one of its requests.
+//!
+//! Both budgets are refilled by a fixed income per second, capped at their
+//! configured maximum. A request received while either budget is exhausted is
+//! rejected immediately with `429 Too Many Requests`; the request that
+//! exhausts a budget is still served in full, pushing the budget negative to
+//! punish overshoot.
+//!
+//! Per-IP state is erased by [`crate::rpc::server`] once the IP's last
+//! connection has been closed for a grace period, keeping the cache proportional
+//! to the amount of recently-connected IP addresses.
+//!
+//! [`Router::into_make_service_with_connect_info`]: axum::Router::into_make_service_with_connect_info
+
+use std::{
+    future::Future,
+    mem::take,
+    net::{IpAddr, SocketAddr},
+    pin::Pin,
+    sync::Arc,
+    task::{ready, Context, Poll},
+};
+
+use axum::{
+    body::{Body, Bytes},
+    extract::connect_info::ConnectInfo,
+};
+use dashmap::DashMap;
+use hyper::{
+    body::{Body as HttpBody, Frame, SizeHint},
+    Request, Response, StatusCode,
+};
+use pin_project_lite::pin_project;
+use tokio::time::Instant;
+use tower::{Layer, Service};
+
+/// The per-IP rate limit budgets of an RPC server, from the RPC configuration.
+#[derive(Copy, Clone, Debug)]
+pub(super) struct RateLimitBudget {
+    /// The maximum size budget. The amount of response bytes an IP address
+    /// can hold at once.
+    max_budget_size: i64,
+    /// The size budget income. The amount of response bytes refilled
+    /// per second.
+    income_size: i64,
+    /// The maximum time budget. The amount of request processing time,
+    /// in milliseconds, an IP address can hold at once.
+    max_budget_time: i64,
+    /// The time budget income. The amount of milliseconds refilled
+    /// per second.
+    income_time: i64,
+}
+
+impl RateLimitBudget {
+    /// Create a new `RateLimitBudget`.
+    pub fn new(
+        max_budget_size: u64,
+        income_size: u64,
+        max_budget_time: u64,
+        income_time: u64,
+    ) -> Self {
+        Self {
+            max_budget_size: i64::try_from(max_budget_size).unwrap_or(i64::MAX),
+            income_size: i64::try_from(income_size).unwrap_or(i64::MAX),
+            max_budget_time: i64::try_from(max_budget_time).unwrap_or(i64::MAX),
+            income_time: i64::try_from(income_time).unwrap_or(i64::MAX),
+        }
+    }
+}
+
+pin_project! {
+    #[project = ResponseFutureProj]
+    pub(super) enum ResponseFuture<F> {
+        /// The request was rate limited: respond `429 Too Many Requests`.
+        RateLimited,
+        /// The request is being served, its processing time and response size
+        /// measured and debited from the IP address' budgets.
+        Future {
+            #[pin]
+            future: F,
+            start: Instant,
+            ip: IpAddr,
+            cache: Arc<RpcRateLimitCache>,
+        },
+    }
+}
+
+impl<F, E> Future for ResponseFuture<F>
+where
+    F: Future<Output = Result<Response<Body>, E>>,
+{
+    type Output = Result<Response<Body>, E>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        match self.project() {
+            ResponseFutureProj::RateLimited => Poll::Ready(Ok(Response::builder()
+                .status(StatusCode::TOO_MANY_REQUESTS)
+                .body(Body::empty())
+                .unwrap())),
+            ResponseFutureProj::Future {
+                future,
+                start,
+                ip,
+                cache,
+            } => {
+                let response = ready!(future.poll(cx))?;
+
+                // The request has finished processing. Time to debit its budget.
+                let millis = i64::try_from(start.elapsed().as_millis()).unwrap_or(i64::MAX);
+                cache.debit_time(ip, millis);
+
+                // Count streamed body bytes, debiting the response size.
+                Poll::Ready(Ok(response.map(|body| {
+                    Body::new(DebitBody::new(body, Arc::clone(cache), *ip))
+                })))
+            }
+        }
+    }
+}
+
+/// The double budget of an IP address.
+struct Budget {
+    /// Remaining response bytes.
+    size: i64,
+    /// Remaining request processing milliseconds.
+    time: i64,
+    /// The instant the last response was served (or dropped),
+    /// for refill.
+    last_request: Instant,
+}
+
+/// The shared per-IP rate limit budgets of an RPC server.
+pub(super) struct RpcRateLimitCache {
+    budgets: DashMap<IpAddr, Budget>,
+    /// The budget configuration.
+    budget: RateLimitBudget,
+}
+
+impl RpcRateLimitCache {
+    /// Create a new `RpcRateLimitCache` with the given budget configuration.
+    pub(super) fn new(budget: RateLimitBudget) -> Self {
+        Self {
+            budgets: DashMap::new(),
+            budget,
+        }
+    }
+
+    /// Refill the IP's budgets by their incomes and check if a request is
+    /// admitted: `true` if both budgets are positive, `false` if the request
+    /// must be rejected with `429 Too Many Requests`.
+    fn check(&self, ip: IpAddr) -> bool {
+        let budget = self.budget;
+        let now = Instant::now();
+
+        let mut entry = self.budgets.entry(ip).or_insert(Budget {
+            size: budget.max_budget_size,
+            time: budget.max_budget_time,
+            last_request: now,
+        });
+
+        // Refill the budgets by their respective incomes.
+        let elapsed =
+            i64::try_from(now.duration_since(entry.last_request).as_millis()).unwrap_or(i64::MAX);
+
+        let refill_size = budget.income_size.saturating_mul(elapsed) / 1000;
+        let refill_time = budget.income_time.saturating_mul(elapsed) / 1000;
+
+        entry.size = budget
+            .max_budget_size
+            .min(entry.size.saturating_add(refill_size));
+        entry.time = budget
+            .max_budget_time
+            .min(entry.time.saturating_add(refill_time));
+
+        entry.size > 0 && entry.time > 0
+    }
+
+    /// Debit response bytes from the IP's size budget, if still tracked.
+    fn debit_size(&self, ip: &IpAddr, bytes: i64) {
+        if let Some(mut budget) = self.budgets.get_mut(ip) {
+            budget.size -= bytes;
+            // Last request is updated here since called after sending the request.
+            budget.last_request = Instant::now();
+        }
+    }
+
+    /// Debit request processing milliseconds from the IP's time budget,
+    /// if still tracked.
+    fn debit_time(&self, ip: &IpAddr, millis: i64) {
+        if let Some(mut budget) = self.budgets.get_mut(ip) {
+            budget.time -= millis;
+        }
+    }
+
+    /// Remove the rate limit state of an IP address.
+    pub(super) fn remove_ip(&self, ip: &IpAddr) {
+        self.budgets.remove(ip);
+    }
+}
+
+/// A response body wrapper counting streamed bytes, debiting them from the
+/// IP address' size budget once the stream ends or is dropped.
+struct DebitBody {
+    inner: Body,
+    /// Number of bytes counted in the stream so far
+    counted: i64,
+    /// Atomic reference to the rate limit cache
+    cache: Arc<RpcRateLimitCache>,
+    /// IP address to debit budget from
+    ip: IpAddr,
+}
+
+impl DebitBody {
+    const fn new(inner: Body, cache: Arc<RpcRateLimitCache>, ip: IpAddr) -> Self {
+        Self {
+            inner,
+            counted: 0,
+            cache,
+            ip,
+        }
+    }
+
+    /// Debit the bytes counted so far.
+    fn debit(&mut self) {
+        self.cache.debit_size(&self.ip, take(&mut self.counted));
+    }
+}
+
+impl HttpBody for DebitBody {
+    type Data = Bytes;
+    type Error = axum::Error;
+
+    fn poll_frame(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
+        match ready!(Pin::new(&mut self.inner).poll_frame(cx)) {
+            Some(Ok(frame)) => {
+                if let Some(data) = frame.data_ref() {
+                    self.counted += i64::try_from(data.len()).unwrap_or(i64::MAX);
+                }
+                Poll::Ready(Some(Ok(frame)))
+            }
+            // The stream ended. debit the bytes counted so far.
+            result => {
+                self.debit();
+                Poll::Ready(result)
+            }
+        }
+    }
+
+    fn is_end_stream(&self) -> bool {
+        self.inner.is_end_stream()
+    }
+
+    fn size_hint(&self) -> SizeHint {
+        self.inner.size_hint()
+    }
+}
+
+impl Drop for DebitBody {
+    /// Mandatory to avoid disconnecting clients from not being debited.
+    fn drop(&mut self) {
+        self.debit();
+    }
+}
+
+/// Enforces a per-IP size-time-budget rate limit: requests received while
+/// either budget is exhausted are rejected with `429 Too Many Requests`.
+/// (see `rpc::ratelimit.rs`)
+#[derive(Clone)]
+pub(super) struct RateLimit<S> {
+    inner: S,
+    cache: Arc<RpcRateLimitCache>,
+}
+
+impl<S> Service<Request<Body>> for RateLimit<S>
+where
+    S: Service<Request<Body>, Response = Response<Body>>,
+{
+    type Response = Response<Body>;
+    type Error = S::Error;
+    type Future = ResponseFuture<S::Future>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, request: Request<Body>) -> Self::Future {
+        // The client IP address is inserted, if available, into the request extensions
+        // by `Router::into_make_service_with_connect_info` (see `rpc::server`).
+        let Some(ip) = request
+            .extensions()
+            .get::<ConnectInfo<SocketAddr>>()
+            .map(|ConnectInfo(addr)| addr.ip())
+        else {
+            panic!("Service must be wrapped inside of a IntoMakeConnectionInfo");
+        };
+
+        if !self.cache.check(ip) {
+            return ResponseFuture::RateLimited;
+        }
+
+        ResponseFuture::Future {
+            future: self.inner.call(request),
+            start: Instant::now(),
+            ip,
+            cache: Arc::clone(&self.cache),
+        }
+    }
+}
+
+/// A [`Layer`] that applies per-IP size-time-budget rate limiting, rejecting
+/// excess requests with `429 Too Many Requests`.
+#[derive(Clone)]
+pub(super) struct RateLimitLayer {
+    /// Atomic reference to the rate limit cache
+    cache: Arc<RpcRateLimitCache>,
+}
+
+impl RateLimitLayer {
+    /// Create a new `RateLimitLayer` with the given rate limit cache.
+    pub const fn new(cache: Arc<RpcRateLimitCache>) -> Self {
+        Self { cache }
+    }
+}
+
+impl<S> Layer<S> for RateLimitLayer {
+    type Service = RateLimit<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        RateLimit {
+            inner,
+            cache: Arc::clone(&self.cache),
+        }
+    }
+}

--- a/binaries/cuprated/src/rpc/semaphore.rs
+++ b/binaries/cuprated/src/rpc/semaphore.rs
@@ -1,0 +1,272 @@
+//! Semaphore Limit service
+//!
+//! Semaphore limiting for the blocks endpoints of the RPC server:
+//!
+//! - `/get_blocks.bin`
+//! - `/get_blocks_by_height.bin` (and their aliases)
+//! - `/json_rpc` => `get_block` or `getblock` method
+//!
+//! At most `N` requests are handled simultaneously; additional requests are
+//! put on hold for a specific period in milliseconds. Requests still queued past that
+//! period are rejected with `503 Service Unavailable` and a `Retry-After` header.
+//!
+//! The permit is held until the response has been fully sent (or dropped).
+
+use std::{
+    future::Future,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+    time::Duration,
+};
+
+use axum::{
+    body::{Body, Bytes},
+    extract::MatchedPath,
+    http::{header::RETRY_AFTER, Method},
+};
+use hyper::{
+    body::{Body as HttpBody, Frame, SizeHint},
+    Request, Response, StatusCode,
+};
+use pin_project_lite::pin_project;
+use serde::Deserialize;
+use tokio::{
+    sync::{OwnedSemaphorePermit, Semaphore},
+    time::timeout,
+};
+use tower::{Layer, Service};
+
+/// A look at the `method` field of a `/json_rpc` payload.
+#[derive(Deserialize)]
+struct MethodLook<'a> {
+    method: Option<&'a str>,
+}
+
+impl MethodLook<'_> {
+    /// Whether a JSON-RPC method is a blocks method.
+    fn is_blocks(method: &str) -> bool {
+        method == "get_block" || method == "getblock"
+    }
+}
+
+pin_project! {
+    #[project = BlockSemaphoreResponseProj]
+    pub(super) enum ResponseFuture<F, E> {
+        /// Not a blocks endpoint, forwarded.
+        Future {
+            #[pin]
+            future: F,
+        },
+        /// A blocks endpoint request waiting for a concurrency permit,
+        /// in order to be served.
+        Queued {
+            #[pin]
+            future: Pin<Box<dyn Future<Output = Result<Response<Body>, E>> + Send>>,
+        },
+    }
+}
+
+impl<F, E> Future for ResponseFuture<F, E>
+where
+    F: Future<Output = Result<Response<Body>, E>>,
+{
+    type Output = Result<Response<Body>, E>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        match self.project() {
+            BlockSemaphoreResponseProj::Future { future } => future.poll(cx),
+            BlockSemaphoreResponseProj::Queued { future } => future.poll(cx),
+        }
+    }
+}
+
+enum EndpointType {
+    Block,
+    JsonRpc,
+    Other,
+}
+
+/// A response body holding the semaphore permit until the stream
+/// ends or is dropped.
+struct PermitBody {
+    inner: Body,
+    /// This permit is freed when the Body is dropped.
+    _permit: OwnedSemaphorePermit,
+}
+
+impl HttpBody for PermitBody {
+    type Data = Bytes;
+    type Error = axum::Error;
+
+    fn poll_frame(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
+        Pin::new(&mut self.inner).poll_frame(cx)
+    }
+
+    fn is_end_stream(&self) -> bool {
+        self.inner.is_end_stream()
+    }
+
+    fn size_hint(&self) -> SizeHint {
+        self.inner.size_hint()
+    }
+}
+
+#[derive(Clone)]
+pub(super) struct BlockSemaphoreLimit<S> {
+    inner: S,
+    semaphore: Arc<Semaphore>,
+    timeout: Duration,
+    retry_after: Arc<str>,
+}
+
+impl<S> BlockSemaphoreLimit<S>
+where
+    S: Service<Request<Body>, Response = Response<Body>> + Clone + Send + 'static,
+    S::Future: Send + 'static,
+{
+    /// Wait for a concurrency permit for up to `timeout`, then serve the
+    /// request holding the permit, or respond `503 Service Unavailable`
+    /// with a `Retry-After` header.
+    async fn acquire_and_serve(
+        mut inner: S,
+        semaphore: Arc<Semaphore>,
+        wait: Duration,
+        retry_after: Arc<str>,
+        request: Request<Body>,
+    ) -> Result<Response<Body>, S::Error> {
+        let Ok(Ok(permit)) = timeout(wait, semaphore.acquire_owned()).await else {
+            // Too much time in queue, go back to client.
+            return Ok(Response::builder()
+                .status(StatusCode::SERVICE_UNAVAILABLE)
+                .header(RETRY_AFTER, retry_after.as_ref())
+                .body(Body::empty())
+                .unwrap());
+        };
+
+        let response = inner.call(request).await?;
+
+        Ok(response.map(|body| {
+            Body::new(PermitBody {
+                inner: body,
+                _permit: permit,
+            })
+        }))
+    }
+}
+
+impl<S> Service<Request<Body>> for BlockSemaphoreLimit<S>
+where
+    S: Service<Request<Body>, Response = Response<Body>> + Clone + Send + 'static,
+    S::Future: Send + 'static,
+{
+    type Response = Response<Body>;
+    type Error = S::Error;
+    type Future = ResponseFuture<S::Future, S::Error>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, request: Request<Body>) -> Self::Future {
+        // Get the endpoint type to decide whether to queue or forward the request.
+        let endpoint = match request.extensions().get::<MatchedPath>() {
+            Some(path)
+                if matches!(
+                    path.as_str(),
+                    "/get_blocks.bin"
+                        | "/getblocks.bin"
+                        | "/get_blocks_by_height.bin"
+                        | "/getblocks_by_height.bin"
+                ) =>
+            {
+                EndpointType::Block
+            }
+            Some(path) if path.as_str() == "/json_rpc" => EndpointType::JsonRpc,
+            _ => EndpointType::Other,
+        };
+
+        match endpoint {
+            EndpointType::JsonRpc => {
+                let mut inner = self.inner.clone();
+                let semaphore = Arc::clone(&self.semaphore);
+                let timeout = self.timeout;
+                let retry_after = Arc::clone(&self.retry_after);
+
+                ResponseFuture::Queued {
+                    future: Box::pin(async move {
+                        // Buffer the body, look at the method in the JSON payload.
+                        let (parts, body) = request.into_parts();
+
+                        let Ok(bytes) = axum::body::to_bytes(body, usize::MAX).await else {
+                            return Ok(Response::builder()
+                                .status(StatusCode::BAD_REQUEST)
+                                .body(Body::empty())
+                                .unwrap());
+                        };
+
+                        let is_blocks = serde_json::from_slice::<MethodLook<'_>>(&bytes)
+                            .ok()
+                            .and_then(|peek| peek.method)
+                            .is_some_and(MethodLook::is_blocks);
+
+                        let request = Request::from_parts(parts, Body::from(bytes));
+
+                        if is_blocks {
+                            Self::acquire_and_serve(inner, semaphore, timeout, retry_after, request)
+                                .await
+                        } else {
+                            inner.call(request).await
+                        }
+                    }),
+                }
+            }
+            EndpointType::Block => ResponseFuture::Queued {
+                future: Box::pin(Self::acquire_and_serve(
+                    self.inner.clone(),
+                    Arc::clone(&self.semaphore),
+                    self.timeout,
+                    Arc::clone(&self.retry_after),
+                    request,
+                )),
+            },
+            EndpointType::Other => ResponseFuture::Future {
+                future: self.inner.call(request),
+            },
+        }
+    }
+}
+
+/// A [`Layer`] that applies the blocks endpoint [`BlockSemaphoreLimit`].
+#[derive(Clone)]
+pub(super) struct BlockSemaphoreLimitLayer {
+    semaphore: Arc<Semaphore>,
+    timeout: Duration,
+    retry_after: Arc<str>,
+}
+
+impl BlockSemaphoreLimitLayer {
+    pub fn new(limit: u64, timeout: Duration) -> Self {
+        Self {
+            semaphore: Arc::new(Semaphore::new(usize::try_from(limit).unwrap_or(usize::MAX))),
+            timeout,
+            retry_after: timeout.as_millis().div_ceil(1000).to_string().into(),
+        }
+    }
+}
+
+impl<S> Layer<S> for BlockSemaphoreLimitLayer {
+    type Service = BlockSemaphoreLimit<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        BlockSemaphoreLimit {
+            inner,
+            semaphore: Arc::clone(&self.semaphore),
+            timeout: self.timeout,
+            retry_after: Arc::clone(&self.retry_after),
+        }
+    }
+}

--- a/binaries/cuprated/src/rpc/server.rs
+++ b/binaries/cuprated/src/rpc/server.rs
@@ -30,10 +30,18 @@ use cuprate_rpc_interface::RouterBuilder;
 
 use crate::{
     config::{restricted_rpc_port, unrestricted_rpc_port, RpcConfig},
-    rpc::{timeout::StreamTimeout, CupratedRpcHandler},
+    rpc::{
+        ratelimit::{RateLimitBudget, RateLimitLayer, RpcRateLimitCache},
+        timeout::StreamTimeout,
+        CupratedRpcHandler,
+    },
     txpool::IncomingTxHandler,
     LaunchContext,
 };
+
+/// The grace period after which the rate limit state of a disconnected IP
+/// address is erased, unless the IP reconnected in the meantime.
+const EVICTION_GRACE_PERIOD: Duration = Duration::from_secs(2);
 
 /// Initialize the RPC server(s).
 ///
@@ -98,8 +106,32 @@ pub fn init_rpc_servers(launch_ctx: &LaunchContext, tx_handler: IncomingTxHandle
         // Initialize RPC handler service.
         let rpc_handler = CupratedRpcHandler::new(restricted, tx_handler.clone(), launch_ctx);
 
+        // Initialize the per IP rate limit budgets.
+        let rate_limit_budget = if restricted {
+            RateLimitBudget::new(
+                config.restricted.max_budget_size,
+                config.restricted.income_size,
+                config.restricted.max_budget_time,
+                config.restricted.income_time,
+            )
+        } else {
+            RateLimitBudget::new(
+                config.unrestricted.max_budget_size,
+                config.unrestricted.income_size,
+                config.unrestricted.max_budget_time,
+                config.unrestricted.income_time,
+            )
+        };
+
+        // Initialize the per IP rate limit cache
+        let rate_limit_cache = Arc::new(RpcRateLimitCache::new(rate_limit_budget));
+
         // Initialize Axum RPC router.
-        let rpc_router = init_rpc_router(rpc_handler, request_byte_limit);
+        let rpc_router = init_rpc_router(
+            rpc_handler,
+            request_byte_limit,
+            Arc::clone(&rate_limit_cache),
+        );
 
         // Initialize per IP connection limit cache.
         let rpc_limit_cache = RpcLimitCache::from_config(config, restricted);
@@ -110,6 +142,7 @@ pub fn init_rpc_servers(launch_ctx: &LaunchContext, tx_handler: IncomingTxHandle
             rpc_send_timeout,
             rpc_read_timeout,
             rpc_limit_cache,
+            rate_limit_cache,
             rpc_router,
         );
 
@@ -132,7 +165,11 @@ pub fn init_rpc_servers(launch_ctx: &LaunchContext, tx_handler: IncomingTxHandle
 }
 
 /// Initialize the Axum router of the RPC server.
-fn init_rpc_router(rpc_handler: CupratedRpcHandler, request_byte_limit: usize) -> Router {
+fn init_rpc_router(
+    rpc_handler: CupratedRpcHandler,
+    request_byte_limit: usize,
+    rate_limit_cache: Arc<RpcRateLimitCache>,
+) -> Router {
     let mut router = RouterBuilder::new()
         .json_rpc()
         //
@@ -166,6 +203,8 @@ fn init_rpc_router(rpc_handler: CupratedRpcHandler, request_byte_limit: usize) -
     // Add restrictive layers if restricted RPC.
     //
     // TODO: <https://github.com/Cuprate/cuprate/issues/445>
+    router = router.layer(RateLimitLayer::new(rate_limit_cache));
+
     if request_byte_limit != 0 {
         router = router.layer(RequestBodyLimitLayer::new(request_byte_limit));
     }
@@ -179,6 +218,10 @@ struct RpcServer {
     rpc: Router,
     /// The connection limit cache of this server.
     ip_limit_cache: RpcLimitCache,
+    /// The rate limit cache of this server, shared with the rate limit layer.
+    rate_limit_cache: Arc<RpcRateLimitCache>,
+    /// Pending erasures of disconnected IP addresses' rate limit state.
+    pending_evictions: HashMap<IpAddr, AbortHandle>,
     listening_address: SocketAddr,
     // Socket timeouts
     send_timeout: Duration,
@@ -193,11 +236,14 @@ impl RpcServer {
         send_timeout: Duration,
         read_timeout: Duration,
         ip_limit_cache: RpcLimitCache,
+        rate_limit_cache: Arc<RpcRateLimitCache>,
         rpc: Router,
     ) -> Self {
         Self {
             rpc,
             ip_limit_cache,
+            rate_limit_cache,
+            pending_evictions: HashMap::new(),
             listening_address,
             send_timeout,
             read_timeout,
@@ -235,6 +281,11 @@ impl RpcServer {
                         continue;
                     }
 
+                    // The IP (re)connected. Cancel the pending erasure of its rate limit state.
+                    if let Some(eviction) = self.pending_evictions.remove(&remote_addr.ip()) {
+                        eviction.abort();
+                    }
+
                     self.serve(socket, remote_addr);
                 },
                 Some(res) = self.rpc_tasks.join_next() => {
@@ -242,16 +293,31 @@ impl RpcServer {
                     let ip = addr.ip();
 
                     // Untrack connection from IP
-                    self.ip_limit_cache.remove_connection(&ip);
+                    let is_last_connection = self.ip_limit_cache.remove_connection(&ip);
 
                     // If hyper serve failed, increase the serve failure and ban the IP
                     // for 3 seconds if it reaches 15 failures.
                     if serve_failed && self.ip_limit_cache.increment_serve_failure(&ip) >= 15 {
                         self.ip_limit_cache.ban_serve_ip(&ip);
                     }
+
+                    // The IP address' last connection ended. Erase its rate limit state
+                    // after a grace period.
+                    if is_last_connection {
+                        let rate_limit_cache = Arc::clone(&self.rate_limit_cache);
+                        let task = tokio::spawn(async move {
+                            tokio::time::sleep(EVICTION_GRACE_PERIOD).await;
+                            rate_limit_cache.remove_ip(&ip);
+                        });
+                        self.pending_evictions.insert(ip, task.abort_handle());
+                    }
                 }
                 () = shutdown_token.cancelled() => {
                     self.rpc_tasks.abort_all();
+
+                    for eviction in std::mem::take(&mut self.pending_evictions).into_values() {
+                        eviction.abort();
+                    }
 
                     return Ok(());
                 }
@@ -383,14 +449,15 @@ impl RpcLimitCache {
         true
     }
 
-    /// Remove a connection of the remote IP address.
-    fn remove_connection(&mut self, remote_addr: &IpAddr) {
+    /// Remove a connection of the remote IP address, returning `true` if this
+    /// was the IP address' last connection to the server.
+    fn remove_connection(&mut self, remote_addr: &IpAddr) -> bool {
         if self.excluded_ips.contains(remote_addr) {
-            return;
+            return false;
         }
 
         let Some(value) = self.per_ip_conn_count.get_mut(remote_addr) else {
-            return;
+            return false;
         };
 
         *value = value.saturating_sub(1);
@@ -398,6 +465,9 @@ impl RpcLimitCache {
 
         if *value == 0 {
             self.per_ip_conn_count.remove(remote_addr);
+            true
+        } else {
+            false
         }
     }
 

--- a/binaries/cuprated/src/rpc/server.rs
+++ b/binaries/cuprated/src/rpc/server.rs
@@ -1,31 +1,27 @@
 //! RPC server initialization and main loop.
 
 use std::{
-    cell::{Cell, UnsafeCell},
     collections::HashMap,
     net::{IpAddr, SocketAddr},
     num::NonZeroUsize,
-    sync::{
-        atomic::{AtomicUsize, Ordering},
-        Arc,
-    },
+    sync::Arc,
     time::Duration,
 };
 
 use anyhow::Error;
 use axum::Router;
-use hyper::{body::Incoming, Request};
+use dashmap::{DashMap, DashSet};
 use hyper_util::{
     rt::{TokioExecutor, TokioIo},
-    server::conn::{self, auto::Builder as ConnAutoBuilder},
+    server::conn::auto::Builder as ConnAutoBuilder,
     service::TowerToHyperService,
 };
 use tokio::{
     net::{TcpListener, TcpStream},
-    task::JoinSet,
+    task::{AbortHandle, JoinSet},
 };
 use tokio_util::{sync::CancellationToken, time::FutureExt};
-use tower::{limit::rate::RateLimitLayer, Service};
+use tower::Service;
 use tower_http::limit::RequestBodyLimitLayer;
 use tracing::{error, info, warn};
 
@@ -105,11 +101,15 @@ pub fn init_rpc_servers(launch_ctx: &LaunchContext, tx_handler: IncomingTxHandle
         // Initialize Axum RPC router.
         let rpc_router = init_rpc_router(rpc_handler, request_byte_limit);
 
+        // Initialize per IP connection limit cache.
+        let rpc_limit_cache = RpcLimitCache::from_config(config, restricted);
+
         // Build the RPC server.
         let rpc_server = RpcServer::new(
             SocketAddr::new(addr, port),
             rpc_send_timeout,
             rpc_read_timeout,
+            rpc_limit_cache,
             rpc_router,
         );
 
@@ -177,11 +177,13 @@ fn init_rpc_router(rpc_handler: CupratedRpcHandler, request_byte_limit: usize) -
 struct RpcServer {
     /// The RPC Axum router.
     rpc: Router,
+    /// The connection limit cache of this server.
+    ip_limit_cache: RpcLimitCache,
     listening_address: SocketAddr,
     // Socket timeouts
     send_timeout: Duration,
     read_timeout: Duration,
-    rpc_tasks: JoinSet<SocketAddr>,
+    rpc_tasks: JoinSet<(SocketAddr, bool)>,
 }
 
 impl RpcServer {
@@ -190,10 +192,12 @@ impl RpcServer {
         listening_address: SocketAddr,
         send_timeout: Duration,
         read_timeout: Duration,
+        ip_limit_cache: RpcLimitCache,
         rpc: Router,
     ) -> Self {
         Self {
             rpc,
+            ip_limit_cache,
             listening_address,
             send_timeout,
             read_timeout,
@@ -221,10 +225,30 @@ impl RpcServer {
                         }
                     };
 
+                    // Check if IP is banned
+                    if self.ip_limit_cache.is_ip_banned(remote_addr.ip()) {
+                        continue;
+                    }
+
+                    // Check for total and per-IP connection limits.
+                    if !self.ip_limit_cache.check_and_track_connection(remote_addr.ip()) {
+                        continue;
+                    }
+
                     self.serve(socket, remote_addr);
                 },
                 Some(res) = self.rpc_tasks.join_next() => {
-                    let res = res?;
+                    let (addr, serve_failed) = res?;
+                    let ip = addr.ip();
+
+                    // Untrack connection from IP
+                    self.ip_limit_cache.remove_connection(&ip);
+
+                    // If hyper serve failed, increase the serve failure and ban the IP
+                    // for 3 seconds if it reaches 15 failures.
+                    if serve_failed && self.ip_limit_cache.increment_serve_failure(&ip) >= 15 {
+                        self.ip_limit_cache.ban_serve_ip(&ip);
+                    }
                 }
                 () = shutdown_token.cancelled() => {
                     self.rpc_tasks.abort_all();
@@ -236,19 +260,178 @@ impl RpcServer {
     }
 
     fn serve(&mut self, socket: TcpStream, remote_addr: SocketAddr) {
-        let rpc = self.rpc.clone();
+        let mut make_service = self
+            .rpc
+            .clone()
+            .into_make_service_with_connect_info::<SocketAddr>();
         let socket = StreamTimeout::new(socket, self.send_timeout, self.read_timeout);
 
         self.rpc_tasks.spawn(async move {
+            let Ok(rpc) = make_service.call(remote_addr).await;
+
             // Serve RPC router to this connection
             if let Err(err) = ConnAutoBuilder::new(TokioExecutor::new())
                 .serve_connection_with_upgrades(TokioIo::new(socket), TowerToHyperService::new(rpc))
                 .await
             {
                 error!("Failed to serve RPC connection: {err:#}");
+                return (remote_addr, true);
             }
 
-            remote_addr
+            (remote_addr, false)
+        });
+    }
+}
+
+/// A cache of the number of connections of all the
+/// IP addresses currently connected to an RPC server.
+struct RpcLimitCache {
+    /// Maximum amount of connections per public IP address.
+    max_conn_count_public_ip: Option<NonZeroUsize>,
+    /// Maximum amount of connections per private IP address.
+    max_conn_count_private_ip: Option<NonZeroUsize>,
+    /// Maximum amount of connections per loopback IP address.
+    max_conn_count_loopback: Option<NonZeroUsize>,
+    /// Total maximum amount of connections by limited IP addresses.
+    max_conn_count: Option<NonZeroUsize>,
+    /// IP addresses that are excluded from any limitations.
+    excluded_ips: Vec<IpAddr>,
+    /// Amount of current connections per limited IP address.
+    per_ip_conn_count: HashMap<IpAddr, usize>,
+    /// Total amount of current connections by limited IP addresses.
+    total_conn_count: usize,
+    /// IP addresses banned after failing HTTP stack too many times.
+    banned_ips: Arc<DashMap<IpAddr, usize>>,
+}
+
+impl RpcLimitCache {
+    /// Initialize an RPC cache from an RPC configuration reference.
+    fn from_config(config: &RpcConfig, restricted: bool) -> Self {
+        if restricted {
+            Self {
+                max_conn_count_public_ip: NonZeroUsize::new(
+                    config.restricted.public_ip_connection_limit,
+                ),
+                max_conn_count_private_ip: NonZeroUsize::new(
+                    config.restricted.private_ip_connection_limit,
+                ),
+                max_conn_count_loopback: NonZeroUsize::new(
+                    config.restricted.loopback_connection_limit,
+                ),
+                max_conn_count: NonZeroUsize::new(config.restricted.total_connection_limit),
+                excluded_ips: config.restricted.excluded_ips_connection_limit.clone(),
+                total_conn_count: 0,
+                per_ip_conn_count: HashMap::new(),
+                banned_ips: Arc::new(DashMap::new()),
+            }
+        } else {
+            Self {
+                max_conn_count_public_ip: NonZeroUsize::new(
+                    config.unrestricted.public_ip_connection_limit,
+                ),
+                max_conn_count_private_ip: NonZeroUsize::new(
+                    config.unrestricted.private_ip_connection_limit,
+                ),
+                max_conn_count_loopback: NonZeroUsize::new(
+                    config.unrestricted.loopback_connection_limit,
+                ),
+                max_conn_count: NonZeroUsize::new(config.unrestricted.total_connection_limit),
+                excluded_ips: config.unrestricted.excluded_ips_connection_limit.clone(),
+                total_conn_count: 0,
+                per_ip_conn_count: HashMap::new(),
+                banned_ips: Arc::new(DashMap::new()),
+            }
+        }
+    }
+
+    /// Check the connection limit of the remote IP address, increase it and return `true` if allowed,
+    /// return `false` if disallowed. Excluded IP address is validated early and do not increase the total
+    /// connection count.
+    fn check_and_track_connection(&mut self, remote_addr: IpAddr) -> bool {
+        if self.excluded_ips.contains(&remote_addr) {
+            return true;
+        }
+
+        if let Some(max_conn_count) = self.max_conn_count {
+            if self.total_conn_count >= max_conn_count.get() {
+                return false;
+            }
+        }
+
+        if let Some(mut conn_count) = self.per_ip_conn_count.get_mut(&remote_addr) {
+            let limit = if remote_addr.is_loopback() {
+                self.max_conn_count_loopback
+            } else if ip_is_local(remote_addr) {
+                self.max_conn_count_private_ip
+            } else {
+                self.max_conn_count_public_ip
+            };
+
+            if let Some(limit) = limit {
+                if *conn_count >= limit.get() {
+                    return false;
+                }
+            }
+
+            *conn_count += 1;
+        } else {
+            self.per_ip_conn_count.insert(remote_addr, 1);
+        }
+
+        self.total_conn_count += 1;
+
+        true
+    }
+
+    /// Remove a connection of the remote IP address.
+    fn remove_connection(&mut self, remote_addr: &IpAddr) {
+        if self.excluded_ips.contains(remote_addr) {
+            return;
+        }
+
+        let Some(value) = self.per_ip_conn_count.get_mut(remote_addr) else {
+            return;
+        };
+
+        *value = value.saturating_sub(1);
+        self.total_conn_count -= 1;
+
+        if *value == 0 {
+            self.per_ip_conn_count.remove(remote_addr);
+        }
+    }
+
+    fn is_ip_banned(&mut self, remote: IpAddr) -> bool {
+        if let Some(counter) = self.banned_ips.get(&remote) {
+            *counter >= 15
+        } else {
+            false
+        }
+    }
+
+    /// Increment the failure counter for an IP address and returning
+    /// its new count. This creates a new entry if the IP address has never
+    /// experienced any failure and isn't present in cache.
+    fn increment_serve_failure(&mut self, remote: &IpAddr) -> usize {
+        if let Some(mut counter) = self.banned_ips.get_mut(remote) {
+            *counter += 1;
+            *counter
+        } else {
+            self.banned_ips.insert(*remote, 1);
+            1
+        }
+    }
+
+    /// Ban a specific IP from being served for 3 seconds.
+    /// After this delay, this delay its entry is deleted from
+    /// the banning cache.
+    fn ban_serve_ip(&mut self, remote: &IpAddr) {
+        let banned_ips = Arc::clone(&self.banned_ips);
+        let remote = *remote;
+
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_secs(3)).await;
+            banned_ips.remove(&remote);
         });
     }
 }

--- a/binaries/cuprated/src/rpc/server.rs
+++ b/binaries/cuprated/src/rpc/server.rs
@@ -1,22 +1,40 @@
 //! RPC server initialization and main loop.
 
 use std::{
+    cell::{Cell, UnsafeCell},
+    collections::HashMap,
     net::{IpAddr, SocketAddr},
+    num::NonZeroUsize,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
     time::Duration,
 };
 
 use anyhow::Error;
-use tokio::net::TcpListener;
-use tokio_util::sync::CancellationToken;
-use tower::limit::rate::RateLimitLayer;
+use axum::Router;
+use hyper::{body::Incoming, Request};
+use hyper_util::{
+    rt::{TokioExecutor, TokioIo},
+    server::conn::{self, auto::Builder as ConnAutoBuilder},
+    service::TowerToHyperService,
+};
+use tokio::{
+    net::{TcpListener, TcpStream},
+    task::JoinSet,
+};
+use tokio_util::{sync::CancellationToken, time::FutureExt};
+use tower::{limit::rate::RateLimitLayer, Service};
 use tower_http::limit::RequestBodyLimitLayer;
-use tracing::{info, warn};
+use tracing::{error, info, warn};
 
+use cuprate_helper::net::ip_is_local;
 use cuprate_rpc_interface::RouterBuilder;
 
 use crate::{
-    config::{restricted_rpc_port, unrestricted_rpc_port},
-    rpc::CupratedRpcHandler,
+    config::{restricted_rpc_port, unrestricted_rpc_port, RpcConfig},
+    rpc::{timeout::StreamTimeout, CupratedRpcHandler},
     txpool::IncomingTxHandler,
     LaunchContext,
 };
@@ -55,7 +73,7 @@ pub fn init_rpc_servers(launch_ctx: &LaunchContext, tx_handler: IncomingTxHandle
             continue;
         }
 
-        if !restricted && !cuprate_helper::net::ip_is_local(addr) {
+        if !restricted && !ip_is_local(addr) {
             if config
                 .unrestricted
                 .i_know_what_im_doing_allow_public_unrestricted_rpc
@@ -69,41 +87,53 @@ pub fn init_rpc_servers(launch_ctx: &LaunchContext, tx_handler: IncomingTxHandle
             }
         }
 
+        let (rpc_send_timeout, rpc_read_timeout) = if restricted {
+            (
+                config.restricted.send_timeout,
+                config.restricted.read_timeout,
+            )
+        } else {
+            (
+                config.unrestricted.send_timeout,
+                config.unrestricted.read_timeout,
+            )
+        };
+
+        // Initialize RPC handler service.
         let rpc_handler = CupratedRpcHandler::new(restricted, tx_handler.clone(), launch_ctx);
 
+        // Initialize Axum RPC router.
+        let rpc_router = init_rpc_router(rpc_handler, request_byte_limit);
+
+        // Build the RPC server.
+        let rpc_server = RpcServer::new(
+            SocketAddr::new(addr, port),
+            rpc_send_timeout,
+            rpc_read_timeout,
+            rpc_router,
+        );
+
+        info!(
+            restricted,
+            address = %addr,
+            "Starting RPC server"
+        );
+
+        // Launch RPC server.
         let shutdown_token = launch_ctx.task_executor.cancellation_token();
         launch_ctx.task_executor.spawn(async move {
-            run_rpc_server(
-                rpc_handler,
-                restricted,
-                SocketAddr::new(addr, port),
-                request_byte_limit,
-                shutdown_token,
-            )
-            .await
-            .unwrap();
+            if let Err(e) = rpc_server.run(shutdown_token).await {
+                error!(restricted, "RPC server error: {e:#}");
+            }
+
             info!(restricted, "RPC server shut down.");
         });
     }
 }
 
-/// This initializes and runs an RPC server.
-///
-/// The function will only return when the server itself returns or an error occurs.
-async fn run_rpc_server(
-    rpc_handler: CupratedRpcHandler,
-    restricted: bool,
-    address: SocketAddr,
-    request_byte_limit: usize,
-    shutdown_token: CancellationToken,
-) -> Result<(), Error> {
-    info!(
-        restricted,
-        address = %address,
-        "Starting RPC server"
-    );
-
-    let router = RouterBuilder::new()
+/// Initialize the Axum router of the RPC server.
+fn init_rpc_router(rpc_handler: CupratedRpcHandler, request_byte_limit: usize) -> Router {
+    let mut router = RouterBuilder::new()
         .json_rpc()
         //
         .other_get_info()
@@ -136,21 +166,89 @@ async fn run_rpc_server(
     // Add restrictive layers if restricted RPC.
     //
     // TODO: <https://github.com/Cuprate/cuprate/issues/445>
-    let router = if request_byte_limit != 0 {
-        router.layer(RequestBodyLimitLayer::new(request_byte_limit))
-    } else {
-        router
-    };
+    if request_byte_limit != 0 {
+        router = router.layer(RequestBodyLimitLayer::new(request_byte_limit));
+    }
 
-    let router = router.layer(tower_http::trace::TraceLayer::new_for_http());
+    router.layer(tower_http::trace::TraceLayer::new_for_http())
+}
 
-    // Start the server.
-    //
-    // TODO: impl custom server code, don't use axum.
-    let listener = TcpListener::bind(address).await?;
-    axum::serve(listener, router)
-        .with_graceful_shutdown(shutdown_token.cancelled_owned())
-        .await?;
+/// An RPC server capable of listening to new connections and serving RPC requests.
+struct RpcServer {
+    /// The RPC Axum router.
+    rpc: Router,
+    listening_address: SocketAddr,
+    // Socket timeouts
+    send_timeout: Duration,
+    read_timeout: Duration,
+    rpc_tasks: JoinSet<SocketAddr>,
+}
 
-    Ok(())
+impl RpcServer {
+    /// Build a new RPC server.
+    fn new(
+        listening_address: SocketAddr,
+        send_timeout: Duration,
+        read_timeout: Duration,
+        rpc: Router,
+    ) -> Self {
+        Self {
+            rpc,
+            listening_address,
+            send_timeout,
+            read_timeout,
+            rpc_tasks: JoinSet::new(),
+        }
+    }
+
+    /// Consume this server and start serving to incoming connections.
+    /// This method only returns errors is unable to listen on its address:port.
+    async fn run(mut self, shutdown_token: CancellationToken) -> Result<(), Error> {
+        // Start the listener.
+        let listener = TcpListener::bind(self.listening_address).await?;
+
+        loop {
+            tokio::select! {
+                res = listener.accept() => {
+                    let (socket, remote_addr) = match res {
+                        Ok(res) => res,
+                        Err(e) => {
+                            // A failed accept can be caused by reaching resource limits.
+                            // We should not attempt to accept a new connection immediately.
+                            warn!("Failed to accept RPC connection: {e}");
+                            tokio::time::sleep(Duration::from_millis(40)).await;
+                            continue
+                        }
+                    };
+
+                    self.serve(socket, remote_addr);
+                },
+                Some(res) = self.rpc_tasks.join_next() => {
+                    let res = res?;
+                }
+                () = shutdown_token.cancelled() => {
+                    self.rpc_tasks.abort_all();
+
+                    return Ok(());
+                }
+            }
+        }
+    }
+
+    fn serve(&mut self, socket: TcpStream, remote_addr: SocketAddr) {
+        let rpc = self.rpc.clone();
+        let socket = StreamTimeout::new(socket, self.send_timeout, self.read_timeout);
+
+        self.rpc_tasks.spawn(async move {
+            // Serve RPC router to this connection
+            if let Err(err) = ConnAutoBuilder::new(TokioExecutor::new())
+                .serve_connection_with_upgrades(TokioIo::new(socket), TowerToHyperService::new(rpc))
+                .await
+            {
+                error!("Failed to serve RPC connection: {err:#}");
+            }
+
+            remote_addr
+        });
+    }
 }

--- a/binaries/cuprated/src/rpc/server.rs
+++ b/binaries/cuprated/src/rpc/server.rs
@@ -32,6 +32,7 @@ use crate::{
     config::{restricted_rpc_port, unrestricted_rpc_port, RpcConfig},
     rpc::{
         ratelimit::{RateLimitBudget, RateLimitLayer, RpcRateLimitCache},
+        semaphore::BlockSemaphoreLimitLayer,
         timeout::StreamTimeout,
         CupratedRpcHandler,
     },
@@ -103,6 +104,17 @@ pub fn init_rpc_servers(launch_ctx: &LaunchContext, tx_handler: IncomingTxHandle
             )
         };
 
+        let (blocks_semaphore_limit, blocks_semaphore_queue_wait) = if restricted {
+            (
+                config.restricted.blocks_semaphore_limit,
+                config.restricted.blocks_semaphore_queue_wait,
+            )
+        } else {
+            (
+                config.unrestricted.blocks_semaphore_limit,
+                config.unrestricted.blocks_semaphore_queue_wait,
+            )
+        };
         // Initialize RPC handler service.
         let rpc_handler = CupratedRpcHandler::new(restricted, tx_handler.clone(), launch_ctx);
 
@@ -131,6 +143,8 @@ pub fn init_rpc_servers(launch_ctx: &LaunchContext, tx_handler: IncomingTxHandle
             rpc_handler,
             request_byte_limit,
             Arc::clone(&rate_limit_cache),
+            blocks_semaphore_limit,
+            blocks_semaphore_queue_wait,
         );
 
         // Initialize per IP connection limit cache.
@@ -169,6 +183,8 @@ fn init_rpc_router(
     rpc_handler: CupratedRpcHandler,
     request_byte_limit: usize,
     rate_limit_cache: Arc<RpcRateLimitCache>,
+    blocks_concurrency_limit: u64,
+    blocks_concurrency_wait: Duration,
 ) -> Router {
     let mut router = RouterBuilder::new()
         .json_rpc()
@@ -201,9 +217,16 @@ fn init_rpc_router(
         .with_state(rpc_handler);
 
     // Add restrictive layers if restricted RPC.
-    //
-    // TODO: <https://github.com/Cuprate/cuprate/issues/445>
     router = router.layer(RateLimitLayer::new(rate_limit_cache));
+
+    // The concurrency limit runs outside the rate limit as queue wait is
+    // unaccounted processing time.
+    if blocks_concurrency_limit != 0 {
+        router = router.layer(BlockSemaphoreLimitLayer::new(
+            blocks_concurrency_limit,
+            blocks_concurrency_wait,
+        ));
+    }
 
     if request_byte_limit != 0 {
         router = router.layer(RequestBodyLimitLayer::new(request_byte_limit));

--- a/binaries/cuprated/src/rpc/timeout.rs
+++ b/binaries/cuprated/src/rpc/timeout.rs
@@ -1,0 +1,290 @@
+//! IO Timeout Wrapper
+//!
+//! This module implements wrapper around [`AsyncRead`]/[`AsyncWrite`] types to return `TimedOut` error if
+//! they haven't been able to complete operation after a period of time.
+//!
+//! This is used as a denial of service mitigation mechanism against keep-alive or one-way spamming connections.
+//!
+//! Internally these wrappers abstract the `Duration` field to welcome shared data structures that can be used to
+//! adapt the timeout period on the fly.
+//!
+
+use std::{
+    future::Future,
+    io::{Error, ErrorKind},
+    pin::Pin,
+    task::{Context, Poll},
+    time::Duration,
+};
+
+use hyper::rt::ReadBufCursor;
+use pin_project_lite::pin_project;
+use tokio::{
+    io::{AsyncRead, AsyncWrite},
+    time::{sleep_until, Instant, Sleep},
+};
+
+/// A pinned timeout state with a specified duration.
+pub struct TimeoutState {
+    timeout: Duration,
+    refresh: bool,
+    sleep: Pin<Box<Sleep>>,
+}
+
+impl TimeoutState
+where
+    Self: Unpin,
+{
+    /// Create a new [`TimeoutState`] with the given timeout type.
+    pub fn new(timeout: Duration) -> Self {
+        Self {
+            timeout,
+            refresh: true,
+            sleep: Box::pin(sleep_until(Instant::now())),
+        }
+    }
+
+    /// Poll inner [`Sleep`] for completion. Update its deadline on first use and return
+    /// `Poll::Ready(Error::from(ErrorKind::TimedOut))` on completion, `Poll::Pending` otherwise
+    pub fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Error> {
+        let mut proj = self;
+
+        // On first poll after refresh activate couldown.
+        if proj.refresh {
+            proj.refresh = false;
+            let timeout = proj.timeout;
+            proj.sleep.as_mut().reset(Instant::now() + timeout);
+        }
+
+        proj.sleep
+            .as_mut()
+            .poll(cx)
+            .map(|()| Error::from(ErrorKind::TimedOut))
+    }
+}
+
+// Helper macros for reducing redundancy. This main logic is present in every poll.
+macro_rules! poll_or_timeout {
+    ($self:ident::$io:ident..$timeout:ident => $poll:ident, $cx:ident, $($arg:expr),*) => {{
+        let proj = $self .project();
+
+        match proj.$io.$poll($cx, $($arg),*) {
+            Poll::Pending => proj.$timeout.as_mut().poll($cx).map(Err),
+            Poll::Ready(r) => {
+                proj.$timeout.refresh = true;
+                Poll::Ready(r)
+            }
+        }
+    }};
+    ($self:ident::$io:ident..$timeout:ident => $poll:ident, $cx:ident) => {{
+        let proj = $self .project();
+
+        match proj.$io.$poll($cx) {
+            Poll::Pending => proj.$timeout.as_mut().poll($cx).map(Err),
+            Poll::Ready(r) => {
+                proj.$timeout.refresh = true;
+                Poll::Ready(r)
+            }
+        }
+    }};
+}
+
+pin_project! {
+    /// A timeout wrapper around an [`AsyncRead`] + [`AsyncWrite`] implemented type.
+    ///
+    /// Returns a `TimedOut` error if `poll_read` have been returning
+    /// `Poll::Pending` for the timeout duration.
+    pub struct StreamTimeout<S> {
+        #[pin]
+        stream: S,
+        write_timeout: Pin<Box<TimeoutState>>,
+        read_timeout: Pin<Box<TimeoutState>>
+    }
+}
+
+impl<S: AsyncWrite + AsyncRead> StreamTimeout<S> {
+    /// Create a new [`StreamTimeout`] from a stream and two [`ExtractDuration`] enabled type.
+    pub fn new(stream: S, write_timeout: Duration, read_timeout: Duration) -> Self {
+        Self {
+            stream,
+            write_timeout: Box::pin(TimeoutState::new(write_timeout)),
+            read_timeout: Box::pin(TimeoutState::new(read_timeout)),
+        }
+    }
+}
+
+impl<S: AsyncWrite + AsyncRead> AsyncWrite for StreamTimeout<S> {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<Result<usize, Error>> {
+        poll_or_timeout!(self::stream..write_timeout => poll_write, cx, buf)
+    }
+
+    fn poll_write_vectored(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[std::io::IoSlice<'_>],
+    ) -> Poll<Result<usize, Error>> {
+        poll_or_timeout!(self::stream..write_timeout => poll_write_vectored, cx, buf)
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Error>> {
+        poll_or_timeout!(self::stream..write_timeout => poll_flush, cx)
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Error>> {
+        poll_or_timeout!(self::stream..write_timeout => poll_shutdown, cx)
+    }
+
+    fn is_write_vectored(&self) -> bool {
+        self.stream.is_write_vectored()
+    }
+}
+
+impl<S: AsyncRead + AsyncWrite> AsyncRead for StreamTimeout<S> {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        poll_or_timeout!(self::stream..read_timeout => poll_read, cx, buf)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::{
+        future::Future,
+        io::ErrorKind,
+        net::{IpAddr, Ipv4Addr, SocketAddr},
+        time::Duration,
+    };
+
+    use tokio::{
+        io::{AsyncReadExt, AsyncWriteExt},
+        net::{TcpListener, TcpStream},
+        select,
+        task::JoinSet,
+        time::{sleep, timeout},
+    };
+
+    use crate::rpc::timeout::StreamTimeout;
+
+    #[cfg(target_os = "macos")]
+    const TEST_TIMEOUT: Duration = Duration::from_secs(2);
+    #[cfg(not(target_os = "macos"))]
+    const TEST_TIMEOUT: Duration = Duration::from_secs(10);
+
+    fn within_current_thread_runtime(future: impl Future) {
+        // Start tokio runtime
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(4)
+            .enable_all()
+            .build()
+            .unwrap();
+
+        runtime.block_on(future);
+    }
+
+    // Common setup used between TCP tests.
+    async fn spawn_tcp_setup<C, L, R1, R2>(port: u16, client_test: C, listener_test: L)
+    where
+        R1: Future<Output = ()> + Send + 'static,
+        R2: Future<Output = ()> + Send + 'static,
+        C: Fn(TcpStream) -> R1 + Send + 'static,
+        L: Fn(TcpStream) -> R2 + Send + 'static,
+    {
+        let socketaddr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port);
+
+        let listener = TcpListener::bind(socketaddr)
+            .await
+            .expect("Unable to bind TCP Listener");
+
+        let mut set = JoinSet::new();
+
+        // Spawn Listener
+        set.spawn(async move {
+            let connection = listener
+                .accept()
+                .await
+                .expect("Unable to accept incoming connection");
+
+            listener_test(connection.0).await;
+        });
+
+        // Spawn client
+        set.spawn(async move {
+            let Ok(stream) = timeout(TEST_TIMEOUT, TcpStream::connect(socketaddr))
+                .await
+                .expect("Unable to connect listener")
+            else {
+                panic!("No connection has been made to the listener!");
+            };
+
+            client_test(stream).await;
+        });
+
+        set.join_all().await;
+    }
+
+    #[test]
+    fn tcp_stream_read_timeout_err() {
+        within_current_thread_runtime(spawn_tcp_setup(
+            60035,
+            async |_stream: TcpStream| {
+                sleep(TEST_TIMEOUT + Duration::from_secs(1)).await;
+            },
+            async |stream: TcpStream| {
+                // Wrap stream into StreamTimeout
+                let mut stream = StreamTimeout::new(stream, TEST_TIMEOUT, TEST_TIMEOUT);
+
+                // Try to read
+                let mut buf = vec![0_u8; 1024]; // 1KiB
+                select! {
+                    r = stream.read_buf(&mut buf) => {
+                        if let Err(err) = r {
+                            assert_eq!(err.kind(), ErrorKind::TimedOut);
+                        } else {
+                            panic!("The buffer has been successfully filled. This test needs to updated.")
+                        }
+                    }
+                    () = sleep(TEST_TIMEOUT + Duration::from_secs(1)) => {
+                        panic!("No error has been returned after <timeout duration>+1 seconds.")
+                    }
+                }
+            },
+        ));
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[test]
+    fn tcp_stream_write_timeout_err() {
+        within_current_thread_runtime(spawn_tcp_setup(
+            60036,
+            async |_stream: TcpStream| {
+                sleep(TEST_TIMEOUT + Duration::from_secs(1)).await;
+            },
+            async |stream: TcpStream| {
+                // Wrap stream into StreamTimeout
+                let mut stream = StreamTimeout::new(stream, TEST_TIMEOUT, TEST_TIMEOUT);
+
+                // Try to write
+                let buf = vec![1_u8; 64 * 1024_usize.pow(2)]; // 16MiB
+                select! {
+                    r = stream.write_all(&buf) => {
+                        if let Err(err) = r {
+                            assert_eq!(err.kind(), ErrorKind::TimedOut);
+                        } else {
+                            panic!("Buffer have been successfully flushed. This test needs to updated.")
+                        }
+                    }
+                    () = sleep(TEST_TIMEOUT * 2) => {
+                        panic!("No error has been returned after <timeout duration>+1 seconds.")
+                    }
+                }
+            },
+        ));
+    }
+}


### PR DESCRIPTION
This PR follows and is based upon https://github.com/Cuprate/cuprate/pull/685

It adds a new limiting layer called `BlockSemaphoreLimitLayer` that limit the maximum amount of block endpoints (`get_blocks.bin`, `get_blocks`, etc...) requests being processed simultaneously. Any additional request is put on hold for a configurable period of time. If that delay is exceeded, the request is dropped and the clients receives a `503 Service unavailable` response with a `Retry-After` header.  

Original idea from @Boog900