### PR TITLE
rpc: inline shared handler service calls

### DIFF
--- a/binaries/cuprated/src/rpc/handlers/shared.rs
+++ b/binaries/cuprated/src/rpc/handlers/shared.rs
@@ -7,8 +7,9 @@
 use std::num::NonZero;
 
 use anyhow::{anyhow, Error};
-use cuprate_types::PreRctOutputDistributionInput;
+use tower::{Service, ServiceExt};
 
+use cuprate_consensus_context::{BlockChainContextRequest, BlockChainContextResponse};
 use cuprate_constants::rpc::MAX_RESTRICTED_GLOBAL_FAKE_OUTS_COUNT;
 use cuprate_helper::cast::usize_to_u64;
 use cuprate_rpc_interface::RpcHandler;
@@ -17,12 +18,13 @@ use cuprate_rpc_types::{
     json::{GetOutputDistributionRequest, GetOutputDistributionResponse},
     misc::{Distribution, DistributionCompressedBinary, DistributionUncompressed, OutKeyBin},
 };
-
-use crate::rpc::{
-    handlers::helper,
-    service::{blockchain, blockchain_context, txpool},
-    CupratedRpcHandler,
+use cuprate_txpool::service::interface::{TxpoolReadRequest, TxpoolReadResponse};
+use cuprate_types::{
+    blockchain::{BlockchainReadRequest, BlockchainResponse},
+    PreRctOutputDistributionInput,
 };
+
+use crate::rpc::{handlers::helper, CupratedRpcHandler};
 
 /// <https://github.com/monero-project/monero/blob/cc73fe71162d564ffda8e549b79a350bca53c454/src/rpc/core_rpc_server.cpp#L912-L957>
 ///
@@ -37,12 +39,25 @@ pub(super) async fn get_outs(
         return Err(anyhow!("Too many outs requested"));
     }
 
-    let outputs = blockchain::outputs_vec(
-        &mut state.blockchain_read,
-        request.outputs,
-        request.get_txid,
-    )
-    .await?;
+    let outputs = request
+        .outputs
+        .into_iter()
+        .map(|output| (output.amount, output.index))
+        .collect();
+
+    let BlockchainResponse::OutputsVec(outputs) = state
+        .blockchain_read
+        .ready()
+        .await?
+        .call(BlockchainReadRequest::OutputsVec {
+            outputs,
+            get_txid: request.get_txid,
+        })
+        .await?
+    else {
+        unreachable!();
+    };
+
     let mut outs = Vec::<OutKeyBin>::with_capacity(outputs.len());
     let blockchain_ctx = state.blockchain_context.blockchain_context();
 
@@ -82,7 +97,20 @@ pub(super) async fn get_transaction_pool_hashes(
     mut state: CupratedRpcHandler,
 ) -> Result<Vec<[u8; 32]>, Error> {
     let include_sensitive_txs = !state.is_restricted();
-    txpool::all_hashes(&mut state.txpool_read, include_sensitive_txs).await
+
+    let TxpoolReadResponse::AllHashes(hashes) = state
+        .txpool_read
+        .ready()
+        .await?
+        .call(TxpoolReadRequest::AllHashes {
+            include_sensitive_txs,
+        })
+        .await?
+    else {
+        unreachable!();
+    };
+
+    Ok(hashes)
 }
 
 /// <https://github.com/monero-project/monero/blob/cc73fe71162d564ffda8e549b79a350bca53c454/src/rpc/core_rpc_server.cpp#L3352-L3398>
@@ -115,35 +143,73 @@ pub(super) async fn get_output_distribution(
     let to_height = match NonZero::new(request.to_height) {
         Some(h) => Some(h),
         None if pre_rct_amounts.is_empty() => None,
-        None => NonZero::new(blockchain::chain_height(&mut state.blockchain_read).await? - 1),
+        None => {
+            let BlockchainResponse::ChainHeight(height, _) = state
+                .blockchain_read
+                .ready()
+                .await?
+                .call(BlockchainReadRequest::ChainHeight)
+                .await?
+            else {
+                unreachable!();
+            };
+
+            NonZero::new(usize_to_u64(height) - 1)
+        }
     };
 
     let mut pre_rct = if pre_rct_amounts.is_empty() {
         Vec::new()
     } else {
-        blockchain::pre_rct_output_distribution(
-            &mut state.blockchain_read,
-            PreRctOutputDistributionInput {
-                amounts: pre_rct_amounts,
-                cumulative: request.cumulative,
-                from_height: request.from_height,
-                to_height,
-            },
-        )
-        .await?
+        let BlockchainResponse::PreRctOutputDistribution(data) = state
+            .blockchain_read
+            .ready()
+            .await?
+            .call(BlockchainReadRequest::PreRctOutputDistribution(
+                PreRctOutputDistributionInput {
+                    amounts: pre_rct_amounts,
+                    cumulative: request.cumulative,
+                    from_height: request.from_height,
+                    to_height,
+                },
+            ))
+            .await?
+        else {
+            unreachable!();
+        };
+
+        data
     }
     .into_iter();
+
+    let rct = if request.amounts.contains(&0) {
+        let BlockChainContextResponse::RctOutputDistribution(data) = state
+            .blockchain_context
+            .ready()
+            .await
+            .map_err(|e| anyhow!(e))?
+            .call(BlockChainContextRequest::RctOutputDistribution {
+                from_height: request.from_height,
+                to_height,
+                cumulative: request.cumulative,
+            })
+            .await
+            .map_err(|e| anyhow!(e))?
+        else {
+            unreachable!();
+        };
+
+        Some(data)
+    } else {
+        None
+    };
 
     let mut distributions = Vec::with_capacity(request.amounts.len());
     for &amount in &request.amounts {
         let data = if amount == 0 {
-            blockchain_context::rct_output_distribution(
-                &mut state.blockchain_context,
-                request.from_height,
-                to_height,
-                request.cumulative,
-            )
-            .await?
+            rct.as_ref()
+                .expect("RCT distribution requested above")
+                .clone()
         } else {
             pre_rct.next().expect("one distribution per pre-RCT amount")
         };

--- a/binaries/cuprated/src/rpc/service/blockchain.rs
+++ b/binaries/cuprated/src/rpc/service/blockchain.rs
@@ -5,15 +5,10 @@ use tower::{Service, ServiceExt};
 
 use cuprate_blockchain::service::BlockchainReadHandle;
 use cuprate_helper::cast::{u64_to_usize, usize_to_u64};
-use cuprate_rpc_types::misc::GetOutputsOut;
 use cuprate_types::{
     blockchain::{BlockchainReadRequest, BlockchainResponse},
-    rpc::{
-        ChainInfo, CoinbaseTxSum, OutputDistributionData, OutputHistogramEntry,
-        OutputHistogramInput,
-    },
-    BlockCompleteEntry, Chain, ExtendedBlockHeader, OutputOnChain, PreRctOutputDistributionInput,
-    TxInBlockchain,
+    rpc::{ChainInfo, CoinbaseTxSum, OutputHistogramEntry, OutputHistogramInput},
+    BlockCompleteEntry, Chain, ExtendedBlockHeader, TxInBlockchain,
 };
 
 /// [`BlockchainReadRequest::Block`].
@@ -92,20 +87,6 @@ pub(crate) async fn block_hash(
     Ok(hash)
 }
 
-/// [`BlockchainReadRequest::ChainHeight`].
-pub(crate) async fn chain_height(blockchain_read: &mut BlockchainReadHandle) -> Result<u64, Error> {
-    let BlockchainResponse::ChainHeight(height, _) = blockchain_read
-        .ready()
-        .await?
-        .call(BlockchainReadRequest::ChainHeight)
-        .await?
-    else {
-        unreachable!();
-    };
-
-    Ok(usize_to_u64(height))
-}
-
 /// [`BlockchainReadRequest::FindBlock`].
 pub(crate) async fn find_block(
     blockchain_read: &mut BlockchainReadHandle,
@@ -148,29 +129,6 @@ pub(crate) async fn next_chain_entry(
     };
 
     Ok((block_ids, start_height, chain_height))
-}
-
-/// [`BlockchainReadRequest::OutputsVec`]
-pub(crate) async fn outputs_vec(
-    blockchain_read: &mut BlockchainReadHandle,
-    outputs: Vec<GetOutputsOut>,
-    get_txid: bool,
-) -> Result<Vec<(u64, Vec<(u64, OutputOnChain)>)>, Error> {
-    let outputs = outputs
-        .into_iter()
-        .map(|output| (output.amount, output.index))
-        .collect();
-
-    let BlockchainResponse::OutputsVec(outputs) = blockchain_read
-        .ready()
-        .await?
-        .call(BlockchainReadRequest::OutputsVec { outputs, get_txid })
-        .await?
-    else {
-        unreachable!();
-    };
-
-    Ok(outputs)
 }
 
 /// [`BlockchainReadRequest::KeyImagesSpentVec`]
@@ -223,23 +181,6 @@ pub(crate) async fn database_size(
     };
 
     Ok((database_size, free_space))
-}
-
-/// [`BlockchainReadRequest::PreRctOutputDistribution`]
-pub(crate) async fn pre_rct_output_distribution(
-    blockchain_read: &mut BlockchainReadHandle,
-    input: PreRctOutputDistributionInput,
-) -> Result<Vec<OutputDistributionData>, Error> {
-    let BlockchainResponse::PreRctOutputDistribution(data) = blockchain_read
-        .ready()
-        .await?
-        .call(BlockchainReadRequest::PreRctOutputDistribution(input))
-        .await?
-    else {
-        unreachable!();
-    };
-
-    Ok(data)
 }
 
 /// [`BlockchainReadRequest::OutputHistogram`]

--- a/binaries/cuprated/src/rpc/service/blockchain_context.rs
+++ b/binaries/cuprated/src/rpc/service/blockchain_context.rs
@@ -1,7 +1,5 @@
 //! Functions to send [`BlockChainContextRequest`]s.
 
-use std::num::NonZero;
-
 use anyhow::{anyhow, Error};
 use monero_oxide::block::Block;
 use tower::{Service, ServiceExt};
@@ -10,7 +8,7 @@ use cuprate_consensus_context::{
     BlockChainContextRequest, BlockChainContextResponse, BlockchainContextService,
 };
 use cuprate_types::{
-    rpc::{FeeEstimate, HardForkInfo, OutputDistributionData},
+    rpc::{FeeEstimate, HardForkInfo},
     HardFork,
 };
 
@@ -51,31 +49,6 @@ pub(crate) async fn fee_estimate(
     };
 
     Ok(fee)
-}
-
-/// [`BlockChainContextRequest::RctOutputDistribution`]
-pub(crate) async fn rct_output_distribution(
-    blockchain_context: &mut BlockchainContextService,
-    from_height: u64,
-    to_height: Option<NonZero<u64>>,
-    cumulative: bool,
-) -> Result<OutputDistributionData, Error> {
-    let BlockChainContextResponse::RctOutputDistribution(data) = blockchain_context
-        .ready()
-        .await
-        .map_err(|e| anyhow!(e))?
-        .call(BlockChainContextRequest::RctOutputDistribution {
-            from_height,
-            to_height,
-            cumulative,
-        })
-        .await
-        .map_err(|e| anyhow!(e))?
-    else {
-        unreachable!();
-    };
-
-    Ok(data)
 }
 
 /// [`BlockChainContextRequest::CalculatePow`]

--- a/binaries/cuprated/src/rpc/service/txpool.rs
+++ b/binaries/cuprated/src/rpc/service/txpool.rs
@@ -196,22 +196,3 @@ pub(crate) async fn pool_stats(
 
     Ok(txpool_stats)
 }
-
-/// [`TxpoolReadRequest::AllHashes`]
-pub(crate) async fn all_hashes(
-    txpool_read: &mut TxpoolReadHandle,
-    include_sensitive_txs: bool,
-) -> Result<Vec<[u8; 32]>, Error> {
-    let TxpoolReadResponse::AllHashes(hashes) = txpool_read
-        .ready()
-        .await?
-        .call(TxpoolReadRequest::AllHashes {
-            include_sensitive_txs,
-        })
-        .await?
-    else {
-        unreachable!();
-    };
-
-    Ok(hashes)
-}


### PR DESCRIPTION
### What
Inline the service calls used by `handlers/shared.rs` and remove the five wrappers they replaced.

### Why
The service cost is visible at the call site. The RCT distribution is also fetched once when amount `0` appears more than once.

Part of #698.