### PR TITLE
cuprated: use NonZeroUsize in tokio thread config

### DIFF
--- a/binaries/cuprated/src/config/tokio.rs
+++ b/binaries/cuprated/src/config/tokio.rs
@@ -1,3 +1,5 @@
+use std::num::NonZeroUsize;
+
 use serde::{Deserialize, Serialize};
 
 use super::macros::config_struct;
@@ -13,14 +15,14 @@ config_struct! {
         /// Type         | Number
         /// Valid values | >= 1
         /// Examples     | 1, 8, 14
-        pub threads: usize,
+        pub threads: NonZeroUsize,
     }
 }
 
 impl Default for TokioConfig {
     fn default() -> Self {
         Self {
-            threads: cuprate_helper::thread::threads_75().get(),
+            threads: cuprate_helper::thread::threads_75(),
         }
     }
 }

--- a/binaries/cuprated/src/main.rs
+++ b/binaries/cuprated/src/main.rs
@@ -217,7 +217,7 @@ fn load_config(args: &Args) -> Config {
 /// Initialize the [`tokio`] runtime.
 fn init_tokio_rt(config: &Config) -> tokio::runtime::Runtime {
     tokio::runtime::Builder::new_multi_thread()
-        .worker_threads(config.tokio.threads)
+        .worker_threads(config.tokio.threads.get())
         .thread_name("cuprated-tokio")
         .enable_all()
         .build()


### PR DESCRIPTION
### What
use NonZeroUsize in the tokio config

### Why
So that the node fails with a parse error instead of a panic

### Where
cuprated