### PR TITLE
RPC: add JSON-RPC batch request support

### DIFF
--- a/binaries/cuprated/src/rpc/rpc_handler.rs
+++ b/binaries/cuprated/src/rpc/rpc_handler.rs
@@ -1,6 +1,9 @@
 //! `cuprated`'s implementation of [`RpcHandler`].
 
-use std::task::{Context, Poll};
+use std::{
+    num::NonZeroUsize,
+    task::{Context, Poll},
+};
 
 use anyhow::Error;
 use futures::future::BoxFuture;
@@ -167,6 +170,9 @@ pub struct CupratedRpcHandler {
     /// This is not `pub` on purpose, as it should not be mutated after [`Self::new`].
     restricted: bool,
 
+    /// How many requests within a `/json_rpc` batch are handled at once.
+    batch_concurrency: NonZeroUsize,
+
     /// The active network.
     pub network: Network,
 
@@ -211,6 +217,8 @@ impl CupratedRpcHandler {
 
         Self {
             restricted,
+            batch_concurrency: NonZeroUsize::new(launch_ctx.config.storage.reader_threads / 4)
+                .unwrap_or(NonZeroUsize::MIN),
             network: launch_ctx.config.network,
             offline: launch_ctx.config.offline,
             tx_handler,
@@ -228,6 +236,10 @@ impl CupratedRpcHandler {
 impl RpcHandler for CupratedRpcHandler {
     fn is_restricted(&self) -> bool {
         self.restricted
+    }
+
+    fn batch_concurrency(&self) -> NonZeroUsize {
+        self.batch_concurrency
     }
 }
 

--- a/books/architecture/src/rpc/differences/json-rpc-strictness.md
+++ b/books/architecture/src/rpc/differences/json-rpc-strictness.md
@@ -102,12 +102,13 @@ Response:
 ```
 
 ## Responding to notifications
-> TODO: decide on Cuprate behavior <https://github.com/Cuprate/cuprate/pull/233#discussion_r1704611186>
-
 Requests that have no `id` field are "notifications".
 
 [The JSON-RPC 2.0 specification states that requests without
 an `id` field must _not_ be responded to](https://www.jsonrpc.org/specification#notification).
+
+`monerod` responds to them anyway. Cuprate follows the specification: the
+method still runs, but the response is an empty HTTP `200` body.
 
 Example:
 ```bash

--- a/books/architecture/src/rpc/differences/json-rpc-strictness.md
+++ b/books/architecture/src/rpc/differences/json-rpc-strictness.md
@@ -118,6 +118,24 @@ curl \
 	-H 'Content-Type: application/json'
 ```
 
+## Batching
+[The JSON-RPC 2.0 specification allows a batch of requests
+to be sent as an array](https://www.jsonrpc.org/specification#batch).
+
+`monerod` does not support this. It reads `method` off the root object of
+the body, so an array is answered with failure, see
+[here](https://github.com/monero-project/monero/blob/893916ad091a92e765ce3241b94e706ad012b62a/contrib/epee/include/net/http_server_handlers_map2.h#L141-L166).
+
+Cuprate supports batching. Empty batches are rejected as invalid.
+
+Example:
+```bash
+curl \
+	http://127.0.0.1:18081/json_rpc \
+	-d '[{"jsonrpc":"2.0","id":"0","method":"get_block_count"},{"jsonrpc":"2.0","id":"1","method":"get_info"}]' \
+	-H 'Content-Type: application/json'
+```
+
 ## Upper/mixed case fields
 `monerod` will accept upper/mixed case fields on:
 - `jsonrpc`

--- a/rpc/interface/Cargo.toml
+++ b/rpc/interface/Cargo.toml
@@ -10,7 +10,7 @@ keywords    = ["cuprate", "rpc", "interface"]
 
 [features]
 default  = ["dummy"]
-dummy    = ["dep:cuprate-helper", "dep:futures"]
+dummy    = ["dep:cuprate-helper"]
 
 [dependencies]
 cuprate-epee-encoding = { workspace = true, default-features = false }
@@ -21,10 +21,10 @@ cuprate-helper        = { workspace = true, features = ["asynch"], default-featu
 anyhow     = { workspace = true }
 axum       = { workspace = true, features = ["json"], default-features = false }
 serde      = { workspace = true }
-serde_json = { workspace = true, features = ["std"] }
+serde_json = { workspace = true, features = ["std", "raw_value"] }
 tower      = { workspace = true, features = ["util"] }
 paste      = { workspace = true }
-futures    = { workspace = true, optional = true }
+futures    = { workspace = true }
 
 [dev-dependencies]
 cuprate-test-utils = { workspace = true }

--- a/rpc/interface/README.md
+++ b/rpc/interface/README.md
@@ -69,6 +69,13 @@ when a request is received to an unknown endpoint, including HTTP stuff, e.g. st
 # Unknown JSON-RPC method behavior
 An unknown method is answered with `-32601 Method not found` at HTTP `200`.
 
+# Batching
+[Batches](https://www.jsonrpc.org/specification#batch) are supported, unlike `monerod`.
+
+Each entry is parsed on its own, so a malformed entry only fails itself.
+An entry that is a notification is not added to the response array.
+An empty batch is answered with `-32600 Invalid Request`.
+
 # Example
 Example usage of this crate + starting an RPC server.
 

--- a/rpc/interface/README.md
+++ b/rpc/interface/README.md
@@ -67,8 +67,7 @@ TODO: decide what this crate should return (per different endpoint)
 when a request is received to an unknown endpoint, including HTTP stuff, e.g. status code.
 
 # Unknown JSON-RPC method behavior
-TODO: decide what this crate returns when a `/json_rpc`
-request is received with an unknown method, including HTTP stuff, e.g. status code.
+An unknown method is answered with `-32601 Method not found` at HTTP `200`.
 
 # Example
 Example usage of this crate + starting an RPC server.
@@ -105,7 +104,7 @@ async fn get_height(port: u16) -> OtherResponse {
 async fn get_block_count(port: u16) -> String {
     let url = format!("http://127.0.0.1:{port}/json_rpc");
     let method = JsonRpcRequest::GetBlockCount(Default::default());
-    let request = Request::new(method);
+    let request = Request::new(Id::Num(0), method);
     ureq::get(&url)
         .set("Content-Type", "application/json")
         .send_json(request)
@@ -143,11 +142,11 @@ async fn main() {
 
     // Assert the response JSON is correct.
     let response = get_block_count(port).await;
-    let expected = r#"{"jsonrpc":"2.0","id":null,"result":{"status":"OK","untrusted":false,"count":0}}"#;
+    let expected = r#"{"jsonrpc":"2.0","id":0,"result":{"status":"OK","untrusted":false,"count":0}}"#;
     assert_eq!(response, expected);
 
     // Assert that (de)serialization works.
-    let expected = Response::ok(Id::Null, Default::default());
+    let expected = Response::ok(Id::Num(0), Default::default());
     let response: Response<GetBlockCountResponse> = serde_json::from_str(&response).unwrap();
     assert_eq!(response, expected);
 }

--- a/rpc/interface/src/route/json_rpc.rs
+++ b/rpc/interface/src/route/json_rpc.rs
@@ -7,7 +7,9 @@ use axum::{
     http::{header::CONTENT_TYPE, HeaderMap, StatusCode},
     response::{IntoResponse, Response},
 };
+use futures::stream::{FuturesUnordered, StreamExt};
 use serde::Deserialize;
+use serde_json::value::RawValue;
 use tower::ServiceExt;
 
 use cuprate_json_rpc::{error::ErrorObject, Id, Response as JsonRpcResponse};
@@ -34,26 +36,58 @@ pub(crate) async fn json_rpc<H: RpcHandler>(
         Err(rejection) => return rejection.into_response(),
     };
 
-    let Some(response) = dispatch(handler, &request).await else {
-        return StatusCode::OK.into_response();
+    // A JSON array is a batch, anything else is a single request.
+    if request.trim_ascii_start().starts_with(b"[") {
+        return batch(handler, &request).await;
+    }
+
+    match dispatch(handler, &request).await {
+        Some(response) => json_rpc_response(response),
+        None => StatusCode::OK.into_response(),
+    }
+}
+
+/// Handle a [batch](https://www.jsonrpc.org/specification#batch) of requests.
+async fn batch<H: RpcHandler>(handler: H, request: &[u8]) -> Response {
+    let entries = match serde_json::from_slice::<Vec<&RawValue>>(request) {
+        // JSON-RPC 2.0 rule:
+        // An empty batch is an invalid request.
+        Ok(entries) if !entries.is_empty() => entries,
+        Err(error) if error.is_syntax() || error.is_eof() => {
+            return json_rpc_response(JsonRpcResponse::parse_error(Id::Null));
+        }
+        _ => {
+            return json_rpc_response(JsonRpcResponse::invalid_request(Id::Null));
+        }
     };
+
+    let concurrency = handler.batch_concurrency().get();
+    let mut entries = entries.into_iter();
+    let mut responses = FuturesUnordered::new();
+    for entry in entries.by_ref().take(concurrency) {
+        responses.push(dispatch(handler.clone(), entry.get().as_bytes()));
+    }
 
     let mut json = Vec::new();
-    let result = match &response.payload {
-        Ok(RpcResponse::GetTxpoolBacklog(body)) => {
-            serialize_txpool_backlog_response(&mut json, &response.id, body)
-        }
-        _ => serde_json::to_writer(&mut json, &response),
-    };
+    json.push(b'[');
 
-    if result.is_err() {
-        json.clear();
-        serde_json::to_writer(
-            &mut json,
-            &JsonRpcResponse::<RpcResponse>::internal_error(response.id),
-        )
-        .expect("an error response always serializes");
+    while let Some(response) = responses.next().await {
+        if let Some(response) = response {
+            write_response_json(response, &mut json);
+            json.push(b',');
+        }
+        if let Some(entry) = entries.next() {
+            responses.push(dispatch(handler.clone(), entry.get().as_bytes()));
+        }
     }
+
+    // A batch of only notifications is not responded to.
+    if json.len() == 1 {
+        return StatusCode::OK.into_response();
+    }
+
+    json.pop();
+    json.push(b']');
 
     Response::builder()
         .header(CONTENT_TYPE, "application/json")
@@ -161,6 +195,37 @@ fn json_content_type(headers: &HeaderMap) -> bool {
         && (subtype.eq_ignore_ascii_case(b"json")
             || subtype.len() > "+json".len()
                 && subtype[subtype.len() - "+json".len()..].eq_ignore_ascii_case(b"+json"))
+}
+
+/// Append a response to an existing JSON buffer.
+fn write_response_json(response: JsonRpcResponse<RpcResponse>, json: &mut Vec<u8>) {
+    let start = json.len();
+    let result = match &response.payload {
+        Ok(RpcResponse::GetTxpoolBacklog(body)) => {
+            serialize_txpool_backlog_response(json, &response.id, body)
+        }
+        _ => serde_json::to_writer(&mut *json, &response),
+    };
+
+    if result.is_err() {
+        json.truncate(start);
+        serde_json::to_writer(
+            json,
+            &JsonRpcResponse::<RpcResponse>::internal_error(response.id),
+        )
+        .expect("an error response always serializes");
+    }
+}
+
+/// Serialize a JSON-RPC response into an HTTP response.
+fn json_rpc_response(response: JsonRpcResponse<RpcResponse>) -> Response {
+    let mut json = Vec::new();
+    write_response_json(response, &mut json);
+
+    Response::builder()
+        .header(CONTENT_TYPE, "application/json")
+        .body(Body::from(json))
+        .expect("valid response builder")
 }
 
 // TODO: remove the code below once this: https://github.com/monero-project/monero/issues/9422 is resolved.

--- a/rpc/interface/src/route/json_rpc.rs
+++ b/rpc/interface/src/route/json_rpc.rs
@@ -2,17 +2,17 @@
 
 //---------------------------------------------------------------------------------------------------- Import
 use axum::{
-    body::Body,
-    extract::State,
-    http::{header::CONTENT_TYPE, StatusCode},
+    body::{Body, Bytes},
+    extract::{rejection::BytesRejection, State},
+    http::{header::CONTENT_TYPE, HeaderMap, StatusCode},
     response::{IntoResponse, Response},
-    Json,
 };
+use serde::Deserialize;
 use tower::ServiceExt;
 
-use cuprate_json_rpc::{Id, Response as JsonRpcResponse};
+use cuprate_json_rpc::{error::ErrorObject, Id, Response as JsonRpcResponse};
 use cuprate_rpc_types::{
-    json::{GetTxpoolBacklogResponse, JsonRpcRequest, JsonRpcResponse as RpcResponse},
+    json::{GetTxpoolBacklogResponse, JsonRpcMethod, JsonRpcResponse as RpcResponse},
     RpcCallValue,
 };
 
@@ -22,79 +22,166 @@ use crate::rpc_handler::RpcHandler;
 /// The `/json_rpc` route function used in [`crate::RouterBuilder`].
 pub(crate) async fn json_rpc<H: RpcHandler>(
     State(handler): State<H>,
-    Json(request): Json<cuprate_json_rpc::Request<JsonRpcRequest>>,
-) -> Result<Response, StatusCode> {
-    // TODO: <https://www.jsonrpc.org/specification#notification>
-    //
-    // JSON-RPC notifications (requests without `id`)
-    // must not be responded too, although, the request's side-effects
-    // must remain. How to do this considering this function will
-    // always return and cause `axum` to respond?
+    headers: HeaderMap,
+    request: Result<Bytes, BytesRejection>,
+) -> Response {
+    if !json_content_type(&headers) {
+        return StatusCode::UNSUPPORTED_MEDIA_TYPE.into_response();
+    }
 
-    // JSON-RPC 2.0 rule:
-    // If there was an error in detecting the `Request`'s ID,
-    // the `Response` must contain an `Id::Null`
-    let id = request.id.unwrap_or(Id::Null);
+    let request = match request {
+        Ok(request) => request,
+        Err(rejection) => return rejection.into_response(),
+    };
 
-    // Return early if this RPC server is restricted and
-    // the requested method is only for non-restricted RPC.
+    let Some(response) = dispatch(handler, &request).await else {
+        return StatusCode::OK.into_response();
+    };
+
+    let mut json = Vec::new();
+    let result = match &response.payload {
+        Ok(RpcResponse::GetTxpoolBacklog(body)) => {
+            serialize_txpool_backlog_response(&mut json, &response.id, body)
+        }
+        _ => serde_json::to_writer(&mut json, &response),
+    };
+
+    if result.is_err() {
+        json.clear();
+        serde_json::to_writer(
+            &mut json,
+            &JsonRpcResponse::<RpcResponse>::internal_error(response.id),
+        )
+        .expect("an error response always serializes");
+    }
+
+    Response::builder()
+        .header(CONTENT_TYPE, "application/json")
+        .body(Body::from(json))
+        .expect("valid response builder")
+}
+
+/// Handle a single request, returning its serialized response.
+///
+/// [`None`] if the request was a
+/// [notification](https://www.jsonrpc.org/specification#notification).
+async fn dispatch<H: RpcHandler>(handler: H, json: &[u8]) -> Option<JsonRpcResponse<RpcResponse>> {
+    let request = match serde_json::from_slice::<cuprate_json_rpc::Request<JsonRpcMethod>>(json) {
+        Ok(request) => request,
+        Err(error) if error.is_syntax() || error.is_eof() => {
+            return Some(JsonRpcResponse::parse_error(Id::Null));
+        }
+        Err(_) => {
+            // The request is malformed; recover its ID if it has a valid one, as per:
+            // <https://www.jsonrpc.org/specification#response_object>
+            #[derive(Deserialize)]
+            struct RequestId {
+                id: Id,
+            }
+
+            let id =
+                serde_json::from_slice::<RequestId>(json).map_or(Id::Null, |request| request.id);
+
+            return Some(JsonRpcResponse::invalid_request(id));
+        }
+    };
+
+    // A method that is only for non-restricted RPC is answered as if it did
+    // not exist, so a restricted server does not leak which methods exist.
     //
     // INVARIANT:
-    // The RPC handler functions in `cuprated` depend on this line existing,
+    // The RPC handler functions in `cuprated` depend on this check existing,
     // the functions themselves do not check if they are being called
-    // from an (un)restricted context. This line must be here or all
-    // methods will be allowed to be called freely.
-    if request.body.is_restricted() && handler.is_restricted() {
+    // from an (un)restricted context. This must be here or all methods will
+    // be allowed to be called freely, including by omitting `id`.
+    let method = match request.body {
         // The error when a restricted JSON-RPC method is called as per:
         //
         // - <https://github.com/monero-project/monero/blob/893916ad091a92e765ce3241b94e706ad012b62a/contrib/epee/include/net/http_server_handlers_map2.h#L244-L252>
         // - <https://github.com/monero-project/monero/blob/cc73fe71162d564ffda8e549b79a350bca53c454/src/rpc/core_rpc_server.h#L188>
-        return Ok(Json(JsonRpcResponse::<RpcResponse>::method_not_found(id)).into_response());
-    }
-
-    // Send request.
-    let Ok(response) = handler.oneshot(request.body).await else {
-        return Err(StatusCode::INTERNAL_SERVER_ERROR);
+        JsonRpcMethod::Known(body) if handler.is_restricted() && body.is_restricted() => {
+            Err(ErrorObject::method_not_found())
+        }
+        JsonRpcMethod::InvalidParams { restricted: true } if handler.is_restricted() => {
+            Err(ErrorObject::method_not_found())
+        }
+        JsonRpcMethod::Known(body) => Ok(body),
+        JsonRpcMethod::Unknown => Err(ErrorObject::method_not_found()),
+        JsonRpcMethod::InvalidParams { .. } => Err(ErrorObject::invalid_params()),
     };
 
-    if let RpcResponse::GetTxpoolBacklog(response) = &response {
-        return txpool_backlog_response(&id, response);
+    // JSON-RPC 2.0 rule:
+    // <https://www.jsonrpc.org/specification#notification>
+    //
+    // JSON-RPC notifications (requests without `id`) must not be responded to,
+    // although their side-effects must remain, so the request is still sent.
+    match request.id {
+        None => {
+            if let Ok(body) = method {
+                drop(handler.oneshot(body).await);
+            }
+            None
+        }
+        Some(id) => Some(match method {
+            Err(error) => JsonRpcResponse::err(id, error),
+            Ok(body) => match handler.oneshot(body).await {
+                Ok(response) => JsonRpcResponse::ok(id, response),
+                Err(_) => JsonRpcResponse::internal_error(id),
+            },
+        }),
+    }
+}
+
+/// Whether the request has a JSON media type.
+fn json_content_type(headers: &HeaderMap) -> bool {
+    let Some(value) = headers.get(CONTENT_TYPE) else {
+        return false;
+    };
+
+    let value = value.as_bytes();
+
+    // Nearly every client sends exactly this.
+    if value == b"application/json" {
+        return true;
     }
 
-    Ok(Json(JsonRpcResponse::ok(id, response)).into_response())
+    // Ignore any `;` parameters, e.g. `application/json; charset=utf-8`.
+    let media_type = match value.iter().position(|&b| b == b';') {
+        Some(i) => &value[..i],
+        None => value,
+    }
+    .trim_ascii();
+
+    let Some((prefix, subtype)) = media_type.split_at_checked("application/".len()) else {
+        return false;
+    };
+
+    prefix.eq_ignore_ascii_case(b"application/")
+        && !subtype.contains(&b'/')
+        && (subtype.eq_ignore_ascii_case(b"json")
+            || subtype.len() > "+json".len()
+                && subtype[subtype.len() - "+json".len()..].eq_ignore_ascii_case(b"+json"))
 }
 
 // TODO: remove the code below once this: https://github.com/monero-project/monero/issues/9422 is resolved.
 
-/// Build a Monero-compatible `get_txpool_backlog` response.
-fn txpool_backlog_response(
-    id: &Id,
-    response: &GetTxpoolBacklogResponse,
-) -> Result<Response, StatusCode> {
-    let body = serialize_txpool_backlog_response(id, response)
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-
-    Ok(Response::builder()
-        .header(CONTENT_TYPE, "application/json")
-        .body(Body::from(body))
-        .expect("valid response builder"))
-}
-
 /// Serialize the backlog's POD container as a binary JSON string.
 fn serialize_txpool_backlog_response(
+    json: &mut Vec<u8>,
     id: &Id,
     response: &GetTxpoolBacklogResponse,
-) -> serde_json::Result<Vec<u8>> {
-    let mut json = [
+) -> serde_json::Result<()> {
+    json.extend_from_slice(
         br#"{
             "jsonrpc":"2.0",
             "id":"#,
-        serde_json::to_string(&id)?.as_bytes(),
+    );
+    serde_json::to_writer(&mut *json, id)?;
+    json.extend_from_slice(
         br#",
             "result":"#,
-        serde_json::to_string(&response.base)?.as_bytes(),
-    ]
-    .concat();
+    );
+    serde_json::to_writer(&mut *json, &response.base)?;
 
     if !response.backlog.is_empty() {
         // Reopen `result` to append the field that serde cannot represent.
@@ -102,12 +189,12 @@ fn serialize_txpool_backlog_response(
             unreachable!("response base must serialize as a JSON object");
         };
         json.extend_from_slice(br#","backlog":"#);
-        write_binary_string(&mut json, &txpool_backlog_blob(response));
+        write_binary_string(json, &txpool_backlog_blob(response));
         json.push(b'}');
     }
 
     json.push(b'}');
-    Ok(json)
+    Ok(())
 }
 
 fn txpool_backlog_blob(response: &GetTxpoolBacklogResponse) -> Vec<u8> {

--- a/rpc/interface/src/rpc_handler.rs
+++ b/rpc/interface/src/rpc_handler.rs
@@ -1,6 +1,8 @@
 //! RPC handler trait.
 
 //---------------------------------------------------------------------------------------------------- Use
+use std::num::NonZeroUsize;
+
 use cuprate_rpc_types::{
     bin::{BinRequest, BinResponse},
     json::{JsonRpcRequest, JsonRpcResponse},
@@ -47,4 +49,7 @@ pub trait RpcHandler:
     /// will automatically be denied access when using the
     /// [`axum::Router`] provided by [`RouterBuilder`](crate::RouterBuilder).
     fn is_restricted(&self) -> bool;
+
+    /// How many requests within a `/json_rpc` batch are handled at once.
+    fn batch_concurrency(&self) -> NonZeroUsize;
 }

--- a/rpc/interface/src/rpc_handler_dummy.rs
+++ b/rpc/interface/src/rpc_handler_dummy.rs
@@ -1,7 +1,7 @@
 //! Dummy implementation of [`RpcHandler`].
 
 //---------------------------------------------------------------------------------------------------- Use
-use std::task::Poll;
+use std::{num::NonZeroUsize, task::Poll};
 
 use anyhow::Error;
 use futures::channel::oneshot::channel;
@@ -39,6 +39,10 @@ pub struct RpcHandlerDummy {
 impl RpcHandler for RpcHandlerDummy {
     fn is_restricted(&self) -> bool {
         self.restricted
+    }
+
+    fn batch_concurrency(&self) -> NonZeroUsize {
+        NonZeroUsize::MIN
     }
 }
 

--- a/rpc/json-rpc/README.md
+++ b/rpc/json-rpc/README.md
@@ -14,10 +14,12 @@ This crate expects you to read the brief JSON-RPC 2.0 specification for context.
 ## Batching
 This crate does not have any types for [JSON-RPC 2.0 batching](https://www.jsonrpc.org/specification#batch).
 
-This is because `monerod` does not support this,
-as such, neither does Cuprate.
+A batch is transport framing, so it is handled by `cuprate-rpc-interface`,
+which decodes each entry into this crate's `Request`.
 
-TODO: citation needed on `monerod` not supporting batching.
+`monerod` does not support batching. It reads `method` off the
+root object of the body, so an array is an `Invalid Request`:
+<https://github.com/monero-project/monero/blob/893916ad091a92e765ce3241b94e706ad012b62a/contrib/epee/include/net/http_server_handlers_map2.h#L141-L166>
 
 ## Request changes
 [JSON-RPC 2.0's `Request` object](https://www.jsonrpc.org/specification#request_object) usually contains these 2 fields:

--- a/rpc/json-rpc/README.md
+++ b/rpc/json-rpc/README.md
@@ -51,7 +51,7 @@ enum Methods {
 }
 
 // Create the request object.
-let request = Request::new_with_id(
+let request = Request::new(
     Id::Str("hello".into()),
     Methods::GetBlock(GetBlock { height: 123 }),
 );

--- a/rpc/json-rpc/src/id.rs
+++ b/rpc/json-rpc/src/id.rs
@@ -1,7 +1,7 @@
 //! [`Id`]: request/response identification.
 
 //---------------------------------------------------------------------------------------------------- Use
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use std::borrow::Cow;
 
 //---------------------------------------------------------------------------------------------------- Id
@@ -119,6 +119,27 @@ impl Id {
     /// ```
     pub fn is_null(&self) -> bool {
         *self == Self::Null
+    }
+
+    /// Deserialize an [`Id`] into [`Some`], including [`Id::Null`].
+    ///
+    /// `#[serde(default)]` preserves an absent ID as [`None`].
+    ///
+    /// ```rust
+    /// # use cuprate_json_rpc::Id;
+    /// # use serde::Deserialize;
+    /// #[derive(Deserialize)]
+    /// struct Request {
+    ///     #[serde(default, deserialize_with = "Id::deserialize_some")]
+    ///     id: Option<Id>,
+    /// }
+    /// assert_eq!(serde_json::from_str::<Request>(r#"{"id":null}"#).unwrap().id, Some(Id::Null));
+    /// assert_eq!(serde_json::from_str::<Request>(r#"{}"#).unwrap().id, None);
+    /// ```
+    pub fn deserialize_some<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<Option<Self>, D::Error> {
+        Self::deserialize(deserializer).map(Some)
     }
 
     /// Create a new [`Id::Str`] from a static string.

--- a/rpc/json-rpc/src/request.rs
+++ b/rpc/json-rpc/src/request.rs
@@ -17,16 +17,18 @@ pub struct Request<T> {
 
     /// An identifier established by the Client.
     ///
-    /// If it is not included it is assumed to be a
+    /// If the `id` field is not included, the request is a
     /// [notification](https://www.jsonrpc.org/specification#notification).
     ///
     /// ### `None` vs `Some(Id::Null)`
     /// This field will be completely omitted during serialization if [`None`],
-    /// however if it is `Some(Id::Null)`, it will be serialized as `"id": null`.
+    /// however if it is `Some(Id::Null)`, it will be serialized as `"id": null`
+    /// and is not a notification.
     ///
-    /// Note that the JSON-RPC 2.0 specification discourages the use of `Id::NUll`,
-    /// so if there is no ID needed, consider using `None`.
+    /// Note that the JSON-RPC 2.0 specification discourages the use of [`Id::Null`],
+    /// so use [`None`] for notifications.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, deserialize_with = "Id::deserialize_some")]
     pub id: Option<Id>,
 
     #[serde(flatten)]
@@ -44,32 +46,35 @@ pub struct Request<T> {
 }
 
 impl<T> Request<T> {
-    /// Create a new [`Self`] with no [`Id`].
-    ///
-    /// ```rust
-    /// use cuprate_json_rpc::Request;
-    ///
-    /// assert_eq!(Request::new("").id, None);
-    /// ```
-    pub const fn new(body: T) -> Self {
-        Self {
-            jsonrpc: Version,
-            id: None,
-            body,
-        }
-    }
-
     /// Create a new [`Self`] with an [`Id`].
     ///
     /// ```rust
     /// use cuprate_json_rpc::{Id, Request};
     ///
-    /// assert_eq!(Request::new_with_id(Id::Num(0), "").id, Some(Id::Num(0)));
+    /// assert_eq!(Request::new(Id::Num(0), "").id, Some(Id::Num(0)));
     /// ```
-    pub const fn new_with_id(id: Id, body: T) -> Self {
+    pub const fn new(id: Id, body: T) -> Self {
         Self {
             jsonrpc: Version,
             id: Some(id),
+            body,
+        }
+    }
+
+    /// Create a new [`Self`] with no [`Id`], i.e. a
+    /// [notification](https://www.jsonrpc.org/specification#notification).
+    ///
+    /// A conforming server will not respond to this.
+    ///
+    /// ```rust
+    /// use cuprate_json_rpc::Request;
+    ///
+    /// assert_eq!(Request::notification("").id, None);
+    /// ```
+    pub const fn notification(body: T) -> Self {
+        Self {
+            jsonrpc: Version,
+            id: None,
             body,
         }
     }
@@ -81,8 +86,8 @@ impl<T> Request<T> {
     /// ```rust
     /// use cuprate_json_rpc::{Id, Request};
     ///
-    /// assert!(Request::new("").is_notification());
-    /// assert!(!Request::new_with_id(Id::Null, "").is_notification());
+    /// assert!(Request::notification("").is_notification());
+    /// assert!(!Request::new(Id::Null, "").is_notification());
     /// ```
     pub const fn is_notification(&self) -> bool {
         self.id.is_none()
@@ -123,7 +128,7 @@ mod test {
             params: [0, 1, 2],
         };
 
-        let req = Request::new_with_id(id, body);
+        let req = Request::new(id, body);
 
         assert!(!req.is_notification());
 
@@ -145,7 +150,7 @@ mod test {
             params: [0, 1, 2],
         };
 
-        let req = Request::new_with_id(id, body);
+        let req = Request::new(id, body);
 
         let ser: String = serde_json::to_string(&req).unwrap();
         assert_eq!(
@@ -161,7 +166,7 @@ mod test {
     /// Tests that null `id` shows when serializing.
     #[test]
     fn request_null_id() {
-        let req = Request::new_with_id(
+        let req = Request::new(
             Id::Null,
             Body {
                 method: "m".into(),
@@ -181,7 +186,7 @@ mod test {
     /// Tests that a `None` `id` omits the field when serializing.
     #[test]
     fn request_none_id() {
-        let req = Request::new(Body {
+        let req = Request::notification(Body {
             method: "a".into(),
             params: "b".to_string(),
         });
@@ -202,7 +207,7 @@ mod test {
             method: String,
         }
 
-        let req = Request::new_with_id(
+        let req = Request::new(
             Id::Num(123),
             NoParamMethod {
                 method: "asdf".to_string(),
@@ -232,7 +237,7 @@ mod test {
             GetHeight(/* param: */ GetHeight),
         }
 
-        let req = Request::new_with_id(Id::Num(123), Methods::GetHeight(GetHeight { height: 0 }));
+        let req = Request::new(Id::Num(123), Methods::GetHeight(GetHeight { height: 0 }));
         let json = json!({
             "jsonrpc": "2.0",
             "id": 123,
@@ -251,7 +256,7 @@ mod test {
         // Test values: (request, expected_value)
         let array: [(Request<Body<[u8; 3]>>, Value); 3] = [
             (
-                Request::new_with_id(
+                Request::new(
                     Id::Num(123),
                     Body {
                         method: "method_1".into(),
@@ -266,7 +271,7 @@ mod test {
                 }),
             ),
             (
-                Request::new_with_id(
+                Request::new(
                     Id::Null,
                     Body {
                         method: "method_2".into(),
@@ -281,7 +286,7 @@ mod test {
                 }),
             ),
             (
-                Request::new_with_id(
+                Request::new(
                     Id::Str("string_id".into()),
                     Body {
                         method: "method_3".into(),
@@ -305,7 +310,7 @@ mod test {
     /// Tests that non-ordered fields still deserialize okay.
     #[test]
     fn deserialize_out_of_order_keys() {
-        let expected = Request::new_with_id(
+        let expected = Request::new(
             Id::Str("id".into()),
             Body {
                 method: "method".into(),
@@ -328,7 +333,7 @@ mod test {
     /// Also that unicode and backslashes work.
     #[test]
     fn unknown_fields_and_unicode() {
-        let expected = Request::new_with_id(
+        let expected = Request::new(
             Id::Str("id".into()),
             Body {
                 method: "method".into(),

--- a/rpc/json-rpc/src/tests.rs
+++ b/rpc/json-rpc/src/tests.rs
@@ -85,7 +85,7 @@ fn monero_jsonrpc_get_block() {
     //--- Request
     const REQUEST: &str =
         r#"{"jsonrpc":"2.0","id":"0","method":"get_block","params":{"height":123}}"#;
-    let request = Request::new_with_id(
+    let request = Request::new(
         Id::Str("0".into()),
         Methods::GetBlock(GetBlock { height: 123 }),
     );
@@ -215,7 +215,7 @@ fn monero_jsonrpc_get_block() {
 fn monero_jsonrpc_get_block_count() {
     //--- Request
     const REQUEST: &str = r#"{"jsonrpc":"2.0","id":0,"method":"get_block_count"}"#;
-    let request = Request::new_with_id(Id::Num(0), Methods::GetBlockCount);
+    let request = Request::new(Id::Num(0), Methods::GetBlockCount);
     assert_ser_string(&request, REQUEST);
     assert_de(REQUEST, request);
 

--- a/rpc/types/src/json.rs
+++ b/rpc/types/src/json.rs
@@ -789,10 +789,45 @@ pub enum JsonRpcRequest {
     GetTxIdsLoose(GetTxIdsLooseRequest),
 }
 
+//---------------------------------------------------------------------------------------------------- Method
+/// Parsed JSON-RPC methods.
+///
+/// A method is known, unknown, or has invalid parameters.
+#[cfg(feature = "serde")]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum JsonRpcMethod {
+    /// A method that exists.
+    Known(JsonRpcRequest),
+
+    /// A method that does not exist.
+    Unknown,
+
+    /// A known method whose parameters could not be decoded.
+    InvalidParams {
+        /// Whether the method is unavailable on restricted RPC servers.
+        restricted: bool,
+    },
+}
+
 #[cfg(feature = "serde")]
 impl<'de> Deserialize<'de> for JsonRpcRequest {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use serde::de::Error;
+
+        match JsonRpcMethod::deserialize(deserializer)? {
+            JsonRpcMethod::Known(request) => Ok(request),
+            JsonRpcMethod::Unknown => Err(D::Error::custom("unknown JSON-RPC method")),
+            JsonRpcMethod::InvalidParams { .. } => {
+                Err(D::Error::custom("invalid JSON-RPC parameters"))
+            }
+        }
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> Deserialize<'de> for JsonRpcMethod {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        use JsonRpcRequest as Req;
 
         fn default_params() -> serde_json::Value {
             serde_json::Value::Object(Default::default())
@@ -816,59 +851,66 @@ impl<'de> Deserialize<'de> for JsonRpcRequest {
         // Deserialize `params` (a `serde_json::Value`) into the concrete request type.
         macro_rules! de {
             ($T:ty) => {
-                serde_json::from_value::<$T>(params).map_err(D::Error::custom)?
+                match serde_json::from_value::<$T>(params) {
+                    Ok(params) => params,
+                    Err(_) => {
+                        return Ok(Self::InvalidParams {
+                            restricted: <$T as crate::rpc_call::RpcCall>::IS_RESTRICTED,
+                        });
+                    }
+                }
             };
         }
 
-        Ok(match method.as_str() {
-            "get_block_count" | "getblockcount" => Self::GetBlockCount(de!(GetBlockCountRequest)),
+        Ok(Self::Known(match method.as_str() {
+            "get_block_count" | "getblockcount" => Req::GetBlockCount(de!(GetBlockCountRequest)),
             "on_get_block_hash" | "on_getblockhash" => {
-                Self::OnGetBlockHash(de!(OnGetBlockHashRequest))
+                Req::OnGetBlockHash(de!(OnGetBlockHashRequest))
             }
             "get_block_template" | "getblocktemplate" => {
-                Self::GetBlockTemplate(de!(GetBlockTemplateRequest))
+                Req::GetBlockTemplate(de!(GetBlockTemplateRequest))
             }
-            "get_miner_data" => Self::GetMinerData(de!(GetMinerDataRequest)),
-            "calc_pow" => Self::CalcPow(de!(CalcPowRequest)),
-            "add_aux_pow" => Self::AddAuxPow(de!(AddAuxPowRequest)),
-            "submit_block" | "submitblock" => Self::SubmitBlock(de!(SubmitBlockRequest)),
-            "generateblocks" => Self::GenerateBlocks(de!(GenerateBlocksRequest)),
+            "get_miner_data" => Req::GetMinerData(de!(GetMinerDataRequest)),
+            "calc_pow" => Req::CalcPow(de!(CalcPowRequest)),
+            "add_aux_pow" => Req::AddAuxPow(de!(AddAuxPowRequest)),
+            "submit_block" | "submitblock" => Req::SubmitBlock(de!(SubmitBlockRequest)),
+            "generateblocks" => Req::GenerateBlocks(de!(GenerateBlocksRequest)),
             "get_last_block_header" | "getlastblockheader" => {
-                Self::GetLastBlockHeader(de!(GetLastBlockHeaderRequest))
+                Req::GetLastBlockHeader(de!(GetLastBlockHeaderRequest))
             }
             "get_block_header_by_hash" | "getblockheaderbyhash" => {
-                Self::GetBlockHeaderByHash(de!(GetBlockHeaderByHashRequest))
+                Req::GetBlockHeaderByHash(de!(GetBlockHeaderByHashRequest))
             }
             "get_block_header_by_height" | "getblockheaderbyheight" => {
-                Self::GetBlockHeaderByHeight(de!(GetBlockHeaderByHeightRequest))
+                Req::GetBlockHeaderByHeight(de!(GetBlockHeaderByHeightRequest))
             }
             "get_block_headers_range" | "getblockheadersrange" => {
-                Self::GetBlockHeadersRange(de!(GetBlockHeadersRangeRequest))
+                Req::GetBlockHeadersRange(de!(GetBlockHeadersRangeRequest))
             }
-            "get_block" | "getblock" => Self::GetBlock(de!(GetBlockRequest)),
-            "get_connections" => Self::GetConnections(de!(GetConnectionsRequest)),
-            "get_info" => Self::GetInfo(de!(GetInfoRequest)),
-            "hard_fork_info" => Self::HardForkInfo(de!(HardForkInfoRequest)),
-            "set_bans" => Self::SetBans(de!(SetBansRequest)),
-            "get_bans" => Self::GetBans(de!(GetBansRequest)),
-            "banned" => Self::Banned(de!(BannedRequest)),
-            "flush_txpool" => Self::FlushTxpool(de!(FlushTxpoolRequest)),
-            "get_output_histogram" => Self::GetOutputHistogram(de!(GetOutputHistogramRequest)),
-            "get_version" => Self::GetVersion(de!(GetVersionRequest)),
-            "get_coinbase_tx_sum" => Self::GetCoinbaseTxSum(de!(GetCoinbaseTxSumRequest)),
-            "get_fee_estimate" => Self::GetFeeEstimate(de!(GetFeeEstimateRequest)),
-            "get_alternate_chains" => Self::GetAlternateChains(de!(GetAlternateChainsRequest)),
-            "relay_tx" => Self::RelayTx(de!(RelayTxRequest)),
-            "sync_info" => Self::SyncInfo(de!(SyncInfoRequest)),
-            "get_txpool_backlog" => Self::GetTxpoolBacklog(de!(GetTxpoolBacklogRequest)),
+            "get_block" | "getblock" => Req::GetBlock(de!(GetBlockRequest)),
+            "get_connections" => Req::GetConnections(de!(GetConnectionsRequest)),
+            "get_info" => Req::GetInfo(de!(GetInfoRequest)),
+            "hard_fork_info" => Req::HardForkInfo(de!(HardForkInfoRequest)),
+            "set_bans" => Req::SetBans(de!(SetBansRequest)),
+            "get_bans" => Req::GetBans(de!(GetBansRequest)),
+            "banned" => Req::Banned(de!(BannedRequest)),
+            "flush_txpool" => Req::FlushTxpool(de!(FlushTxpoolRequest)),
+            "get_output_histogram" => Req::GetOutputHistogram(de!(GetOutputHistogramRequest)),
+            "get_version" => Req::GetVersion(de!(GetVersionRequest)),
+            "get_coinbase_tx_sum" => Req::GetCoinbaseTxSum(de!(GetCoinbaseTxSumRequest)),
+            "get_fee_estimate" => Req::GetFeeEstimate(de!(GetFeeEstimateRequest)),
+            "get_alternate_chains" => Req::GetAlternateChains(de!(GetAlternateChainsRequest)),
+            "relay_tx" => Req::RelayTx(de!(RelayTxRequest)),
+            "sync_info" => Req::SyncInfo(de!(SyncInfoRequest)),
+            "get_txpool_backlog" => Req::GetTxpoolBacklog(de!(GetTxpoolBacklogRequest)),
             "get_output_distribution" => {
-                Self::GetOutputDistribution(de!(GetOutputDistributionRequest))
+                Req::GetOutputDistribution(de!(GetOutputDistributionRequest))
             }
-            "prune_blockchain" => Self::PruneBlockchain(de!(PruneBlockchainRequest)),
-            "flush_cache" => Self::FlushCache(de!(FlushCacheRequest)),
-            "get_tx_ids_loose" => Self::GetTxIdsLoose(de!(GetTxIdsLooseRequest)),
-            other => return Err(D::Error::unknown_variant(other, &[])),
-        })
+            "prune_blockchain" => Req::PruneBlockchain(de!(PruneBlockchainRequest)),
+            "flush_cache" => Req::FlushCache(de!(FlushCacheRequest)),
+            "get_tx_ids_loose" => Req::GetTxIdsLoose(de!(GetTxIdsLooseRequest)),
+            _ => return Ok(Self::Unknown),
+        }))
     }
 }
 


### PR DESCRIPTION
### What
Add JSON-RPC 2.0 [batch request](https://www.jsonrpc.org/specification#batch) support

Depends on #692 

### Why
Compliance with the spec, more efficient if you know you need to request several items at once

### Where
`cuprated`, `rpc`

### How
- `/json_rpc` takes raw `Bytes` instead of axum's `Json`; a body starting with `[` is a batch, everything else is the existing single-request path. The `Content-Type` check `Json` did implicitly is now manual. This was done to improve batch performance
- A handrolled json content type checker was added so we don't have to depend on `mime`
- Entries are held as `RawValue` and parsed individually, so one bad entry only fails itself. Notifications are left out of the response array. An empty batch is not accepted
- Entries run concurrently via `FuturesUnordered`, capped by a new `RpcHandler::batch_concurrency()`. Responses come back in completion order, matched by id
- Docs: architecture book + both RPC READMEs