### PR TITLE
RPC: near-parity with JSON-RPC 2.0 specification

### DIFF
--- a/books/architecture/src/rpc/differences/json-rpc-strictness.md
+++ b/books/architecture/src/rpc/differences/json-rpc-strictness.md
@@ -102,12 +102,13 @@ Response:
 ```
 
 ## Responding to notifications
-> TODO: decide on Cuprate behavior <https://github.com/Cuprate/cuprate/pull/233#discussion_r1704611186>
-
 Requests that have no `id` field are "notifications".
 
 [The JSON-RPC 2.0 specification states that requests without
 an `id` field must _not_ be responded to](https://www.jsonrpc.org/specification#notification).
+
+`monerod` responds to them anyway. Cuprate follows the specification: the
+method still runs, but the response is an empty HTTP `200` body.
 
 Example:
 ```bash

--- a/rpc/interface/README.md
+++ b/rpc/interface/README.md
@@ -67,8 +67,7 @@ TODO: decide what this crate should return (per different endpoint)
 when a request is received to an unknown endpoint, including HTTP stuff, e.g. status code.
 
 # Unknown JSON-RPC method behavior
-TODO: decide what this crate returns when a `/json_rpc`
-request is received with an unknown method, including HTTP stuff, e.g. status code.
+An unknown method is answered with `-32601 Method not found` at HTTP `200`.
 
 # Example
 Example usage of this crate + starting an RPC server.
@@ -105,7 +104,7 @@ async fn get_height(port: u16) -> OtherResponse {
 async fn get_block_count(port: u16) -> String {
     let url = format!("http://127.0.0.1:{port}/json_rpc");
     let method = JsonRpcRequest::GetBlockCount(Default::default());
-    let request = Request::new(method);
+    let request = Request::new(Id::Num(0), method);
     ureq::get(&url)
         .set("Content-Type", "application/json")
         .send_json(request)
@@ -143,11 +142,11 @@ async fn main() {
 
     // Assert the response JSON is correct.
     let response = get_block_count(port).await;
-    let expected = r#"{"jsonrpc":"2.0","id":null,"result":{"status":"OK","untrusted":false,"count":0}}"#;
+    let expected = r#"{"jsonrpc":"2.0","id":0,"result":{"status":"OK","untrusted":false,"count":0}}"#;
     assert_eq!(response, expected);
 
     // Assert that (de)serialization works.
-    let expected = Response::ok(Id::Null, Default::default());
+    let expected = Response::ok(Id::Num(0), Default::default());
     let response: Response<GetBlockCountResponse> = serde_json::from_str(&response).unwrap();
     assert_eq!(response, expected);
 }

--- a/rpc/interface/src/route/json_rpc.rs
+++ b/rpc/interface/src/route/json_rpc.rs
@@ -2,17 +2,17 @@
 
 //---------------------------------------------------------------------------------------------------- Import
 use axum::{
-    body::Body,
-    extract::State,
-    http::{header::CONTENT_TYPE, StatusCode},
+    body::{Body, Bytes},
+    extract::{rejection::BytesRejection, State},
+    http::{header::CONTENT_TYPE, HeaderMap, StatusCode},
     response::{IntoResponse, Response},
-    Json,
 };
+use serde::Deserialize;
 use tower::ServiceExt;
 
-use cuprate_json_rpc::{Id, Response as JsonRpcResponse};
+use cuprate_json_rpc::{error::ErrorObject, Id, Response as JsonRpcResponse};
 use cuprate_rpc_types::{
-    json::{GetTxpoolBacklogResponse, JsonRpcRequest, JsonRpcResponse as RpcResponse},
+    json::{GetTxpoolBacklogResponse, JsonRpcMethod, JsonRpcResponse as RpcResponse},
     RpcCallValue,
 };
 
@@ -22,79 +22,166 @@ use crate::rpc_handler::RpcHandler;
 /// The `/json_rpc` route function used in [`crate::RouterBuilder`].
 pub(crate) async fn json_rpc<H: RpcHandler>(
     State(handler): State<H>,
-    Json(request): Json<cuprate_json_rpc::Request<JsonRpcRequest>>,
-) -> Result<Response, StatusCode> {
-    // TODO: <https://www.jsonrpc.org/specification#notification>
-    //
-    // JSON-RPC notifications (requests without `id`)
-    // must not be responded too, although, the request's side-effects
-    // must remain. How to do this considering this function will
-    // always return and cause `axum` to respond?
+    headers: HeaderMap,
+    request: Result<Bytes, BytesRejection>,
+) -> Response {
+    if !json_content_type(&headers) {
+        return StatusCode::UNSUPPORTED_MEDIA_TYPE.into_response();
+    }
 
-    // JSON-RPC 2.0 rule:
-    // If there was an error in detecting the `Request`'s ID,
-    // the `Response` must contain an `Id::Null`
-    let id = request.id.unwrap_or(Id::Null);
+    let request = match request {
+        Ok(request) => request,
+        Err(rejection) => return rejection.into_response(),
+    };
 
-    // Return early if this RPC server is restricted and
-    // the requested method is only for non-restricted RPC.
+    let Some(response) = dispatch(handler, &request).await else {
+        return StatusCode::OK.into_response();
+    };
+
+    let mut json = Vec::new();
+    let result = match &response.payload {
+        Ok(RpcResponse::GetTxpoolBacklog(body)) => {
+            serialize_txpool_backlog_response(&mut json, &response.id, body)
+        }
+        _ => serde_json::to_writer(&mut json, &response),
+    };
+
+    if result.is_err() {
+        json.clear();
+        serde_json::to_writer(
+            &mut json,
+            &JsonRpcResponse::<RpcResponse>::internal_error(response.id),
+        )
+        .expect("an error response always serializes");
+    }
+
+    Response::builder()
+        .header(CONTENT_TYPE, "application/json")
+        .body(Body::from(json))
+        .expect("valid response builder")
+}
+
+/// Handle a single request, returning its serialized response.
+///
+/// [`None`] if the request was a
+/// [notification](https://www.jsonrpc.org/specification#notification).
+async fn dispatch<H: RpcHandler>(handler: H, json: &[u8]) -> Option<JsonRpcResponse<RpcResponse>> {
+    let request = match serde_json::from_slice::<cuprate_json_rpc::Request<JsonRpcMethod>>(json) {
+        Ok(request) => request,
+        Err(error) if error.is_syntax() || error.is_eof() => {
+            return Some(JsonRpcResponse::parse_error(Id::Null));
+        }
+        Err(_) => {
+            // The request is malformed; recover its ID if it has a valid one, as per:
+            // <https://www.jsonrpc.org/specification#response_object>
+            #[derive(Deserialize)]
+            struct RequestId {
+                id: Id,
+            }
+
+            let id =
+                serde_json::from_slice::<RequestId>(json).map_or(Id::Null, |request| request.id);
+
+            return Some(JsonRpcResponse::invalid_request(id));
+        }
+    };
+
+    // A method that is only for non-restricted RPC is answered as if it did
+    // not exist, so a restricted server does not leak which methods exist.
     //
     // INVARIANT:
-    // The RPC handler functions in `cuprated` depend on this line existing,
+    // The RPC handler functions in `cuprated` depend on this check existing,
     // the functions themselves do not check if they are being called
-    // from an (un)restricted context. This line must be here or all
-    // methods will be allowed to be called freely.
-    if request.body.is_restricted() && handler.is_restricted() {
+    // from an (un)restricted context. This must be here or all methods will
+    // be allowed to be called freely, including by omitting `id`.
+    let method = match request.body {
         // The error when a restricted JSON-RPC method is called as per:
         //
         // - <https://github.com/monero-project/monero/blob/893916ad091a92e765ce3241b94e706ad012b62a/contrib/epee/include/net/http_server_handlers_map2.h#L244-L252>
         // - <https://github.com/monero-project/monero/blob/cc73fe71162d564ffda8e549b79a350bca53c454/src/rpc/core_rpc_server.h#L188>
-        return Ok(Json(JsonRpcResponse::<RpcResponse>::method_not_found(id)).into_response());
-    }
-
-    // Send request.
-    let Ok(response) = handler.oneshot(request.body).await else {
-        return Err(StatusCode::INTERNAL_SERVER_ERROR);
+        JsonRpcMethod::Known(body) if handler.is_restricted() && body.is_restricted() => {
+            Err(ErrorObject::method_not_found())
+        }
+        JsonRpcMethod::InvalidParams { restricted: true } if handler.is_restricted() => {
+            Err(ErrorObject::method_not_found())
+        }
+        JsonRpcMethod::Known(body) => Ok(body),
+        JsonRpcMethod::Unknown => Err(ErrorObject::method_not_found()),
+        JsonRpcMethod::InvalidParams { .. } => Err(ErrorObject::invalid_params()),
     };
 
-    if let RpcResponse::GetTxpoolBacklog(response) = &response {
-        return txpool_backlog_response(&id, response);
+    // JSON-RPC 2.0 rule:
+    // <https://www.jsonrpc.org/specification#notification>
+    //
+    // JSON-RPC notifications (requests without `id`) must not be responded to,
+    // although their side-effects must remain, so the request is still sent.
+    match request.id {
+        None => {
+            if let Ok(body) = method {
+                drop(handler.oneshot(body).await);
+            }
+            None
+        }
+        Some(id) => Some(match method {
+            Err(error) => JsonRpcResponse::err(id, error),
+            Ok(body) => match handler.oneshot(body).await {
+                Ok(response) => JsonRpcResponse::ok(id, response),
+                Err(_) => JsonRpcResponse::internal_error(id),
+            },
+        }),
+    }
+}
+
+/// Whether the request has a JSON media type.
+fn json_content_type(headers: &HeaderMap) -> bool {
+    let Some(value) = headers.get(CONTENT_TYPE) else {
+        return false;
+    };
+
+    let value = value.as_bytes();
+
+    // Nearly every client sends exactly this.
+    if value == b"application/json" {
+        return true;
     }
 
-    Ok(Json(JsonRpcResponse::ok(id, response)).into_response())
+    // Ignore any `;` parameters, e.g. `application/json; charset=utf-8`.
+    let media_type = match value.iter().position(|&b| b == b';') {
+        Some(i) => &value[..i],
+        None => value,
+    }
+    .trim_ascii();
+
+    let Some((prefix, subtype)) = media_type.split_at_checked("application/".len()) else {
+        return false;
+    };
+
+    prefix.eq_ignore_ascii_case(b"application/")
+        && !subtype.contains(&b'/')
+        && (subtype.eq_ignore_ascii_case(b"json")
+            || subtype.len() > "+json".len()
+                && subtype[subtype.len() - "+json".len()..].eq_ignore_ascii_case(b"+json"))
 }
 
 // TODO: remove the code below once this: https://github.com/monero-project/monero/issues/9422 is resolved.
 
-/// Build a Monero-compatible `get_txpool_backlog` response.
-fn txpool_backlog_response(
-    id: &Id,
-    response: &GetTxpoolBacklogResponse,
-) -> Result<Response, StatusCode> {
-    let body = serialize_txpool_backlog_response(id, response)
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-
-    Ok(Response::builder()
-        .header(CONTENT_TYPE, "application/json")
-        .body(Body::from(body))
-        .expect("valid response builder"))
-}
-
 /// Serialize the backlog's POD container as a binary JSON string.
 fn serialize_txpool_backlog_response(
+    json: &mut Vec<u8>,
     id: &Id,
     response: &GetTxpoolBacklogResponse,
-) -> serde_json::Result<Vec<u8>> {
-    let mut json = [
+) -> serde_json::Result<()> {
+    json.extend_from_slice(
         br#"{
             "jsonrpc":"2.0",
             "id":"#,
-        serde_json::to_string(&id)?.as_bytes(),
+    );
+    serde_json::to_writer(&mut *json, id)?;
+    json.extend_from_slice(
         br#",
             "result":"#,
-        serde_json::to_string(&response.base)?.as_bytes(),
-    ]
-    .concat();
+    );
+    serde_json::to_writer(&mut *json, &response.base)?;
 
     if !response.backlog.is_empty() {
         // Reopen `result` to append the field that serde cannot represent.
@@ -102,12 +189,12 @@ fn serialize_txpool_backlog_response(
             unreachable!("response base must serialize as a JSON object");
         };
         json.extend_from_slice(br#","backlog":"#);
-        write_binary_string(&mut json, &txpool_backlog_blob(response));
+        write_binary_string(json, &txpool_backlog_blob(response));
         json.push(b'}');
     }
 
     json.push(b'}');
-    Ok(json)
+    Ok(())
 }
 
 fn txpool_backlog_blob(response: &GetTxpoolBacklogResponse) -> Vec<u8> {

--- a/rpc/json-rpc/README.md
+++ b/rpc/json-rpc/README.md
@@ -51,7 +51,7 @@ enum Methods {
 }
 
 // Create the request object.
-let request = Request::new_with_id(
+let request = Request::new(
     Id::Str("hello".into()),
     Methods::GetBlock(GetBlock { height: 123 }),
 );

--- a/rpc/json-rpc/src/id.rs
+++ b/rpc/json-rpc/src/id.rs
@@ -1,7 +1,7 @@
 //! [`Id`]: request/response identification.
 
 //---------------------------------------------------------------------------------------------------- Use
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use std::borrow::Cow;
 
 //---------------------------------------------------------------------------------------------------- Id
@@ -119,6 +119,27 @@ impl Id {
     /// ```
     pub fn is_null(&self) -> bool {
         *self == Self::Null
+    }
+
+    /// Deserialize an [`Id`] into [`Some`], including [`Id::Null`].
+    ///
+    /// `#[serde(default)]` preserves an absent ID as [`None`].
+    ///
+    /// ```rust
+    /// # use cuprate_json_rpc::Id;
+    /// # use serde::Deserialize;
+    /// #[derive(Deserialize)]
+    /// struct Request {
+    ///     #[serde(default, deserialize_with = "Id::deserialize_some")]
+    ///     id: Option<Id>,
+    /// }
+    /// assert_eq!(serde_json::from_str::<Request>(r#"{"id":null}"#).unwrap().id, Some(Id::Null));
+    /// assert_eq!(serde_json::from_str::<Request>(r#"{}"#).unwrap().id, None);
+    /// ```
+    pub fn deserialize_some<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<Option<Self>, D::Error> {
+        Self::deserialize(deserializer).map(Some)
     }
 
     /// Create a new [`Id::Str`] from a static string.

--- a/rpc/json-rpc/src/request.rs
+++ b/rpc/json-rpc/src/request.rs
@@ -17,16 +17,18 @@ pub struct Request<T> {
 
     /// An identifier established by the Client.
     ///
-    /// If it is not included it is assumed to be a
+    /// If the `id` field is not included, the request is a
     /// [notification](https://www.jsonrpc.org/specification#notification).
     ///
     /// ### `None` vs `Some(Id::Null)`
     /// This field will be completely omitted during serialization if [`None`],
-    /// however if it is `Some(Id::Null)`, it will be serialized as `"id": null`.
+    /// however if it is `Some(Id::Null)`, it will be serialized as `"id": null`
+    /// and is not a notification.
     ///
-    /// Note that the JSON-RPC 2.0 specification discourages the use of `Id::NUll`,
-    /// so if there is no ID needed, consider using `None`.
+    /// Note that the JSON-RPC 2.0 specification discourages the use of [`Id::Null`],
+    /// so use [`None`] for notifications.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, deserialize_with = "Id::deserialize_some")]
     pub id: Option<Id>,
 
     #[serde(flatten)]
@@ -44,32 +46,35 @@ pub struct Request<T> {
 }
 
 impl<T> Request<T> {
-    /// Create a new [`Self`] with no [`Id`].
-    ///
-    /// ```rust
-    /// use cuprate_json_rpc::Request;
-    ///
-    /// assert_eq!(Request::new("").id, None);
-    /// ```
-    pub const fn new(body: T) -> Self {
-        Self {
-            jsonrpc: Version,
-            id: None,
-            body,
-        }
-    }
-
     /// Create a new [`Self`] with an [`Id`].
     ///
     /// ```rust
     /// use cuprate_json_rpc::{Id, Request};
     ///
-    /// assert_eq!(Request::new_with_id(Id::Num(0), "").id, Some(Id::Num(0)));
+    /// assert_eq!(Request::new(Id::Num(0), "").id, Some(Id::Num(0)));
     /// ```
-    pub const fn new_with_id(id: Id, body: T) -> Self {
+    pub const fn new(id: Id, body: T) -> Self {
         Self {
             jsonrpc: Version,
             id: Some(id),
+            body,
+        }
+    }
+
+    /// Create a new [`Self`] with no [`Id`], i.e. a
+    /// [notification](https://www.jsonrpc.org/specification#notification).
+    ///
+    /// A conforming server will not respond to this.
+    ///
+    /// ```rust
+    /// use cuprate_json_rpc::Request;
+    ///
+    /// assert_eq!(Request::notification("").id, None);
+    /// ```
+    pub const fn notification(body: T) -> Self {
+        Self {
+            jsonrpc: Version,
+            id: None,
             body,
         }
     }
@@ -81,8 +86,8 @@ impl<T> Request<T> {
     /// ```rust
     /// use cuprate_json_rpc::{Id, Request};
     ///
-    /// assert!(Request::new("").is_notification());
-    /// assert!(!Request::new_with_id(Id::Null, "").is_notification());
+    /// assert!(Request::notification("").is_notification());
+    /// assert!(!Request::new(Id::Null, "").is_notification());
     /// ```
     pub const fn is_notification(&self) -> bool {
         self.id.is_none()
@@ -123,7 +128,7 @@ mod test {
             params: [0, 1, 2],
         };
 
-        let req = Request::new_with_id(id, body);
+        let req = Request::new(id, body);
 
         assert!(!req.is_notification());
 
@@ -145,7 +150,7 @@ mod test {
             params: [0, 1, 2],
         };
 
-        let req = Request::new_with_id(id, body);
+        let req = Request::new(id, body);
 
         let ser: String = serde_json::to_string(&req).unwrap();
         assert_eq!(
@@ -161,7 +166,7 @@ mod test {
     /// Tests that null `id` shows when serializing.
     #[test]
     fn request_null_id() {
-        let req = Request::new_with_id(
+        let req = Request::new(
             Id::Null,
             Body {
                 method: "m".into(),
@@ -181,7 +186,7 @@ mod test {
     /// Tests that a `None` `id` omits the field when serializing.
     #[test]
     fn request_none_id() {
-        let req = Request::new(Body {
+        let req = Request::notification(Body {
             method: "a".into(),
             params: "b".to_string(),
         });
@@ -202,7 +207,7 @@ mod test {
             method: String,
         }
 
-        let req = Request::new_with_id(
+        let req = Request::new(
             Id::Num(123),
             NoParamMethod {
                 method: "asdf".to_string(),
@@ -232,7 +237,7 @@ mod test {
             GetHeight(/* param: */ GetHeight),
         }
 
-        let req = Request::new_with_id(Id::Num(123), Methods::GetHeight(GetHeight { height: 0 }));
+        let req = Request::new(Id::Num(123), Methods::GetHeight(GetHeight { height: 0 }));
         let json = json!({
             "jsonrpc": "2.0",
             "id": 123,
@@ -251,7 +256,7 @@ mod test {
         // Test values: (request, expected_value)
         let array: [(Request<Body<[u8; 3]>>, Value); 3] = [
             (
-                Request::new_with_id(
+                Request::new(
                     Id::Num(123),
                     Body {
                         method: "method_1".into(),
@@ -266,7 +271,7 @@ mod test {
                 }),
             ),
             (
-                Request::new_with_id(
+                Request::new(
                     Id::Null,
                     Body {
                         method: "method_2".into(),
@@ -281,7 +286,7 @@ mod test {
                 }),
             ),
             (
-                Request::new_with_id(
+                Request::new(
                     Id::Str("string_id".into()),
                     Body {
                         method: "method_3".into(),
@@ -305,7 +310,7 @@ mod test {
     /// Tests that non-ordered fields still deserialize okay.
     #[test]
     fn deserialize_out_of_order_keys() {
-        let expected = Request::new_with_id(
+        let expected = Request::new(
             Id::Str("id".into()),
             Body {
                 method: "method".into(),
@@ -328,7 +333,7 @@ mod test {
     /// Also that unicode and backslashes work.
     #[test]
     fn unknown_fields_and_unicode() {
-        let expected = Request::new_with_id(
+        let expected = Request::new(
             Id::Str("id".into()),
             Body {
                 method: "method".into(),

--- a/rpc/json-rpc/src/tests.rs
+++ b/rpc/json-rpc/src/tests.rs
@@ -85,7 +85,7 @@ fn monero_jsonrpc_get_block() {
     //--- Request
     const REQUEST: &str =
         r#"{"jsonrpc":"2.0","id":"0","method":"get_block","params":{"height":123}}"#;
-    let request = Request::new_with_id(
+    let request = Request::new(
         Id::Str("0".into()),
         Methods::GetBlock(GetBlock { height: 123 }),
     );
@@ -215,7 +215,7 @@ fn monero_jsonrpc_get_block() {
 fn monero_jsonrpc_get_block_count() {
     //--- Request
     const REQUEST: &str = r#"{"jsonrpc":"2.0","id":0,"method":"get_block_count"}"#;
-    let request = Request::new_with_id(Id::Num(0), Methods::GetBlockCount);
+    let request = Request::new(Id::Num(0), Methods::GetBlockCount);
     assert_ser_string(&request, REQUEST);
     assert_de(REQUEST, request);
 

--- a/rpc/types/src/json.rs
+++ b/rpc/types/src/json.rs
@@ -789,10 +789,45 @@ pub enum JsonRpcRequest {
     GetTxIdsLoose(GetTxIdsLooseRequest),
 }
 
+//---------------------------------------------------------------------------------------------------- Method
+/// Parsed JSON-RPC methods.
+///
+/// A method is known, unknown, or has invalid parameters.
+#[cfg(feature = "serde")]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum JsonRpcMethod {
+    /// A method that exists.
+    Known(JsonRpcRequest),
+
+    /// A method that does not exist.
+    Unknown,
+
+    /// A known method whose parameters could not be decoded.
+    InvalidParams {
+        /// Whether the method is unavailable on restricted RPC servers.
+        restricted: bool,
+    },
+}
+
 #[cfg(feature = "serde")]
 impl<'de> Deserialize<'de> for JsonRpcRequest {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use serde::de::Error;
+
+        match JsonRpcMethod::deserialize(deserializer)? {
+            JsonRpcMethod::Known(request) => Ok(request),
+            JsonRpcMethod::Unknown => Err(D::Error::custom("unknown JSON-RPC method")),
+            JsonRpcMethod::InvalidParams { .. } => {
+                Err(D::Error::custom("invalid JSON-RPC parameters"))
+            }
+        }
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> Deserialize<'de> for JsonRpcMethod {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        use JsonRpcRequest as Req;
 
         fn default_params() -> serde_json::Value {
             serde_json::Value::Object(Default::default())
@@ -816,59 +851,66 @@ impl<'de> Deserialize<'de> for JsonRpcRequest {
         // Deserialize `params` (a `serde_json::Value`) into the concrete request type.
         macro_rules! de {
             ($T:ty) => {
-                serde_json::from_value::<$T>(params).map_err(D::Error::custom)?
+                match serde_json::from_value::<$T>(params) {
+                    Ok(params) => params,
+                    Err(_) => {
+                        return Ok(Self::InvalidParams {
+                            restricted: <$T as crate::rpc_call::RpcCall>::IS_RESTRICTED,
+                        });
+                    }
+                }
             };
         }
 
-        Ok(match method.as_str() {
-            "get_block_count" | "getblockcount" => Self::GetBlockCount(de!(GetBlockCountRequest)),
+        Ok(Self::Known(match method.as_str() {
+            "get_block_count" | "getblockcount" => Req::GetBlockCount(de!(GetBlockCountRequest)),
             "on_get_block_hash" | "on_getblockhash" => {
-                Self::OnGetBlockHash(de!(OnGetBlockHashRequest))
+                Req::OnGetBlockHash(de!(OnGetBlockHashRequest))
             }
             "get_block_template" | "getblocktemplate" => {
-                Self::GetBlockTemplate(de!(GetBlockTemplateRequest))
+                Req::GetBlockTemplate(de!(GetBlockTemplateRequest))
             }
-            "get_miner_data" => Self::GetMinerData(de!(GetMinerDataRequest)),
-            "calc_pow" => Self::CalcPow(de!(CalcPowRequest)),
-            "add_aux_pow" => Self::AddAuxPow(de!(AddAuxPowRequest)),
-            "submit_block" | "submitblock" => Self::SubmitBlock(de!(SubmitBlockRequest)),
-            "generateblocks" => Self::GenerateBlocks(de!(GenerateBlocksRequest)),
+            "get_miner_data" => Req::GetMinerData(de!(GetMinerDataRequest)),
+            "calc_pow" => Req::CalcPow(de!(CalcPowRequest)),
+            "add_aux_pow" => Req::AddAuxPow(de!(AddAuxPowRequest)),
+            "submit_block" | "submitblock" => Req::SubmitBlock(de!(SubmitBlockRequest)),
+            "generateblocks" => Req::GenerateBlocks(de!(GenerateBlocksRequest)),
             "get_last_block_header" | "getlastblockheader" => {
-                Self::GetLastBlockHeader(de!(GetLastBlockHeaderRequest))
+                Req::GetLastBlockHeader(de!(GetLastBlockHeaderRequest))
             }
             "get_block_header_by_hash" | "getblockheaderbyhash" => {
-                Self::GetBlockHeaderByHash(de!(GetBlockHeaderByHashRequest))
+                Req::GetBlockHeaderByHash(de!(GetBlockHeaderByHashRequest))
             }
             "get_block_header_by_height" | "getblockheaderbyheight" => {
-                Self::GetBlockHeaderByHeight(de!(GetBlockHeaderByHeightRequest))
+                Req::GetBlockHeaderByHeight(de!(GetBlockHeaderByHeightRequest))
             }
             "get_block_headers_range" | "getblockheadersrange" => {
-                Self::GetBlockHeadersRange(de!(GetBlockHeadersRangeRequest))
+                Req::GetBlockHeadersRange(de!(GetBlockHeadersRangeRequest))
             }
-            "get_block" | "getblock" => Self::GetBlock(de!(GetBlockRequest)),
-            "get_connections" => Self::GetConnections(de!(GetConnectionsRequest)),
-            "get_info" => Self::GetInfo(de!(GetInfoRequest)),
-            "hard_fork_info" => Self::HardForkInfo(de!(HardForkInfoRequest)),
-            "set_bans" => Self::SetBans(de!(SetBansRequest)),
-            "get_bans" => Self::GetBans(de!(GetBansRequest)),
-            "banned" => Self::Banned(de!(BannedRequest)),
-            "flush_txpool" => Self::FlushTxpool(de!(FlushTxpoolRequest)),
-            "get_output_histogram" => Self::GetOutputHistogram(de!(GetOutputHistogramRequest)),
-            "get_version" => Self::GetVersion(de!(GetVersionRequest)),
-            "get_coinbase_tx_sum" => Self::GetCoinbaseTxSum(de!(GetCoinbaseTxSumRequest)),
-            "get_fee_estimate" => Self::GetFeeEstimate(de!(GetFeeEstimateRequest)),
-            "get_alternate_chains" => Self::GetAlternateChains(de!(GetAlternateChainsRequest)),
-            "relay_tx" => Self::RelayTx(de!(RelayTxRequest)),
-            "sync_info" => Self::SyncInfo(de!(SyncInfoRequest)),
-            "get_txpool_backlog" => Self::GetTxpoolBacklog(de!(GetTxpoolBacklogRequest)),
+            "get_block" | "getblock" => Req::GetBlock(de!(GetBlockRequest)),
+            "get_connections" => Req::GetConnections(de!(GetConnectionsRequest)),
+            "get_info" => Req::GetInfo(de!(GetInfoRequest)),
+            "hard_fork_info" => Req::HardForkInfo(de!(HardForkInfoRequest)),
+            "set_bans" => Req::SetBans(de!(SetBansRequest)),
+            "get_bans" => Req::GetBans(de!(GetBansRequest)),
+            "banned" => Req::Banned(de!(BannedRequest)),
+            "flush_txpool" => Req::FlushTxpool(de!(FlushTxpoolRequest)),
+            "get_output_histogram" => Req::GetOutputHistogram(de!(GetOutputHistogramRequest)),
+            "get_version" => Req::GetVersion(de!(GetVersionRequest)),
+            "get_coinbase_tx_sum" => Req::GetCoinbaseTxSum(de!(GetCoinbaseTxSumRequest)),
+            "get_fee_estimate" => Req::GetFeeEstimate(de!(GetFeeEstimateRequest)),
+            "get_alternate_chains" => Req::GetAlternateChains(de!(GetAlternateChainsRequest)),
+            "relay_tx" => Req::RelayTx(de!(RelayTxRequest)),
+            "sync_info" => Req::SyncInfo(de!(SyncInfoRequest)),
+            "get_txpool_backlog" => Req::GetTxpoolBacklog(de!(GetTxpoolBacklogRequest)),
             "get_output_distribution" => {
-                Self::GetOutputDistribution(de!(GetOutputDistributionRequest))
+                Req::GetOutputDistribution(de!(GetOutputDistributionRequest))
             }
-            "prune_blockchain" => Self::PruneBlockchain(de!(PruneBlockchainRequest)),
-            "flush_cache" => Self::FlushCache(de!(FlushCacheRequest)),
-            "get_tx_ids_loose" => Self::GetTxIdsLoose(de!(GetTxIdsLooseRequest)),
-            other => return Err(D::Error::unknown_variant(other, &[])),
-        })
+            "prune_blockchain" => Req::PruneBlockchain(de!(PruneBlockchainRequest)),
+            "flush_cache" => Req::FlushCache(de!(FlushCacheRequest)),
+            "get_tx_ids_loose" => Req::GetTxIdsLoose(de!(GetTxIdsLooseRequest)),
+            _ => return Ok(Self::Unknown),
+        }))
     }
 }
 


### PR DESCRIPTION
### What
Brings the RPC closer to compliance with the JSON-RPC 2.0 specification

Not implemented are support for negative ids and batch requests (#694). The latter _could_ be done after the rate limit changes in #685 

### Why
Correctness

### Where
`rpc`

### How
- Executes [notifications](https://www.jsonrpc.org/specification#notification) without returning a JSON-RPC response
- Distinguishes missing id from explicit `"id": null` 
- Returns `-32700 Parse error` for malformed JSON
- Returns `-32600 Invalid Request` for invalid request structures
- Returns `-32601 Method not found` for unknown methods
- Returns `-32602 Invalid params` for malformed method parameters
- Returns `-32603 Internal error` for internal failures
- Uses `"id": null` when the request ID cannot be determined