### PR TITLE
ci: publish Docker images to GHCR

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,262 @@
+# Publish official `cuprated` images to GHCR.
+#
+# `main` / dispatch-on-main → `nightly` + short SHA
+# `cuprated-<version>` tags → `<version>` + `latest` + short SHA
+# PRs that touch the Dockerfile or this workflow build amd64 only and do not push.
+
+name: Docker
+
+on:
+  push:
+    branches: [main]
+    tags: ["cuprated-*"]
+  pull_request:
+    paths:
+      - Dockerfile
+      - .github/workflows/docker.yml
+  workflow_dispatch:
+
+# Tags must finish; a second release tag queues.
+# `main` and PRs cancel older runs so a stale `main` build cannot overwrite `nightly`.
+concurrency:
+  group: ${{ startsWith(github.ref, 'refs/tags/cuprated-') && 'docker-release' || format('docker-{0}', github.ref) }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/cuprated-') }}
+
+env:
+  IMAGE: ghcr.io/cuprate/cuprated
+
+permissions:
+  contents: read
+
+jobs:
+  # Pull requests: amd64 only, no registry login, no push.
+  pr:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 90
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Expected commit
+        id: commit
+        run: |
+          set -euo pipefail
+          EXPECTED="$(git rev-parse HEAD)"
+          if [[ ! "$EXPECTED" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "expected commit is not a 40-character hex hash: $EXPECTED" >&2
+            exit 1
+          fi
+          echo "sha=$EXPECTED" >> "$GITHUB_OUTPUT"
+          echo "created=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
+        with:
+          images: cuprated
+          tags: |
+            type=raw,value=testing
+          labels: |
+            org.opencontainers.image.title=cuprated
+            org.opencontainers.image.description=Official Cuprate Monero node image
+            org.opencontainers.image.url=https://github.com/Cuprate/cuprate
+            org.opencontainers.image.source=https://github.com/Cuprate/cuprate
+            org.opencontainers.image.licenses=AGPL-3.0
+            org.opencontainers.image.revision=${{ steps.commit.outputs.sha }}
+            org.opencontainers.image.version=testing
+
+      - name: Build
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64
+          push: false
+          load: true
+          tags: cuprated:testing
+          labels: ${{ steps.meta.outputs.labels }}
+          provenance: false
+          sbom: false
+          build-args: |
+            GITHUB_SHA=${{ steps.commit.outputs.sha }}
+            BUILD_DATE=${{ steps.commit.outputs.created }}
+            VCS_REF=${{ steps.commit.outputs.sha }}
+            VERSION=testing
+          cache-from: type=gha,scope=build-amd64
+
+      - name: Smoke test
+        env:
+          IMG: cuprated:testing
+          EXPECTED: ${{ steps.commit.outputs.sha }}
+        run: |
+          set -euo pipefail
+          json="$(docker run --rm "$IMG" --version)"
+          echo "$json"
+          commit="$(echo "$json" | jq -r .commit)"
+          if [ "$commit" != "$EXPECTED" ]; then
+            echo "commit mismatch: got $commit want $EXPECTED" >&2
+            exit 1
+          fi
+
+  # Push to main, cuprated-* tags, and workflow_dispatch: one image per architecture.
+  build:
+    if: github.event_name != 'pull_request'
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 90
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            arch: amd64
+            runner: ubuntu-24.04
+          - platform: linux/arm64
+            arch: arm64
+            runner: ubuntu-24.04-arm
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Expected commit
+        id: commit
+        run: |
+          set -euo pipefail
+          EXPECTED="$(git rev-parse HEAD)"
+          if [[ ! "$EXPECTED" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "expected commit is not a 40-character hex hash: $EXPECTED" >&2
+            exit 1
+          fi
+          echo "sha=$EXPECTED" >> "$GITHUB_OUTPUT"
+          echo "created=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
+          if [[ "$GITHUB_REF" == refs/tags/cuprated-* ]]; then
+            echo "version=${GITHUB_REF#refs/tags/cuprated-}" >> "$GITHUB_OUTPUT"
+          elif [ "$GITHUB_REF" = "refs/heads/main" ]; then
+            echo "version=nightly" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Log in to GHCR
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
+        with:
+          images: ${{ env.IMAGE }}
+          tags: |
+            type=raw,value=${{ steps.commit.outputs.sha }}-${{ matrix.arch }}
+          labels: |
+            org.opencontainers.image.title=cuprated
+            org.opencontainers.image.description=Official Cuprate Monero node image
+            org.opencontainers.image.url=https://github.com/Cuprate/cuprate
+            org.opencontainers.image.source=https://github.com/Cuprate/cuprate
+            org.opencontainers.image.licenses=AGPL-3.0
+            org.opencontainers.image.revision=${{ steps.commit.outputs.sha }}
+            org.opencontainers.image.version=${{ steps.commit.outputs.version }}
+
+      - name: Build and push
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: ${{ matrix.platform }}
+          push: true
+          tags: ${{ env.IMAGE }}:${{ steps.commit.outputs.sha }}-${{ matrix.arch }}
+          labels: ${{ steps.meta.outputs.labels }}
+          provenance: false
+          sbom: false
+          build-args: |
+            GITHUB_SHA=${{ steps.commit.outputs.sha }}
+            BUILD_DATE=${{ steps.commit.outputs.created }}
+            VCS_REF=${{ steps.commit.outputs.sha }}
+            VERSION=${{ steps.commit.outputs.version }}
+          cache-from: type=gha,scope=build-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=build-${{ matrix.arch }}
+
+      - name: Smoke test
+        env:
+          IMG: ${{ env.IMAGE }}:${{ steps.commit.outputs.sha }}-${{ matrix.arch }}
+          EXPECTED: ${{ steps.commit.outputs.sha }}
+        run: |
+          set -euo pipefail
+          docker pull "$IMG"
+          json="$(docker run --rm "$IMG" --version)"
+          echo "$json"
+          commit="$(echo "$json" | jq -r .commit)"
+          if [ "$commit" != "$EXPECTED" ]; then
+            echo "commit mismatch: got $commit want $EXPECTED" >&2
+            exit 1
+          fi
+
+  # Promote multi-arch tags only after both architectures smoke-test clean.
+  merge:
+    if: github.event_name != 'pull_request' && success()
+    needs: [build]
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Expected commit
+        id: commit
+        run: |
+          set -euo pipefail
+          EXPECTED="$(git rev-parse HEAD)"
+          if [[ ! "$EXPECTED" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "expected commit is not a 40-character hex hash: $EXPECTED" >&2
+            exit 1
+          fi
+          echo "sha=$EXPECTED" >> "$GITHUB_OUTPUT"
+          echo "short_sha=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Log in to GHCR
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Merge manifests
+        env:
+          EXPECTED: ${{ steps.commit.outputs.sha }}
+          SHORT_SHA: ${{ steps.commit.outputs.short_sha }}
+        run: |
+          set -euo pipefail
+          tags=(-t "${IMAGE}:${SHORT_SHA}")
+          if [ "$GITHUB_REF" = "refs/heads/main" ]; then
+            tags+=(-t "${IMAGE}:nightly")
+          fi
+          if [[ "$GITHUB_REF" == refs/tags/cuprated-* ]]; then
+            version="${GITHUB_REF#refs/tags/cuprated-}"
+            tags+=(-t "${IMAGE}:${version}" -t "${IMAGE}:latest")
+          fi
+          docker buildx imagetools create \
+            "${tags[@]}" \
+            "${IMAGE}:${EXPECTED}-amd64" \
+            "${IMAGE}:${EXPECTED}-arm64"

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,9 @@ WORKDIR /cuprate
 COPY . .
 
 ARG FEATURES="jemalloc"
+# Embedded by constants/build.rs into `cuprated --version`. Not copied into scratch.
+ARG GITHUB_SHA
+ENV GITHUB_SHA=$GITHUB_SHA
 
 # Persist the registry and target file across builds. See: https://docs.docker.com/build/cache/optimize/#use-cache-mounts
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
@@ -23,7 +26,18 @@ RUN mkdir -p /skel/.local/share/cuprate \
 # Runtime stage
 FROM scratch
 
-LABEL org.opencontainers.image.source="https://github.com/Cuprate/cuprate"
+ARG BUILD_DATE
+ARG VCS_REF
+ARG VERSION
+
+LABEL org.opencontainers.image.title="cuprated" \
+      org.opencontainers.image.description="Official Cuprate Monero node image" \
+      org.opencontainers.image.url="https://github.com/Cuprate/cuprate" \
+      org.opencontainers.image.source="https://github.com/Cuprate/cuprate" \
+      org.opencontainers.image.licenses="AGPL-3.0" \
+      org.opencontainers.image.created="${BUILD_DATE}" \
+      org.opencontainers.image.revision="${VCS_REF}" \
+      org.opencontainers.image.version="${VERSION}"
 
 COPY --from=builder /passwd /etc/passwd
 COPY --from=builder /group  /etc/group

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ _(work-in-progress)_
 - [About](#about)
 - [Books](#books)
 - [Build](#build)
+- [Docker](#docker)
 - [Crates](#crates)
 - [Contributing](#contributing)
 - [Security](#security)
@@ -43,6 +44,23 @@ Cuprate maintains various documentation books:
 ## Build
 
 To build Cuprate from source code, see <https://user.cuprate.org/getting-started/source.html>.
+
+## Docker
+
+Official `cuprated` images (`linux/amd64` and `linux/arm64`) are published at [`ghcr.io/cuprate/cuprated`](https://github.com/Cuprate/cuprate/pkgs/container/cuprated).
+
+| Tag | Source |
+|-----|--------|
+| `nightly` | Latest `main` |
+| `<version>` | Git tag `cuprated-<version>` |
+| `latest` | Same as the latest `<version>` |
+
+A `main` build never writes `latest`. The image is built from the [`Dockerfile`](Dockerfile) in this repository.
+
+```bash
+docker pull ghcr.io/cuprate/cuprated:0.1.0-preview
+docker run --rm ghcr.io/cuprate/cuprated:0.1.0-preview --version
+```
 
 ## Crates
 For a detailed list of all crates, see: <https://architecture.cuprate.org/appendix/crates.html>.

--- a/constants/build.rs
+++ b/constants/build.rs
@@ -7,22 +7,12 @@ fn set_commit_env() {
     const PATH: &str = "../.git/refs/heads/";
 
     println!("cargo:rerun-if-changed={PATH}");
+    println!("cargo:rerun-if-env-changed=GITHUB_SHA");
 
-    let commit = if let Ok(t) = std::env::var("GITHUB_SHA") {
-        t
-    } else {
-        // FIXME: This could also be `std::fs::read({PATH}/{branch})`
-        // so the machine building doesn't need `git`, although:
-        // 1. Having `git` as a build dependency is probably ok
-        // 2. It causes issues on PRs that aren't the `main` branch
-        String::from_utf8(
-            std::process::Command::new("git")
-                .args(["show", "-s", "--format=%H"])
-                .output()
-                .unwrap()
-                .stdout,
-        )
-        .unwrap()
+    // Docker ARG/ENV without --build-arg is an empty string, not unset.
+    let commit = match std::env::var("GITHUB_SHA") {
+        Ok(t) if !t.trim().is_empty() => t,
+        _ => git_head_commit(),
     }
     .trim()
     .to_lowercase();
@@ -34,4 +24,20 @@ fn set_commit_env() {
     );
 
     println!("cargo:rustc-env=COMMIT={commit}");
+}
+
+/// Resolve `HEAD` via `git`. Used when `GITHUB_SHA` is missing or empty.
+fn git_head_commit() -> String {
+    // FIXME: This could also be `std::fs::read({PATH}/{branch})`
+    // so the machine building doesn't need `git`, although:
+    // 1. Having `git` as a build dependency is probably ok
+    // 2. It causes issues on PRs that aren't the `main` branch
+    String::from_utf8(
+        std::process::Command::new("git")
+            .args(["show", "-s", "--format=%H"])
+            .output()
+            .unwrap()
+            .stdout,
+    )
+    .unwrap()
 }


### PR DESCRIPTION
### What

Build the existing Dockerfile on `main` and on `cuprated-*` tags, and publish `ghcr.io/cuprate/cuprated`.

| Event | Tags written |
| --- | --- |
| Push or `workflow_dispatch` on `main` | `nightly`, short SHA |
| Git tag `cuprated-<version>` | `<version>`, `latest`, short SHA |
| PR that touches `Dockerfile` or this workflow | none (local `cuprated:testing` only) |

A `main` build never writes `latest`.

### Why

`cuprated` already has an in-tree Dockerfile. This adds a workflow so official images are built from the same tree and published to GHCR.

### Where

- `.github/workflows/docker.yml` (new)
- `Dockerfile` (builder `GITHUB_SHA`, OCI labels)
- `constants/build.rs` (treat empty `GITHUB_SHA` as unset; rebuild when it changes)

### How

`git rev-parse HEAD` after checkout is the commit used for `GITHUB_SHA` and for the smoke test. That avoids annotated-tag objects, which `cuprated` rejects because they are not a 40-character commit.

Per-arch jobs (`linux/amd64` on `ubuntu-24.04`, `linux/arm64` on `ubuntu-24.04-arm`) push only `<commit>-amd64` / `<commit>-arm64`. After both pass `docker run --rm "$IMG" --version` (`.commit` must match the expected commit), a merge job writes the multi-arch tags with `docker buildx imagetools create`. A failed arch smoke test leaves the previous `nightly` / version / `latest` tags in place.

Actions in the new workflow are pinned to release SHAs. Existing workflows are unchanged.

### Maintainer note: first GHCR publish

The workflow can **publish** the image. It cannot make that image **publicly pullable**. Package visibility is a GitHub Packages setting, not a workflow input, and it is independent of this repository being public.

The first successful push **creates** the `cuprated` container package under the Cuprate org (`ghcr.io/cuprate/cuprated`). GitHub’s default for a new container package is **private**. Until an org owner or package admin changes that:

- This workflow can still push (`packages: write` + `GITHUB_TOKEN`).
- Anonymous `docker pull ghcr.io/cuprate/cuprated:nightly` fails.
- Only people with package read access can pull.

To make the official image public (one-time):

1. After the first green `main` run, open the [org package](https://github.com/orgs/Cuprate/packages/container/package/cuprated). It may only appear under the org’s **private** packages list at first.
2. Package settings → Change visibility → Public.

Later pushes reuse the same package. Visibility stays public.
