### PR TITLE
p2p-core: fix HandleBuilder build docs

### DIFF
--- a/p2p/p2p-core/src/handles.rs
+++ b/p2p/p2p-core/src/handles.rs
@@ -30,8 +30,6 @@ impl HandleBuilder {
     }
 
     /// Builds the [`ConnectionGuard`] which should be handed to the connection task and the [`ConnectionHandle`].
-    ///
-    /// This will panic if a permit was not set [`HandleBuilder::with_permit`]
     pub fn build(self) -> (ConnectionGuard, ConnectionHandle) {
         let token = CancellationToken::new();
 


### PR DESCRIPTION
The current rustdoc says build() panics when no permit is set, but that is not how the function behaves.

This removes the outdated note.