### PR TITLE
cuprated: allow batch writing full verification batches

### DIFF
--- a/binaries/cuprated/src/blockchain/manager/handler.rs
+++ b/binaries/cuprated/src/blockchain/manager/handler.rs
@@ -256,6 +256,7 @@ impl super::BlockchainManager {
         let mut verification_context =
             VerificationContext::<ConsensusBlockchainReadHandle>::BatchPrepareCache(output_cache);
         let mut valid_blocks = Vec::with_capacity(prepped_blocks.len());
+        let mut error = false;
 
         for (block, txs) in prepped_blocks {
             let hash = block.block_hash;
@@ -279,7 +280,8 @@ impl super::BlockchainManager {
 
                         batch.peer_handle.ban_peer(MEDIUM_BAN);
                         self.stop_current_block_downloader.notify_waiters();
-                        return Ok(());
+                        error = true;
+                        break;
                     }
                 },
             };
@@ -289,10 +291,20 @@ impl super::BlockchainManager {
 
             valid_blocks.push(verified_block);
         }
+
+        let valid_blocks_len = valid_blocks.len();
         self.batch_add_valid_block_to_blockchain_database(valid_blocks)
             .await?;
 
-        info!(fast_sync = false, "Successfully added block batch");
+        if error {
+            info!(
+                valid_blocks = valid_blocks_len,
+                fast_sync = false,
+                "Partially added block batch"
+            );
+        } else {
+            info!(fast_sync = false, "Successfully added block batch");
+        }
         Ok(())
     }
 

--- a/binaries/cuprated/src/blockchain/manager/handler.rs
+++ b/binaries/cuprated/src/blockchain/manager/handler.rs
@@ -19,6 +19,7 @@ use cuprate_consensus::{
     },
     transactions::new_tx_verification_data,
     BlockChainContextRequest, BlockChainContextResponse, ExtendedConsensusError,
+    VerificationContext,
 };
 use cuprate_consensus_context::{distribution::rct_output_count, BlockchainContext, NewBlockData};
 use cuprate_fast_sync::{block_to_verified_block_information, fast_sync_stop_height};
@@ -34,7 +35,7 @@ use cuprate_types::{
 use crate::{
     blockchain::{
         manager::commands::{BlockchainManagerCommand, IncomingBlockOk},
-        IncomingBlockError,
+        ConsensusBlockchainReadHandle, IncomingBlockError,
     },
     monitor::FatalError,
 };
@@ -252,14 +253,17 @@ impl super::BlockchainManager {
             }
         };
 
+        let mut verification_context =
+            VerificationContext::<ConsensusBlockchainReadHandle>::BatchPrepareCache(output_cache);
+        let mut valid_blocks = Vec::with_capacity(prepped_blocks.len());
+
         for (block, txs) in prepped_blocks {
             let hash = block.block_hash;
             let verified_block = match verify_prepped_main_chain_block(
                 block,
                 txs,
                 &mut self.blockchain_context_service,
-                self.blockchain_read_handle.clone(),
-                Some(&mut output_cache),
+                &mut verification_context,
             )
             .await
             {
@@ -280,9 +284,14 @@ impl super::BlockchainManager {
                 },
             };
 
-            self.add_valid_block_to_main_chain(verified_block, BlockSource::BatchSync)
+            self.add_valid_block_to_blockchain_cache(&verified_block)
                 .await?;
+
+            valid_blocks.push(verified_block);
         }
+        self.batch_add_valid_block_to_blockchain_database(valid_blocks)
+            .await?;
+
         info!(fast_sync = false, "Successfully added block batch");
         Ok(())
     }
@@ -633,8 +642,7 @@ impl super::BlockchainManager {
                 prepped_block,
                 prepped_txs,
                 &mut self.blockchain_context_service,
-                self.blockchain_read_handle.clone(),
-                None,
+                &mut VerificationContext::Database(self.blockchain_read_handle.clone()),
             )
             .await?;
 
@@ -779,8 +787,6 @@ enum AddAltBlock {
 enum BlockSource {
     /// A single incoming block. Will be announced to peers.
     Incoming,
-    /// A block from the block downloader's batch sync.
-    BatchSync,
     /// A block re-applied during a reorg.
     Reorg,
 }

--- a/binaries/cuprated/src/txpool/incoming_tx.rs
+++ b/binaries/cuprated/src/txpool/incoming_tx.rs
@@ -15,6 +15,7 @@ use cuprate_blockchain::service::BlockchainReadHandle;
 use cuprate_consensus::{
     transactions::{new_tx_verification_data, start_tx_verification, PrepTransactions},
     BlockChainContextRequest, BlockChainContextResponse, BlockchainContextService,
+    VerificationContext,
 };
 use cuprate_dandelion_tower::{
     pool::{DandelionPoolService, IncomingTxBuilder},
@@ -217,8 +218,7 @@ async fn handle_incoming_txs(
             context.top_hash,
             context.current_adjusted_timestamp_for_time_lock(),
             context.current_hf,
-            blockchain_read_handle,
-            None,
+            &mut VerificationContext::Database(blockchain_read_handle),
         )
         .verify()
         .await?;

--- a/consensus/src/block.rs
+++ b/consensus/src/block.rs
@@ -29,7 +29,9 @@ use cuprate_consensus_rules::{
     ConsensusError, HardFork,
 };
 
-use crate::{transactions::start_tx_verification, Database, ExtendedConsensusError};
+use crate::{
+    transactions::start_tx_verification, Database, ExtendedConsensusError, VerificationContext,
+};
 
 mod alt_block;
 mod batch_prepare;
@@ -294,7 +296,13 @@ where
     let ordered_txs = pull_ordered_transactions(&prepped_block.block, txs)
         .map_err(BlockVerificationError::valid_pow)?;
 
-    verify_prepped_main_chain_block(prepped_block, ordered_txs, context_svc, database, None).await
+    verify_prepped_main_chain_block(
+        prepped_block,
+        ordered_txs,
+        context_svc,
+        &mut VerificationContext::Database(database),
+    )
+    .await
 }
 
 /// Fully verify a block that has already been prepared using [`batch_prepare_main_chain_blocks`].
@@ -302,8 +310,7 @@ pub async fn verify_prepped_main_chain_block<D>(
     prepped_block: PreparedBlock,
     mut txs: Vec<TransactionVerificationData>,
     context_svc: &mut BlockchainContextService,
-    database: D,
-    batch_prep_cache: Option<&mut BatchPrepareCache>,
+    verification_context: &mut VerificationContext<D>,
 ) -> Result<VerifiedBlockInformation, BlockVerificationError>
 where
     D: Database + Clone + Send + 'static,
@@ -340,8 +347,7 @@ where
                 context.top_hash,
                 context.current_adjusted_timestamp_for_time_lock(),
                 context.current_hf,
-                database,
-                batch_prep_cache.as_deref(),
+                verification_context,
             )
             .verify()
             .await
@@ -394,7 +400,7 @@ where
         cumulative_difficulty: context.cumulative_difficulty + context.next_difficulty,
     };
 
-    if let Some(batch_prep_cache) = batch_prep_cache {
+    if let VerificationContext::BatchPrepareCache(batch_prep_cache) = verification_context {
         batch_prep_cache.output_cache.add_block_to_cache(&block);
     }
 

--- a/consensus/src/block/batch_prepare.rs
+++ b/consensus/src/block/batch_prepare.rs
@@ -29,9 +29,6 @@ use crate::{
 /// other blocks.
 pub struct BatchPrepareCache {
     pub(crate) output_cache: OutputCache,
-    /// [`true`] if all the key images in the batch have been checked for double spends in the batch and
-    /// the whole chain.
-    pub(crate) key_images_spent_checked: bool,
 }
 
 /// Batch prepares a list of blocks for verification.
@@ -214,11 +211,5 @@ pub async fn batch_prepare_main_chain_blocks<D: Database>(
     let output_cache =
         get_output_cache(blocks.iter().flat_map(|(_, txs)| txs.iter()), database).await?;
 
-    Ok((
-        blocks,
-        BatchPrepareCache {
-            output_cache,
-            key_images_spent_checked: true,
-        },
-    ))
+    Ok((blocks, BatchPrepareCache { output_cache }))
 }

--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -46,7 +46,7 @@ pub enum VerificationContext<D> {
     ///
     /// This cache is only valid for the set of blocks it was created with, it should not be used for other blocks.
     /// You must pass blocks in sequentially.
-    BatchPrepareCache(BatchPrepareCache),
+    BatchPrepareCache(block::BatchPrepareCache),
 }
 
 /// An Error returned from one of the consensus services.
@@ -62,7 +62,6 @@ pub enum ExtendedConsensusError {
     FatalError(#[from] tower::BoxError),
 }
 
-use crate::block::BatchPrepareCache;
 use __private::Database;
 
 pub mod __private {

--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -37,6 +37,18 @@ pub use cuprate_types::{
     HardFork,
 };
 
+/// The verification context to verify a block or transaction with.
+#[expect(clippy::large_enum_variant)]
+pub enum VerificationContext<D> {
+    /// A full database
+    Database(D),
+    /// A batch prepared cache.
+    ///
+    /// This cache is only valid for the set of blocks it was created with, it should not be used for other blocks.
+    /// You must pass blocks in sequentially.
+    BatchPrepareCache(BatchPrepareCache),
+}
+
 /// An Error returned from one of the consensus services.
 #[derive(Debug, thiserror::Error)]
 pub enum ExtendedConsensusError {
@@ -50,6 +62,7 @@ pub enum ExtendedConsensusError {
     FatalError(#[from] tower::BoxError),
 }
 
+use crate::block::BatchPrepareCache;
 use __private::Database;
 
 pub mod __private {

--- a/consensus/src/transactions.rs
+++ b/consensus/src/transactions.rs
@@ -41,15 +41,13 @@ use cuprate_consensus_rules::{
 use cuprate_helper::asynch::rayon_spawn_async;
 use cuprate_types::{
     blockchain::{BlockchainReadRequest, BlockchainResponse},
-    output_cache::OutputCache,
     CachedVerificationState, TransactionVerificationData, TxVersion,
 };
 
 use crate::{
     batch_verifier::MultiThreadedBatchVerifier,
-    block::BatchPrepareCache,
     transactions::contextual_data::{batch_get_decoy_info, batch_get_ring_member_info},
-    Database, ExtendedConsensusError,
+    Database, ExtendedConsensusError, VerificationContext,
 };
 
 pub mod contextual_data;
@@ -156,8 +154,7 @@ impl VerificationWanted {
         top_hash: [u8; 32],
         time_for_time_lock: u64,
         hf: HardFork,
-        database: D,
-        batch_prep_cache: Option<&BatchPrepareCache>,
+        verification_context: &mut VerificationContext<D>,
     ) -> FullVerification<'_, D> {
         FullVerification {
             prepped_txs: self.prepped_txs,
@@ -165,8 +162,7 @@ impl VerificationWanted {
             top_hash,
             time_for_time_lock,
             hf,
-            database,
-            batch_prep_cache,
+            verification_context,
         }
     }
 }
@@ -219,8 +215,7 @@ pub struct FullVerification<'a, D> {
     top_hash: [u8; 32],
     time_for_time_lock: u64,
     hf: HardFork,
-    database: D,
-    batch_prep_cache: Option<&'a BatchPrepareCache>,
+    verification_context: &'a mut VerificationContext<D>,
 }
 
 impl<D: Database + Clone> FullVerification<'_, D> {
@@ -228,15 +223,13 @@ impl<D: Database + Clone> FullVerification<'_, D> {
     pub async fn verify(
         mut self,
     ) -> Result<Vec<TransactionVerificationData>, ExtendedConsensusError> {
-        if self
-            .batch_prep_cache
-            .is_none_or(|c| !c.key_images_spent_checked)
-        {
-            check_kis_unique(self.prepped_txs.iter(), &mut self.database).await?;
-        }
-
         let hashes_in_main_chain =
-            hashes_referenced_in_main_chain(&self.prepped_txs, &mut self.database).await?;
+            if let VerificationContext::Database(database) = &mut self.verification_context {
+                check_kis_unique(self.prepped_txs.iter(), database).await?;
+                hashes_referenced_in_main_chain(&self.prepped_txs, database).await?
+            } else {
+                HashSet::new()
+            };
 
         let (verification_needed, any_v1_decoy_check_needed) = verification_needed(
             &self.prepped_txs,
@@ -259,8 +252,7 @@ impl<D: Database + Clone> FullVerification<'_, D> {
                         }
                     }),
                 self.hf,
-                self.database.clone(),
-                self.batch_prep_cache.map(|c| &c.output_cache),
+                self.verification_context,
             )
             .await?;
         }
@@ -272,8 +264,7 @@ impl<D: Database + Clone> FullVerification<'_, D> {
             self.top_hash,
             self.time_for_time_lock,
             self.hf,
-            self.database,
-            self.batch_prep_cache.map(|c| &c.output_cache),
+            self.verification_context,
         )
         .await
     }
@@ -443,15 +434,14 @@ fn verification_needed(
 async fn verify_transactions_decoy_info<D: Database>(
     txs: impl Iterator<Item = &TransactionVerificationData> + Clone,
     hf: HardFork,
-    database: D,
-    output_cache: Option<&OutputCache>,
+    verification_context: &mut VerificationContext<D>,
 ) -> Result<(), ExtendedConsensusError> {
     // Decoy info is not validated for V1 txs.
     if hf == HardFork::V1 {
         return Ok(());
     }
 
-    batch_get_decoy_info(txs, hf, database, output_cache)
+    batch_get_decoy_info(txs, hf, verification_context)
         .await?
         .try_for_each(|decoy_info| decoy_info.and_then(|di| Ok(check_decoy_info(&di, hf)?)))?;
 
@@ -463,7 +453,6 @@ async fn verify_transactions_decoy_info<D: Database>(
 /// The inputs to this function are the txs wanted to be verified and a list of [`VerificationNeeded`],
 /// if any other [`VerificationNeeded`] is specified other than [`VerificationNeeded::Contextual`] or
 /// [`VerificationNeeded::SemanticAndContextual`], nothing will be verified for that tx.
-#[expect(clippy::too_many_arguments)]
 async fn verify_transactions<D>(
     mut txs: Vec<TransactionVerificationData>,
     verification_needed: Vec<VerificationNeeded>,
@@ -471,8 +460,7 @@ async fn verify_transactions<D>(
     top_hash: [u8; 32],
     current_time_lock_timestamp: u64,
     hf: HardFork,
-    database: D,
-    output_cache: Option<&OutputCache>,
+    verification_context: &mut VerificationContext<D>,
 ) -> Result<Vec<TransactionVerificationData>, ExtendedConsensusError>
 where
     D: Database,
@@ -492,8 +480,7 @@ where
             .filter(tx_filter)
             .map(|(tx, _)| tx),
         hf,
-        database,
-        output_cache,
+        verification_context,
     )
     .await?;
 

--- a/consensus/src/transactions/contextual_data.rs
+++ b/consensus/src/transactions/contextual_data.rs
@@ -32,7 +32,10 @@ use cuprate_types::{
     OutputOnChain,
 };
 
-use crate::{transactions::TransactionVerificationData, Database, ExtendedConsensusError};
+use crate::{
+    transactions::TransactionVerificationData, Database, ExtendedConsensusError,
+    VerificationContext,
+};
 
 /// Get the ring members for the inputs from the outputs on the chain.
 ///
@@ -160,32 +163,32 @@ pub async fn get_output_cache<D: Database>(
 pub async fn batch_get_ring_member_info<D: Database>(
     txs_verification_data: impl Iterator<Item = &TransactionVerificationData> + Clone,
     hf: HardFork,
-    mut database: D,
-    cache: Option<&OutputCache>,
+    verification_context: &mut VerificationContext<D>,
 ) -> Result<Vec<TxRingMembersInfo>, ExtendedConsensusError> {
-    let mut outputs = IndexMap::new();
+    let outputs = match verification_context {
+        VerificationContext::BatchPrepareCache(cache) => Cow::Borrowed(&cache.output_cache),
+        VerificationContext::Database(database) => {
+            let mut outputs = IndexMap::new();
 
-    for tx_v_data in txs_verification_data.clone() {
-        insert_ring_member_ids(&tx_v_data.tx.prefix().inputs, &mut outputs)
-            .map_err(ConsensusError::Transaction)?;
-    }
+            for tx_v_data in txs_verification_data.clone() {
+                insert_ring_member_ids(&tx_v_data.tx.prefix().inputs, &mut outputs)
+                    .map_err(ConsensusError::Transaction)?;
+            }
 
-    let outputs = if let Some(cache) = cache {
-        Cow::Borrowed(cache)
-    } else {
-        let BlockchainResponse::Outputs(outputs) = database
-            .ready()
-            .await?
-            .call(BlockchainReadRequest::Outputs {
-                outputs,
-                get_txid: false,
-            })
-            .await?
-        else {
-            unreachable!();
-        };
+            let BlockchainResponse::Outputs(outputs) = database
+                .ready()
+                .await?
+                .call(BlockchainReadRequest::Outputs {
+                    outputs,
+                    get_txid: false,
+                })
+                .await?
+            else {
+                unreachable!();
+            };
 
-        Cow::Owned(outputs)
+            Cow::Owned(outputs)
+        }
     };
 
     Ok(txs_verification_data
@@ -223,8 +226,7 @@ pub async fn batch_get_ring_member_info<D: Database>(
 pub async fn batch_get_decoy_info<'a, 'b, D: Database>(
     txs_verification_data: impl Iterator<Item = &'a TransactionVerificationData> + Clone,
     hf: HardFork,
-    mut database: D,
-    cache: Option<&'b OutputCache>,
+    verification_context: &mut VerificationContext<D>,
 ) -> Result<
     impl Iterator<Item = Result<DecoyInfo, ConsensusError>> + sealed::Captures<(&'a (), &'b ())>,
     ExtendedConsensusError,
@@ -248,24 +250,25 @@ pub async fn batch_get_decoy_info<'a, 'b, D: Database>(
         unique_input_amounts.len()
     );
 
-    let outputs_with_amount = if let Some(cache) = cache {
-        unique_input_amounts
+    let outputs_with_amount = match verification_context {
+        VerificationContext::BatchPrepareCache(cache) => unique_input_amounts
             .into_iter()
-            .map(|amount| (amount, cache.number_outs_with_amount(amount)))
-            .collect()
-    } else {
-        let BlockchainResponse::NumberOutputsWithAmount(outputs_with_amount) = database
-            .ready()
-            .await?
-            .call(BlockchainReadRequest::NumberOutputsWithAmount(
-                unique_input_amounts.into_iter().collect(),
-            ))
-            .await?
-        else {
-            unreachable!();
-        };
+            .map(|amount| (amount, cache.output_cache.number_outs_with_amount(amount)))
+            .collect(),
+        VerificationContext::Database(database) => {
+            let BlockchainResponse::NumberOutputsWithAmount(outputs_with_amount) = database
+                .ready()
+                .await?
+                .call(BlockchainReadRequest::NumberOutputsWithAmount(
+                    unique_input_amounts.into_iter().collect(),
+                ))
+                .await?
+            else {
+                unreachable!();
+            };
 
-        outputs_with_amount
+            outputs_with_amount
+        }
     };
 
     Ok(txs_verification_data.map(move |tx_v_data| {

--- a/consensus/tests/verify_correct_txs.rs
+++ b/consensus/tests/verify_correct_txs.rs
@@ -15,7 +15,9 @@ use monero_oxide::{
 };
 use tower::service_fn;
 
-use cuprate_consensus::{__private::Database, transactions::start_tx_verification};
+use cuprate_consensus::{
+    __private::Database, transactions::start_tx_verification, VerificationContext,
+};
 use cuprate_types::{
     blockchain::{BlockchainReadRequest, BlockchainResponse},
     output_cache::OutputCache,
@@ -94,7 +96,7 @@ macro_rules! test_verify_valid_v2_tx {
                 )
                 .prepare()
                 .unwrap()
-                .full(10, [0; 32], u64::MAX, HardFork::$hf, database.clone(), None)
+                .full(10, [0; 32], u64::MAX, HardFork::$hf, &mut VerificationContext::Database(database.clone()))
                 .verify()
                 .await.is_ok()
             );
@@ -122,7 +124,7 @@ macro_rules! test_verify_valid_v2_tx {
                 )
                 .prepare()
                 .unwrap()
-                .full(10, [0; 32], u64::MAX, HardFork::$hf, database.clone(), None)
+                .full(10, [0; 32], u64::MAX, HardFork::$hf, &mut VerificationContext::Database(database.clone()))
                 .verify()
                 .await.is_err()
             );


### PR DESCRIPTION
### What
 This PR caused a regression in full verification block sync speed: https://github.com/Cuprate/cuprate/pull/678, we always wrote fully verified blocks 1 by 1 so during full verification we would always be using the safest DB settings.
 
 This PR changes full verification block sync to allow us to batch write the blocks to DB. This should make us even faster than before the regression.