### PR TITLE
ci: remove openbsd

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,13 +208,11 @@ jobs:
       CARGO_PROFILE_DEV_DEBUG: "0"
       CARGO_PROFILE_TEST_DEBUG: "0"
       CARGO_PROFILE_DEV_BUILD_OVERRIDE_DEBUG: "0"
-      RUSTFLAGS: "-C strip=symbols"
 
     strategy:
       matrix:
         os: [
           { name: freebsd, architecture: x86_64, version: "15.1", dependencies: "cmake curl git gmake" },
-          { name: openbsd, architecture: x86_64, version: "7.9", dependencies: "cmake git gmake rust rust-clippy" },
         ]
 
     defaults:
@@ -228,7 +226,6 @@ jobs:
           submodules: recursive
 
       - name: Download monerod
-        if: matrix.os.name != 'openbsd' # There is no prebuilt monerod for OpenBSD
         uses: ./.github/actions/monerod-download
         with:
           os: ${{ matrix.os.name }}
@@ -243,14 +240,11 @@ jobs:
           memory: 6G
           cpu_count: 4
           sync_files: runner-to-vm
-          environment_variables: CARGO_TERM_COLOR RUST_BACKTRACE RUST_MIN_STACK RUSTFLAGS RUSTDOCFLAGS CARGO_PROFILE_DEV_BUILD_OVERRIDE_DEBUG CARGO_INCREMENTAL CARGO_PROFILE_DEV_DEBUG CARGO_PROFILE_TEST_DEBUG
+          environment_variables: CARGO_TERM_COLOR RUST_BACKTRACE RUST_MIN_STACK RUSTDOCFLAGS CARGO_PROFILE_DEV_BUILD_OVERRIDE_DEBUG CARGO_INCREMENTAL CARGO_PROFILE_DEV_DEBUG CARGO_PROFILE_TEST_DEBUG
 
       - name: Install dependencies
         run: |
           case "${{ matrix.os.name }}" in
-            openbsd)
-              sudo pkg_add ${{ matrix.os.dependencies }}
-              ;;
             freebsd)
               sudo pkg install -y ${{ matrix.os.dependencies }}
               sudo pkg clean -y
@@ -274,34 +268,13 @@ jobs:
         run: ${{ env.CMD_CLIPPY }}
 
       - name: Test
-        run: |
-          cargo clean
-          case "${{ matrix.os.name }}" in
-            openbsd)
-              ulimit -Sd 4194304
-              ulimit -n 1024
-              cargo test --all-features --workspace --exclude cuprate-p2p-core
-              cargo test --all-features --package cuprate-p2p-core --lib --tests -- --skip monerod
-              ;;
-            *)
-              ${{ env.CMD_TEST }}
-              ;;
-          esac
+        run: ${{ env.CMD_TEST }}
 
       - name: Build
         run: ${{ env.CMD_BUILD }}
 
       - name: Hack Check
-        run: |
-          case "${{ matrix.os.name }}" in
-            openbsd)
-              cargo install cargo-hack --locked
-              cargo hack check --feature-powerset --no-dev-deps --workspace --exclude cuprate-fuzz
-              ;;
-            *)
-              ${{ env.CMD_HACK }}
-              ;;
-          esac
+        run: ${{ env.CMD_HACK }}
 
   # CI, runs cross-compiled targets under emulation.
   ci-cross:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,7 +118,6 @@ jobs:
       matrix:
         os: [
             { name: freebsd, architecture: x86_64, version: "15.1" },
-            { name: openbsd, architecture: x86_64, version: "7.9" },
         ]
 
     defaults:
@@ -146,9 +145,6 @@ jobs:
       - name: Install dependencies
         run: |
           case "${{ matrix.os.name }}" in
-            openbsd)
-              sudo pkg_add cmake git gmake rust
-              ;;
             freebsd)
               sudo pkg install -y cmake curl git gmake
               ;;
@@ -161,9 +157,7 @@ jobs:
           sudo ln -s "$HOME"/.cargo/bin/* /usr/local/bin/
 
       - name: Build
-        run: |
-          [ "${{ matrix.os.name }}" != openbsd ] || ulimit -Sd 4194304
-          cargo build --release --package cuprated
+        run: cargo build --release --package cuprated
 
       - name: Generate Archive
         shell: cpa.sh {0} --sync-files vm-to-runner
@@ -181,15 +175,7 @@ jobs:
 
           # Generate the asset name.
           readonly TARGET=$(rustc -vV | sed -n 's/^host: //p')
-          case "${{ matrix.os.name }}" in
-            # OpenBSD does not keep binary compatibility between releases.
-            openbsd)
-              readonly ASSET="cuprated-$VERSION-${TARGET}$(uname -r).tar.gz"
-              ;;
-            *)
-              readonly ASSET="cuprated-$VERSION-$TARGET.tar.gz"
-              ;;
-          esac
+          readonly ASSET="cuprated-$VERSION-$TARGET.tar.gz"
 
           # Generate archive for BSD.
           cp LICENSE-AGPL target/release/LICENSE

--- a/books/user/src/platform.md
+++ b/books/user/src/platform.md
@@ -31,7 +31,6 @@ Tier 2 targets can be thought of as "guaranteed to build".
 |------------------------------|--------|
 | `x86_64-unknown-linux-musl`  | x64 Linux (musl 1.2.3)
 | `x86_64-unknown-freebsd` 	   | x64 FreeBSD
-| `x86_64-unknown-openbsd`     | x64 OpenBSD (7.9+)
 | `riscv64gc-unknown-linux-gnu`  | RISC-V 64 Linux (glibc 2.36+)
 
 ## Tier 3
@@ -46,3 +45,4 @@ Official builds are not available, but may eventually be planned.
 | `aarch64-pc-windows-msvc`      | ARM64 Windows (MSVC, Windows 11+)
 | `aarch64-unknown-linux-musl`   | ARM64 Linux (musl 1.2.3)
 | `riscv64gc-unknown-linux-musl` | RISC-V 64 Linux (musl 1.2.3)
+| `x86_64-unknown-openbsd`       | x64 OpenBSD (7.9+)


### PR DESCRIPTION
OpenBSD doesn't reliably pass tests in the CPA VM due to environment related problems

Still builds and runs just fine, but we can't have CI that only passes 10% of the time